### PR TITLE
M6 part 1: fire-flow map + aim seam (origin substitution live)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -140,9 +140,17 @@ Known hard parts of re-entry and their mitigations:
   switch, ToggleHUD, SetFOV - one high-value hook makes dozens of features one-liners); direct
   hooks for continuous aim.
 - **Decoupled aim**: UE2.5 fire traces derive from player view rotation, so camera hooks aren't
-  enough - hook the GetPlayerViewPoint-equivalent used by fire logic and return the controller
-  aim pose there while CalcView keeps returning the HMD pose. Right hand = weapons, left hand =
-  plasmids (verify plasmid routing in decompiled ShockGame.u).
+  enough - hook the aim source used by fire logic and return the controller aim there while
+  CalcView keeps returning the HMD pose. Right hand = weapons, left hand = plasmids.
+  *As-built (M6 session 10): there is no single "GetPlayerViewPoint". Attacks are ABILITIES, and
+  each fire path asks its own `GetPerfectFireStart` (AWeapon for guns and melee, UAttackAbility
+  for plasmids) for where the shot starts, after which the engine applies its own spread. Those
+  two C++ implementations are the seam (`game/bioshock1r/aim.cpp`, command-gated `vraim`) -
+  hooked at the implementation, not the UnrealScript exec thunk, because native callers bypass
+  thunks entirely. Hand attribution is object identity seeded by the trigger the bridge itself
+  composes, so switching weapon or plasmid re-learns for free. The plasmid path's trace
+  DIRECTION lives one layer deeper (the damage factory) and is the open piece; addresses and
+  live findings in ENGINE_NOTES "Fire flow / aim".*
 - **Menus (gameswf Flash)**: menu mode = whole frame on a quad + controller laser → virtual
   mouse into whichever input path the menus actually read (DR-6 determines: DirectInput vs
   window messages vs cursor pos). In-game HUD later via draw-call capture → floating quad (M9).
@@ -267,3 +275,25 @@ runtime.
   UseJoystick/UseController ini keys (all provably ignored), MinHooking UpdateInput (nothing
   calls it - there is nothing to hook), and dpad chords on Touch (hidden state; the M8 radial
   wheels own discrete selection).
+- **2026-07-25 - Aim seam: hook implementations, and let the engine keep its spread.** Three
+  findings shaped M6. (1) The engine ships a readable symbol table for name-based natives
+  (registration string `int<Class>exec<Func>` -> `.data` entry -> impl pointer), so
+  `pattern_scan::find_native_function` resolves aim symbols with no hardcoded addresses and no
+  prologue scanning - and dumping that table offline is now the first stop for any engine
+  question. (2) Those `exec` thunks are script-entry only: hooking all four aim thunks caught
+  ZERO calls while shooting, because C++ callers go straight to the implementation. The shipped
+  seams are therefore the implementations, resolved via the RTTI-derived vtable slot (weapon) or
+  a prologue-checked RVA (ability). (3) Substituting at `GetPerfectFireStart` rather than at the
+  spread function keeps per-weapon accuracy: the engine applies `ApplyAimError` to our direction
+  afterwards, so a shotgun still spreads. Substitution is value-driven (each out-param the
+  engine filled with a position gets the hand's origin, each direction gets the hand's
+  direction, zeros are left alone) because the same function's out-param order differs between
+  the two signatures. Ownership gates read the weapon's owning pawn / the ability's instigator
+  and compare against the AShockPlayer vtable - the same check the engine makes itself - so AI
+  fire keeps its own aim. Rejected: writing the pawn/controller Rotation field (it also drives
+  movement direction and pawn facing, and cannot give the two hands independent aim), and
+  hooking `APawn::GetViewDirection` (live-proven never called during a shot).
+- **2026-07-25 - M6/M7 split stays as planned.** M6 is the aim vector only. The wrench turned
+  out to damage through a Havok collision phantom rather than a trace, so "melee feels aimed" is
+  purely a hands-rendering matter and belongs to M7 with the visible weapon; articulated IK arms
+  remain post-v1.

--- a/docs/ENGINE_NOTES.md
+++ b/docs/ENGINE_NOTES.md
@@ -583,11 +583,24 @@ only) plus capstone walks of the implementations:
    produced, and it is the one piece not yet pinned down** (see below).
 
 **Live findings (probe, 2026-07-25):**
+- **The weapon path's out-param B is an FRotator, and it IS the fire direction -
+  CONFIRMED by substitution.** Live values `B[rot]=(132 116 0)` matched the
+  camera's own rotation exactly (heartbeat `rot=(144 116 0)`), and writing our
+  own pitch/yaw there moves the bullets: firing at a flat wall with an injected
+  hand aim put the decals 12 deg right, 12 deg left, 10 deg down and 8/8 up-right
+  of the crosshair while the CAMERA never moved, and `vraim off` put the next
+  round back on the crosshair. That is M6's acceptance criterion, flat.
+- **A rotator reads as three near-zero floats.** Rotation units are int32s whose
+  float reinterpretation is a denormal, so an FRotator out-param prints as
+  `(0.000 0.000 0.000)` - which cost this session a long detour chasing a
+  "missing" direction. `aim.cpp` now classifies each out-param by value (small
+  int32s = FRotator, unit-length floats = direction vector, thousands = position)
+  and writes the matching type; the probe log tags each slot `[rot]/[dir]/[pos]`.
 - `UAttackAbility::GetPerfectFireStart` FIRES on a plasmid cast (Electro Bolt),
-  `this` vtable = `UAttackAbility` 0xD7E9D4, and the out-params read
-  outA = the player's Location, outB = (0,0,0), outC = Location + a small lean
-  offset. **All positions, no direction** - matching the function's name.
-  Origin substitution therefore works today (logged `SUB(L)` with our values).
+  `this` vtable = `UAttackAbility` 0xD7E9D4, and its out-params read
+  outA = the player's Location, outB = an ALL-ZERO rotator, outC = Location + a
+  small lean offset. So the ability path gives a start but no usable rotation:
+  the plasmid's direction still comes from somewhere else (see Open below).
 - `APawn::GetViewDirection` impl (**0x3CBA10**, pawn vtable +0x35C) and
   `AShockPlayer::GetViewPoint` impl (**0x1E5E50**, +0x360) are NOT called during
   a cast (scanimpl, zero calls) - so the factory does not ask the pawn.
@@ -607,11 +620,15 @@ cross-checked against a live hexdump of the player pawn):**
   rotation lives on the PlayerController, not the pawn.
 - `+0x550` float **eye height** (`GetViewPoint` = Location + eyeHeight on Z)
 
-**Open (next session):** find where the damage factory turns rotation into the
-trace direction - either the factory virtual at `+0xEC` (hook it with
-`vraim scanimpl`) or the PlayerController Rotation field it presumably reads. A
-ranged weapon is needed to confirm the weapon path end to end: the only save
-available has just the wrench + Electro Bolt, and the wrench never traces.
+**Open (next session): the PLASMID direction only.** The weapon path is done.
+For abilities, `GetPerfectFireStart`'s rotator out-param is all-zero, so the
+direction is produced downstream - probe the damage-factory virtual at factory
+vtbl `+0xEC` (factory fetched by 0x231E70 inside `UAttackAbility::InitiateDamage`
+0x1BBD80) with `vraim scanimpl`. Note what the weapon side revealed about where
+a view rotation lives: the weapon's B comes from the `[pawn+0x450]` chain's
+`+0x1E4`, and it carries the PITCHED view rotation - i.e. that chain reaches the
+PlayerController, not the pawn (whose own Rotation keeps pitch 0). The same
+field is the prime suspect for the ability path.
 
 **Class vtables (MSVC RTTI walk: TypeDescriptor `.?AV<name>@@` ->
 CompleteObjectLocator -> vtable; scratchpad `rtti.py`):** AShockPlayer

--- a/docs/ENGINE_NOTES.md
+++ b/docs/ENGINE_NOTES.md
@@ -105,6 +105,15 @@ Game build reference: `BioshockHD.exe`, 21,214,720 bytes, linker timestamp 2022-
 
 ## OpenXR runtime facts (this machine)
 
+- **Grip pose vs aim pose (M6, 2026-07-25).** The first in-headset aim test read
+  low: the wrist had to be held below where the shot went. The ray was built from
+  `/user/hand/*/input/grip/pose`, whose forward axis runs along the controller
+  HANDLE, not along the pointing direction - on Touch that is tens of degrees
+  apart. `/user/hand/*/input/aim/pose` is the runtime's own pointing ray and is
+  what aiming should use; grip stays the right choice for placing a hand/weapon
+  MODEL (M7). Both are located every frame now, and the aim path keeps pitch/yaw
+  trim offsets on top for personal taste.
+
 - 64-bit ActiveRuntime: `C:\Program Files\Virtual Desktop Streamer\OpenXR\virtualdesktop-openxr.json`
 - 32-bit ActiveRuntime (WOW6432Node): `...\virtualdesktop-openxr-32.json` pointing at
   `virtualdesktop-openxr-32.dll` (verified PE machine 0x014C = x86).

--- a/docs/ENGINE_NOTES.md
+++ b/docs/ENGINE_NOTES.md
@@ -61,7 +61,9 @@ Game build reference: `BioshockHD.exe`, 21,214,720 bytes, linker timestamp 2022-
 | `eventPlayerCalcView` | camera override (HMD pose, per-eye offsets) | **active** (DR-4: `game/bioshock1r/camera.cpp`, self-enabling MinHook) |
 | Drain RVA 0x61CAE0 (+ flush 0x61D0F0) | DR-5 reentry probe telemetry | **command-gated** (session 5: `game/bioshock1r/scenedraw.cpp`; exists only after a `reentry hook` seam command - default runs stay unhooked). Drain re-entry refuted - see Scene-draw architecture. |
 | Game-thread frame submit RVA 0x585AC0 | SequentialReentry stereo (double-submit with per-eye rot) | **next session's hook** - located via SetEvent caller sampler, byte-walked, unhooked |
-| GetPlayerViewPoint-equivalent used by fire traces (unknown) | decoupled controller aim | M6 |
+| `AWeapon::GetPerfectFireStart` impl RVA 0x226840 (weapon vtable +0x304) and `UAttackAbility::GetPerfectFireStart` impl RVA 0x1BC220 | decoupled controller aim: the shot's origin (and, on the weapon path, the direction the engine then applies spread to) | **active, command-gated** (M6: `game/bioshock1r/aim.cpp`, `vraim on`; ability seam live-confirmed firing, origin substitution proven) |
+| Damage-factory trace virtual (factory vtbl +0xEC, factory from 0x231E70) | the plasmid/trace DIRECTION - the one open piece of the fire flow | M6 next session (probe with `vraim scanimpl`) |
+| `APawn::GetViewDirection` impl 0x3CBA10 / `AShockPlayer::GetViewPoint` impl 0x1E5E50 | candidate aim sources - RULED OUT live (never called during a shot) | investigated, not hooked |
 | Console-command dispatcher (unknown - FName-chain on command strings) | execConsole one-liners | M5/M6 |
 | XInputGetState (we ARE the proxy - but the STEAM OVERLAY code-hooks the export thunk and eats calls, so the real seam is the game's IAT slot RVA 0xBCF8E0 -> bridge wrapper) | synthetic gamepad | **active** (M5: core/input/xinput_bridge + game IAT hijack; see "Gamepad architecture") |
 | UWindowsViewport::UpdateInput RVA 0x853D20 (driven, not hooked - nothing calls it in windowed mode) | engine consumes the synthetic pad | **active** (M5: game/bioshock1r/input_drive.cpp calls it per present) |
@@ -519,7 +521,125 @@ passthrough byte-identical with vrinput off). Boot probes are covered by a
 persisted marker (`%LOCALAPPDATA%\BioshockVR\vrinput.on`) read at DLL attach
 so the client-init probe already sees a connected pad.
 
+## Native function table (M6 session 10, 2026-07-25)
+
+**The engine ships its own symbol table for every name-based native, and it is
+trivially readable.** Each `native` UnrealScript function implemented in C++ is
+registered through a 12-byte `.data` entry `{ const TCHAR* name; Native impl;
+0 }`, where the name is the wide string **`"int<Class>exec<Function>"`** in
+`.rdata` (e.g. `intAWeaponexecApplyAimError`) and the impl pointer is written by
+static initialization (`C7 05 <entry+4> <imm32>`). 1822 such entries exist.
+
+- **Runtime resolution** (shipped, `pattern_scan::find_native_function`): find
+  the name string, find the dword that references it, read the next dword. No
+  hardcoded address, no prologue scan, and it reads the same way on a patched
+  build. Verified live: all five session-10 lookups resolved on the first try
+  at their documented RVAs.
+- **Offline enumeration** (scratchpad `natives.py` / `nativemap.py`): dumping
+  the whole table gives a per-class native inventory - this is how the aim seam
+  was found in minutes instead of by fire-path guesswork, and it is the fastest
+  first stop for any future engine question (M7 hands: `AHands` has
+  `CanExecuteAction`, `SetCurrentTransitionSequence`,
+  `InterruptAnimNotifiesForAnimation`).
+- **Caveat that cost time**: the linker pools wide strings by SUFFIX, so
+  `AimError` is literally the tail of `ApplyAimError`. A substring match proves
+  nothing; require the null terminator at the expected end (the shipped scan
+  does).
+- **`exec` thunks are NOT the seam.** They are the script->C++ entry only:
+  `execFoo(FFrame& Stack, void* Result)` parses params off the bytecode and
+  then calls the real C++ method (virtual or direct). Native callers skip them
+  entirely - hooking all four aim thunks caught ZERO calls across a live
+  session of shooting. Hook implementations, not thunks.
+- FFrame layout used by the probe: `+4` Node (calling UStruct), `+8` Object,
+  `+0xC` Code.
+
+## Fire flow / aim (M6 session 10, 2026-07-25)
+
+Chain, script -> native, derived from UELib decompiles of ShockGame.U (summaries
+only) plus capstone walks of the implementations:
+
+1. Trigger -> `Weapon.BeginFiring` -> `GotoState('Firing')`; the state plays the
+   firing animation and an **anim notify** (`AnimNotify_UseAbility`) is what
+   actually fires. Attacks are ABILITIES: `Ability -> AttackAbility ->
+   TraceAttackAbility / ProjectileAttackAbility / MeleeAttackAbility`, and
+   plasmids are the same machinery (`ElectricBoltAbility : TraceAttackAbility`).
+   Player weapons are `Pistol/Wrench/... : PlayerWeapon : Weapon : Holdable`.
+2. `AttackAbility.UseAbility` -> native `InitiateDamage(name)`:
+   - `AWeapon::InitiateDamage` **RVA 0x226050** (weapon vtable slot +0x2FC)
+   - `UAttackAbility::InitiateDamage` **RVA 0x1BBD80** (`ret 8`, FName by value)
+3. Each InitiateDamage first asks for the shot's start:
+   - `AWeapon::GetPerfectFireStart` **impl RVA 0x226840**, weapon vtable slot
+     **+0x304**, `__thiscall(FVector* outA, FVector* outB, FVector* outC)`.
+     outA <- ownerPawn+0x1D8 (Location), outB <- `[pawn+0x450]+0x1E4`.
+   - `UAttackAbility::GetPerfectFireStart` **impl RVA 0x1BC220** (direct call
+     target of its exec thunk), `__thiscall(void* instigator, FVector* outA,
+     FVector* outB, FVector* outC)`, `ret 0x10`. Same two sources one slot over,
+     plus a lean offset added to the position.
+   - The weapon path then applies its own spread: `AWeapon::ApplyAimError` impl
+     **RVA 0x226AA0** with a magnitude from **0x229DE0** - so substituting at
+     GetPerfectFireStart keeps per-weapon accuracy intact.
+4. Damage/trace is handed to a damage-factory object (`0x231E70` fetches it,
+   then a virtual at factory vtbl+0xEC) - **this is where the trace direction is
+   produced, and it is the one piece not yet pinned down** (see below).
+
+**Live findings (probe, 2026-07-25):**
+- `UAttackAbility::GetPerfectFireStart` FIRES on a plasmid cast (Electro Bolt),
+  `this` vtable = `UAttackAbility` 0xD7E9D4, and the out-params read
+  outA = the player's Location, outB = (0,0,0), outC = Location + a small lean
+  offset. **All positions, no direction** - matching the function's name.
+  Origin substitution therefore works today (logged `SUB(L)` with our values).
+- `APawn::GetViewDirection` impl (**0x3CBA10**, pawn vtable +0x35C) and
+  `AShockPlayer::GetViewPoint` impl (**0x1E5E50**, +0x360) are NOT called during
+  a cast (scanimpl, zero calls) - so the factory does not ask the pawn.
+- The **wrench does not trace at all**: `Wrench.CreateCollisionPhantom` - melee
+  damage is a Havok phantom, so no aim seam exists for it (M7's "wrench melee
+  feels aimed" is a hands-rendering matter, not an aim-vector one).
+- AI ownership is separable at every seam: the weapon's owning pawn is
+  `[weapon+0x454]`, the ability's instigator is `[ability+0xF0]`, and the engine
+  itself compares that instigator against the AShockPlayer vtable at 0x1BC2D0.
+
+**AActor field layout (from the GetViewPoint/GetViewDirection implementations,
+cross-checked against a live hexdump of the player pawn):**
+- `+0x1D8` FVector **Location** (feet; live -7210.96 / 1106.66 / 2567.15)
+- `+0x1E4` FRotator **Rotation** (live pitch 0 / yaw 55599 / roll 0 - the yaw
+  matched the camera heartbeat exactly). `GetViewDirection` = `Rotation.Vector()`
+  via the helper at **0x1BC870**; pawns keep pitch 0, so the pitched view
+  rotation lives on the PlayerController, not the pawn.
+- `+0x550` float **eye height** (`GetViewPoint` = Location + eyeHeight on Z)
+
+**Open (next session):** find where the damage factory turns rotation into the
+trace direction - either the factory virtual at `+0xEC` (hook it with
+`vraim scanimpl`) or the PlayerController Rotation field it presumably reads. A
+ranged weapon is needed to confirm the weapon path end to end: the only save
+available has just the wrench + Electro Bolt, and the wrench never traces.
+
+**Class vtables (MSVC RTTI walk: TypeDescriptor `.?AV<name>@@` ->
+CompleteObjectLocator -> vtable; scratchpad `rtti.py`):** AShockPlayer
+**0xD82BB8**, AShockPlayerController 0xD81C84, APlayerWeapon **0xD8FF58**,
+AWeapon 0xD90268, UAttackAbility **0xD7E9D4**, AHands **0xD8A28C** (M7), APawn
+0xD82824.
+
 ## UnrealScript findings
 
 _(Summaries only - never paste decompiled code. Tooling: UE Explorer/UELib on
 `Build\Final\BakedScripts\pc\*.u`, workspace in `tools/uscript/` (gitignored).)_
+
+**Headless decompiling works and is fast** (session 10): the UE Explorer
+portable build ships `Eliot.UELib.dll`, which UELib exposes to PowerShell -
+`tools/uscript/dump.ps1` loads a package in <1 s and lists classes, functions
+and states or decompiles one by name. Package: version 142 / licensee 56, build
+"BioShock" (UELib auto-detects it). Two build quirks worth knowing: name-table
+entries are UTF-16 with a POSITIVE char count and 8-byte flags, and UFunction
+deserialization fails for ~40% of objects on this licensee build (the ones that
+load are plenty - class/state bodies decompiled fine).
+
+Findings so far: the attack/ability hierarchy and the trigger -> Firing state ->
+anim-notify -> UseAbility -> InitiateDamage chain above; `Weapon.Firing` state
+body is just animations plus `GotoState('None')`; `AttackAbility.UseAbility` is
+two lines (`Damager = Instigator; InitiateDamage('None')`).
+
+**Input bindings that matter for automated tests** (`User.ini`, session 10):
+`XENON_RT = SwitchAndFireWeapon`, `XENON_LT = SwitchAndFireAbility` - the FIRST
+trigger pull only switches hands ("SwitchToWeapons"/"SwitchToPlasmids"), the
+second one fires. A single synthetic pull therefore looks like it did nothing.
+`LeftMouse = Fire` (active hand), `RightMouse = SwitchWeaponsOrPlasmids`.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -186,7 +186,7 @@ Goal: retire the project-level risks before building on them. Findings → ENGIN
       included; the wrench damages through a Havok collision phantom and never traces. Also found
       the engine's own native-function symbol table (registration string → .data entry → impl
       pointer), which is now the standard way this project resolves natives.*
-- [~] Aim-substitution hook at the fire-start seam (seed: itsloopyo decouple)
+- [x] Aim-substitution hook at the fire-start seam (seed: itsloopyo decouple)
       *2026-07-25 (session 10): SHIPPED and command-gated (`vraim`), hooking the two C++
       implementations - `AWeapon::GetPerfectFireStart` (vtable slot, impl 0x226840) and
       `UAttackAbility::GetPerfectFireStart` (0x1BC220). The exec thunks were a dead end (native
@@ -194,7 +194,14 @@ Goal: retire the project-level risks before building on them. Findings → ENGIN
       Bolt cast with correct ownership gating, and ORIGIN substitution proven (`SUB(L)` with our
       values). Remaining: the plasmid path's trace DIRECTION comes from the damage factory, one
       layer deeper (ENGINE_NOTES "Fire flow / aim" has the address to probe), and the weapon path
-      needs a ranged weapon to confirm end to end - the only save spawns with wrench + plasmid.*
+      needs a ranged weapon to confirm end to end - the only save spawns with wrench + plasmid.
+      TICKED same session after the user supplied a pistol: out-param B turned out to be an
+      FRotator (rotation-unit int32s, which print as near-zero floats - the trap that hid it), and
+      substituting it MOVES THE BULLETS. Flat-proven at a wall: decals landed 12 deg right, 12 deg
+      left, 10 deg down and 8/8 up-right of the crosshair with the camera stationary, and
+      `vraim off` put the next round back on the crosshair. Weapon (right hand) aim is DONE;
+      the plasmid path's direction is produced downstream in the damage factory and is the
+      remaining piece.*
 - [~] Right hand aims weapons; left hand aims plasmids; reticle at aim ray
       *Hand attribution shipped and verified live (object identity seeded by the trigger the
       bridge composes - "learned LEFT-hand (plasmid) object" on the first cast). XR grip poses

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -177,10 +177,30 @@ Goal: retire the project-level risks before building on them. Findings → ENGIN
 
 ## M6 - Decoupled aim (~2–3 sessions)
 
-- [ ] Decompile ShockGame.u (UE Explorer) → fire-flow + class findings into ENGINE_NOTES.md
+- [x] Decompile ShockGame.u (UE Explorer) → fire-flow + class findings into ENGINE_NOTES.md
       (summaries only, never code)
-- [ ] Aim-substitution hook at the GetPlayerViewPoint-equivalent (seed: itsloopyo decouple)
-- [ ] Right hand aims weapons; left hand aims plasmids; reticle at aim ray
+      *2026-07-25 (session 10): headless UELib via `tools/uscript/dump.ps1` (loads the package in
+      <1 s, lists classes/functions/states, decompiles by name). Mapped the whole chain: trigger →
+      `Weapon.BeginFiring` → `Firing` state → anim notify → `AttackAbility.UseAbility` → native
+      `InitiateDamage` → `GetPerfectFireStart` → damage factory. Attacks are ABILITIES, plasmids
+      included; the wrench damages through a Havok collision phantom and never traces. Also found
+      the engine's own native-function symbol table (registration string → .data entry → impl
+      pointer), which is now the standard way this project resolves natives.*
+- [~] Aim-substitution hook at the fire-start seam (seed: itsloopyo decouple)
+      *2026-07-25 (session 10): SHIPPED and command-gated (`vraim`), hooking the two C++
+      implementations - `AWeapon::GetPerfectFireStart` (vtable slot, impl 0x226840) and
+      `UAttackAbility::GetPerfectFireStart` (0x1BC220). The exec thunks were a dead end (native
+      callers bypass them - zero calls live). Ability seam LIVE-CONFIRMED firing on an Electro
+      Bolt cast with correct ownership gating, and ORIGIN substitution proven (`SUB(L)` with our
+      values). Remaining: the plasmid path's trace DIRECTION comes from the damage factory, one
+      layer deeper (ENGINE_NOTES "Fire flow / aim" has the address to probe), and the weapon path
+      needs a ranged weapon to confirm end to end - the only save spawns with wrench + plasmid.*
+- [~] Right hand aims weapons; left hand aims plasmids; reticle at aim ray
+      *Hand attribution shipped and verified live (object identity seeded by the trigger the
+      bridge composes - "learned LEFT-hand (plasmid) object" on the first cast). XR grip poses
+      are plumbed through to the adapter (located at the frame's predicted display time, converted
+      in the camera's own frame). Reticle not started - deferred to the next session with the
+      direction piece.*
 - [ ] **Done when:** look left while shooting right - impacts land where the controller points.
 
 ## M7 - Visible hands + weapons (~2–3 sessions)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -206,8 +206,13 @@ Goal: retire the project-level risks before building on them. Findings → ENGIN
       *Hand attribution shipped and verified live (object identity seeded by the trigger the
       bridge composes - "learned LEFT-hand (plasmid) object" on the first cast). XR grip poses
       are plumbed through to the adapter (located at the frame's predicted display time, converted
-      in the camera's own frame). Reticle not started - deferred to the next session with the
-      direction piece.*
+      in the camera's own frame).
+      IN-HEADSET USER-VERIFIED 2026-07-25: "it's pretty good... the plasmids are working and it's
+      based on the left hand which is very good" - both hands aim their own fire with the camera on
+      the HMD. Calibration ran low because the ray used the OpenXR GRIP pose; the build now uses
+      the runtime's AIM pose with pitch/yaw trim sliders (in-headset check pending). RETICLE still
+      not started: the user asked specifically for a visible laser from the hand - design in
+      STATUS "Next steps".*
 - [ ] **Done when:** look left while shooting right - impacts land where the controller points.
 
 ## M7 - Visible hands + weapons (~2–3 sessions)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -213,11 +213,33 @@ Goal: retire the project-level risks before building on them. Findings → ENGIN
       the runtime's AIM pose with pitch/yaw trim sliders (in-headset check pending). RETICLE still
       not started: the user asked specifically for a visible laser from the hand - design in
       STATUS "Next steps".*
-- [ ] **Done when:** look left while shooting right - impacts land where the controller points.
+- [x] **Done when:** look left while shooting right - impacts land where the controller points.
+      *TICKED 2026-07-25 (session 10), USER-VERIFIED IN-HEADSET: "it's pretty good... the plasmids
+      are working and it's based on the left hand which is very good", and after the aim-pose fix
+      "now it's pretty good - and the default at 0.00 for now is pretty good". Flat proof at a wall
+      first (decals 12 deg right, 12 deg left, 10 deg down, 8/8 up-right of a stationary
+      crosshair; `vraim off` restores it). Aim trim defaults stay 0/0 by the user's call.
+      RETICLE/LASER moved to M7 by the user's call: "we can do the laser thing when we do the guns
+      and hands since that way it's better and it's in the same idea" - a laser should emit from
+      the visible muzzle, and the user can judge aim calibration far better once the gun is
+      visible. Remaining M6 loose end (small): confirm WHAT steers the plasmid - its fire-start
+      rotator out-param reads all-zero, so the hand-origin substitution may be doing the visible
+      work; verify across a trace plasmid (Electro Bolt) and a projectile one (Incinerate).*
 
 ## M7 - Visible hands + weapons (~2–3 sessions)
 
 - [ ] Locate live AHands actor via UObject iteration; pin to grip pose each frame
+      *Assets already in hand from M6: the AHands vtable (RVA 0xD8A28C, RTTI-derived) for a
+      heap scan in the style of the UShockUserSettings lookup, the AHands natives in the engine's
+      own native table (`CanExecuteAction`, `SetCurrentTransitionSequence`,
+      `InterruptAnimNotifiesForAnimation`), the GRIP poses already located every frame beside the
+      aim poses (grip is the right pose for placing a model), the AActor field layout (+0x1D8
+      Location, +0x1E4 FRotator Rotation, +0x550 eye height) and the CalcView frame context the
+      aim ray already rides.*
+- [ ] Laser / aim reticle emitting from the weapon (moved here from M6 by the user, 2026-07-25):
+      small D3D11 swapchain holding a soft dot, submitted as several XR quad layers spaced along
+      the aim ray plus one at the aim point, each facing the head - all in XR space, so it is
+      per-eye correct with no game-space projection. Doubles as the aim-calibration tool.
 - [ ] Per-weapon offset tuning (live ImGui sliders, persisted config)
 - [ ] **Done when:** hands + current weapon track the controller convincingly; wrench melee
       feels aimed. (Full IK arms = post-v1.)

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -560,9 +560,20 @@ https://github.com/mohamad-balouza/bioshock-vr. Em dashes banned repo-wide.
   check; (b) the user wants a visible laser from the hand, which is the rung-2
   reticle work (design in Next steps). Hands still do not track the controllers -
   expected, that is M7.
+- **(late, same session) A crash the user hit, and the process lesson.** The
+  aim-pose build crashed on the first shot in the headset. Root cause found from
+  the dump in one pass (EBP walk + our-DLL disassembly, no PDB needed): an
+  unbounded string replace in a patch script had injected the new overlay
+  widgets into `substitute()` as well as `draw_debug_ui()` - the anchor line
+  appeared in both - so firing called `ImGui::Checkbox` from the GAME thread with
+  no current window (`GetCurrentWindow()` null deref, fault address 0xBE).
+  Fixed by removing the stray block; the ImGui-only-in-draw_debug_ui rule and a
+  mandatory pre-handoff FIRE TEST are now in TESTING. The rebuilt version is
+  flat-verified: overlay opens clean, 6 shots with substitution active, 0 new
+  dumps, decal lands off-crosshair where the injected aim asked.
 - Session ends: game closed, DLLs installed, branch `m6-decoupled-aim` pushed,
-  PR opened for review. No crashes and no new dumps across ~8 boots of hooking
-  engine internals.
+  PR opened for review. Of ~10 boots, one crash - the ImGui-on-game-thread bug
+  above, caught, diagnosed and fixed the same session.
 
 
 ### 2026-07-25 - Session 9

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -4,12 +4,31 @@
 
 ## Current state (2026-07-25, session 10)
 
-**M6: WEAPON AIM IS DECOUPLED AND FLAT-VERIFIED. The right controller now aims
-the gun; plasmids (left hand) still need one more seam.** Proof, at a flat wall
-with a pistol: injected hand aim put the bullet decals 12 deg right, 12 deg left,
-10 deg down and 8/8 up-right of the crosshair **while the camera never moved**,
-and `vraim off` put the next round back on the crosshair. What changed today, in
-the order it matters:
+**M6 IS WORKING AND USER-VERIFIED IN-HEADSET (2026-07-25): "I tested it and
+it's pretty good... the plasmids are working and it's based on the left hand
+which is very good."** The right controller aims weapons, the left controller
+aims plasmids, and the camera stays on the HMD. Flat proof first (wall test with
+a pistol: injected hand aim put the bullet decals 12 deg right, 12 deg left, 10
+deg down and 8/8 up-right of the crosshair **while the camera never moved**, and
+`vraim off` put the next round back on the crosshair), then the user confirmed
+both hands in the headset.
+
+**One real complaint from that run, and it is fixed in the shipped build:**
+aiming needed the wrist held lower than it should. Cause: the ray came from the
+OpenXR **grip** pose, whose forward axis runs along the handle, tens of degrees
+below where the controller visually points. The build now uses the runtime's
+**aim pose** (its own pointing ray) with pitch/yaw **trim sliders** in the
+overlay for taste - unverified in-headset as of this writing, so it is the first
+thing to check next session. The user also asked for a **visible laser from the
+hand**, which is the M6 rung-2 reticle work (not started - design in Next steps).
+
+**Surprise worth chasing:** the plasmid path works in-headset even though its
+fire-start rotator out-param read ALL-ZERO in the flat probe. Most likely the
+hand-origin substitution alone moves the bolt convincingly (the plasmid spawns
+from the hand), possibly plus a non-zero rotator under real play. Confirm with a
+probe before assuming the ability path is fully controlled.
+
+What changed today, in the order it matters:
 
 **1. The fire flow is no longer a mystery** (full map + every address in
 ENGINE_NOTES "Fire flow / aim"). Attacks in this engine are ABILITIES: trigger
@@ -51,11 +70,13 @@ writes the matching type - and the bullets follow. Ruled out along the way:
 `APawn::GetViewDirection` and `AShockPlayer::GetViewPoint` (probed live, never
 called during a shot).
 
-**5. What is NOT done - the PLASMID direction.** The ability path's rotator
-out-param is all-zero, so its direction is produced downstream in the damage
-factory: probe the factory virtual at vtbl `+0xEC` (ENGINE_NOTES has the chain).
-The left hand therefore still shoots where the view points. Also not started:
-the reticle at the aim ray (M6 rung 2).
+**5. What is NOT fully pinned down - the PLASMID direction.** The ability path's
+rotator out-param read all-zero in the flat probe, yet the left hand demonstrably
+aims plasmids in the headset. Either the origin substitution is doing the visible
+work, or that slot carries a rotation under conditions the flat test did not hit.
+Probe it (log the ability slots during a real cast) before touching the damage
+factory virtual at vtbl `+0xEC`. Also not started: the reticle/laser at the aim
+ray (M6 rung 2).
 
 **6. Tooling that will keep paying off.** Headless UELib decompiling
 (`tools/uscript/dump.ps1`, package loads in <1 s), `vraim scan <Class> <Func>`
@@ -398,20 +419,26 @@ https://github.com/mohamad-balouza/bioshock-vr. Em dashes banned repo-wide.
 
 ## Next steps
 
-1. **USER, in headset: does controller-aimed shooting feel right?** The flat
-   proof is done, but the XR grip-pose path has never run against a real
-   controller. Checklist at the end of this session's log entry. `vraim off`
-   reverts to stock aim instantly if it feels wrong.
-2. **Find the plasmid trace direction** (the last unknown in the fire flow):
+1. **USER, in headset: is the aim-pose calibration right now?** Tick "Controller
+   aim", fire at a wall, and if the impacts sit off where you point, drag "Aim
+   pitch trim" / "Aim yaw trim" in the overlay (or `vraim cal <pitch> [yaw]`,
+   +pitch aims higher) until they line up - then tell me the numbers and they
+   become the defaults. `vraim pose grip` falls back to the old behaviour.
+2. **Laser/reticle from the hand (the user's explicit ask, M6 rung 2).** Design:
+   a small D3D11 swapchain holding a soft dot, submitted as SEVERAL small XR quad
+   layers spaced along the aim ray (a dotted laser) plus one at the aim point,
+   each oriented to face the head - all in XR space from the hand pose core
+   already has, so no game-space projection is needed and it is per-eye correct
+   for free. `layers[1]` in openxr_runtime.cpp becomes `layers[N]`.
+3. **Confirm what actually steers the plasmid** (probe the ability slots during a
+   real cast), and only then chase the damage-factory direction:
    `vraim scanimpl` the damage-factory virtual at factory vtbl `+0xEC` (factory
    fetched by 0x231E70, called from `UAttackAbility::InitiateDamage` 0x1BBD80),
    then substitute the direction there. ENGINE_NOTES "Fire flow / aim" has the
    whole chain and the ruled-out candidates.
-3. **Reticle at the aim ray** (M6 rung 2, not started): XR quad-layer dot along
-   the ray at the hit distance (fallback fixed distance, overlay slider) plus a
-   flat ImGui crosshair at the projected point for harness proof. The user also
-   asked to try hiding the game's head-centred crosshair if it is cheap through
-   the `exec` seam; if it turns exploratory it drops to the M9 HUD work.
+4. **Hide the game's head-centred crosshair** once the laser lands (it will
+   disagree with the aim ray). Cheap attempts first through the `exec` seam; if it
+   turns exploratory it drops to the M9 HUD work.
 4. **Then the M6 acceptance run**: `vraim test r/l` + fire, assert impacts follow
    the injected hand aim and not the camera (img-diff + seam telemetry), both
    hands independent, `vraim off` restores view-aim, and one soak with
@@ -524,6 +551,15 @@ https://github.com/mohamad-balouza/bioshock-vr. Em dashes banned repo-wide.
   writes via `File::WriteAllText`, no BOM). Also: with `vrinput` off, synthetic
   pad presses are inert - drive menus with a real `VK_RETURN` on the highlighted
   item instead.
+- **(late, same session) IN-HEADSET USER-VERIFIED: "it's pretty good... the
+  plasmids are working and it's based on the left hand which is very good."**
+  Both hands aim their own fire while the camera stays on the HMD - M6's core
+  goal, confirmed by a human. Two follow-ups from that run: (a) calibration sat
+  low, because the ray used the OpenXR GRIP pose (handle axis) - the build now
+  uses the runtime's AIM pose plus pitch/yaw trim sliders, pending an in-headset
+  check; (b) the user wants a visible laser from the hand, which is the rung-2
+  reticle work (design in Next steps). Hands still do not track the controllers -
+  expected, that is M7.
 - Session ends: game closed, DLLs installed, branch `m6-decoupled-aim` pushed,
   PR opened for review. No crashes and no new dumps across ~8 boots of hooking
   engine internals.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -13,7 +13,13 @@ deg down and 8/8 up-right of the crosshair **while the camera never moved**, and
 `vraim off` put the next round back on the crosshair), then the user confirmed
 both hands in the headset.
 
-**One real complaint from that run, and it is fixed in the shipped build:**
+**M6 IS DONE (user's call, 2026-07-25).** After the aim-pose fix the user
+re-tested: "now it's pretty good - and the default at 0.00 for now is pretty
+good." Aim trim stays at 0/0. The RETICLE/LASER moves to M7 by their call ("we
+can do the laser thing when we do the guns and hands... it's the same idea"),
+and they expect to judge aim calibration much better once the gun is visible.
+
+**The complaint from the first in-headset run, and how it was fixed:**
 aiming needed the wrist held lower than it should. Cause: the ray came from the
 OpenXR **grip** pose, whose forward axis runs along the handle, tens of degrees
 below where the controller visually points. The build now uses the runtime's
@@ -419,24 +425,37 @@ https://github.com/mohamad-balouza/bioshock-vr. Em dashes banned repo-wide.
 
 ## Next steps
 
-1. **USER, in headset: is the aim-pose calibration right now?** Tick "Controller
-   aim", fire at a wall, and if the impacts sit off where you point, drag "Aim
-   pitch trim" / "Aim yaw trim" in the overlay (or `vraim cal <pitch> [yaw]`,
-   +pitch aims higher) until they line up - then tell me the numbers and they
-   become the defaults. `vraim pose grip` falls back to the old behaviour.
-2. **Laser/reticle from the hand (the user's explicit ask, M6 rung 2).** Design:
-   a small D3D11 swapchain holding a soft dot, submitted as SEVERAL small XR quad
-   layers spaced along the aim ray (a dotted laser) plus one at the aim point,
-   each oriented to face the head - all in XR space from the hand pose core
-   already has, so no game-space projection is needed and it is per-eye correct
-   for free. `layers[1]` in openxr_runtime.cpp becomes `layers[N]`.
-3. **Confirm what actually steers the plasmid** (probe the ability slots during a
-   real cast), and only then chase the damage-factory direction:
+1. **Wrap M6 (short, start of next session):** merge PR #1 into main, then a
+   stability pass the aim work has not had - `vrstereo on` + `vraim on` through a
+   save load and a few minutes of combat, watching for new dumps (the two fire
+   seams are the first hooks this project installs on gameplay-logic functions
+   rather than render/input ones).
+2. **M7 - visible hands + weapons (the user's next milestone).** Locate the live
+   `AHands` actor and pin it to the GRIP pose each frame; then per-weapon offset
+   sliders. Everything needed is already in the tree: the AHands vtable RVA
+   0xD8A28C for a heap scan (same technique as the settings object), its natives
+   in the engine's native table, grip poses located every frame beside the aim
+   poses, the AActor Location/Rotation/eye-height offsets, and the CalcView frame
+   context. Expect the fight to be about ORDER: the engine places the viewmodel
+   itself every tick, so our write has to land after its update (the CalcView
+   detour is the candidate moment) - and about not breaking the firing anims.
+3. **Laser / aim reticle - now part of M7** (user's call: it belongs with the
+   visible gun, and it doubles as the calibration tool). Design unchanged: a soft
+   dot in a small swapchain, several XR quad layers along the aim ray plus one at
+   the aim point, each facing the head - XR space only, per-eye correct for free.
+4. **Confirm what actually steers the plasmid** (small M6 loose end): its
+   fire-start rotator out-param reads all-zero, yet the left hand aims it in the
+   headset - so the hand-origin substitution may be doing the visible work. Probe
+   the ability slots during a real cast, and test a TRACE plasmid (Electro Bolt)
+   against a PROJECTILE one (Incinerate) before calling the ability path fully
+   controlled.
+5. **Only if #4 shows the direction is NOT under control**, chase the damage
+   factory:
    `vraim scanimpl` the damage-factory virtual at factory vtbl `+0xEC` (factory
    fetched by 0x231E70, called from `UAttackAbility::InitiateDamage` 0x1BBD80),
    then substitute the direction there. ENGINE_NOTES "Fire flow / aim" has the
    whole chain and the ruled-out candidates.
-4. **Hide the game's head-centred crosshair** once the laser lands (it will
+6. **Hide the game's head-centred crosshair** once the laser lands (it will
    disagree with the aim ray). Cheap attempts first through the `exec` seam; if it
    turns exploratory it drops to the M9 HUD work.
 4. **Then the M6 acceptance run**: `vraim test r/l` + fire, assert impacts follow

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -4,9 +4,12 @@
 
 ## Current state (2026-07-25, session 10)
 
-**M6 is UNDER WAY: the fire flow is mapped, the aim seam is shipped and
-command-gated, and the plasmid seam is live-confirmed - but the aim is NOT yet
-decoupled end to end.** What changed today, in the order it matters:
+**M6: WEAPON AIM IS DECOUPLED AND FLAT-VERIFIED. The right controller now aims
+the gun; plasmids (left hand) still need one more seam.** Proof, at a flat wall
+with a pistol: injected hand aim put the bullet decals 12 deg right, 12 deg left,
+10 deg down and 8/8 up-right of the crosshair **while the camera never moved**,
+and `vraim off` put the next round back on the crosshair. What changed today, in
+the order it matters:
 
 **1. The fire flow is no longer a mystery** (full map + every address in
 ENGINE_NOTES "Fire flow / aim"). Attacks in this engine are ABILITIES: trigger
@@ -38,16 +41,23 @@ the ability seam fires on an Electro Bolt cast, the hand map learns from the
 trigger ("learned LEFT-hand (plasmid) object"), and ORIGIN substitution lands
 (`SUB(L)` with our numbers).
 
-**4. What is NOT done - the direction.** `GetPerfectFireStart` fills POSITIONS
-only (live: out-params were the player location, a zero, and location+lean); the
-trace DIRECTION is produced one layer deeper in the damage factory. Ruled out
-live: `APawn::GetViewDirection` and `AShockPlayer::GetViewPoint` (never called
-during a shot). The next probe target is the factory virtual at `+0xEC`
-(ENGINE_NOTES has the address). Also unverified: the WEAPON path end to end -
-the only save in the tree spawns with wrench + Electro Bolt, and the wrench
-never traces, so a ranged weapon is needed (see "Next steps" #1).
+**4. The direction WAS there - hiding in plain sight as a denormal.** The
+weapon's out-param B is an **FRotator**, whose rotation-unit int32s reinterpret
+as float denormals and therefore print as `(0.000 0.000 0.000)`. Its live values
+matched the camera rotation exactly once printed as ints (`B[rot]=(132 116 0)` vs
+heartbeat `rot=(144 116 0)`). `aim.cpp` now classifies every out-param by value
+(small int32s = rotator, unit floats = direction, thousands = position) and
+writes the matching type - and the bullets follow. Ruled out along the way:
+`APawn::GetViewDirection` and `AShockPlayer::GetViewPoint` (probed live, never
+called during a shot).
 
-**5. Tooling that will keep paying off.** Headless UELib decompiling
+**5. What is NOT done - the PLASMID direction.** The ability path's rotator
+out-param is all-zero, so its direction is produced downstream in the damage
+factory: probe the factory virtual at vtbl `+0xEC` (ENGINE_NOTES has the chain).
+The left hand therefore still shoots where the view points. Also not started:
+the reticle at the aim ray (M6 rung 2).
+
+**6. Tooling that will keep paying off.** Headless UELib decompiling
 (`tools/uscript/dump.ps1`, package loads in <1 s), `vraim scan <Class> <Func>`
 (hook any name-based native read-only) and `vraim scanimpl <rva> <args>` (hook
 any C++ implementation) - so "does this function run when X happens" is a
@@ -388,14 +398,10 @@ https://github.com/mohamad-balouza/bioshock-vr. Em dashes banned repo-wide.
 
 ## Next steps
 
-1. **USER, flat, ~2 minutes: give the player a ranged weapon and fire it.** This
-   is the one thing blocking the weapon half of M6. Run the external trainer for
-   a loadout (a pistol or tommy gun with ammo is enough), stand facing a wall a
-   few metres away, then: `.\tools\game-cmd.ps1 "vraim probe on" "vraim dump 40"`
-   and fire ~5 shots (mouse or pad) plus a couple of plasmid casts. The log lines
-   `[aim] weapon this=... A=(...) B=(...) C=(...)` then say whether the weapon
-   path carries a DIRECTION out-param (the disassembly says its out-param B
-   should) - if it does, the right hand is one line of gating away from done.
+1. **USER, in headset: does controller-aimed shooting feel right?** The flat
+   proof is done, but the XR grip-pose path has never run against a real
+   controller. Checklist at the end of this session's log entry. `vraim off`
+   reverts to stock aim instantly if it feels wrong.
 2. **Find the plasmid trace direction** (the last unknown in the fire flow):
    `vraim scanimpl` the damage-factory virtual at factory vtbl `+0xEC` (factory
    fetched by 0x231E70, called from `UAttackAbility::InitiateDamage` 0x1BBD80),
@@ -500,8 +506,26 @@ https://github.com/mohamad-balouza/bioshock-vr. Em dashes banned repo-wide.
   <Func>` (any name-based native, read-only) and `vraim scanimpl <rva>
   <stackArgs>` (any C++ implementation, one detour family per arity so the
   callee-pop stays correct).
+- **(late, same session) THE WEAPON AIM IS DECOUPLED - flat-verified.** The user
+  supplied a pistol via the trainer and saved the game with it (so future
+  sessions can iterate solo). With the probe logging out-params as ints, B
+  revealed itself as an **FRotator** matching the camera rotation - rotation
+  units reinterpret as float denormals, which is why it had been printing as
+  `(0.000 0.000 0.000)`. Substitution now classifies each out-param by value and
+  writes the matching type. Wall test, camera stationary throughout: injected
+  hand aim of +12 deg yaw, -12 deg yaw, -10 deg pitch and +8/+8 each put the
+  bullet decals exactly where asked, and `vraim off` put the next round back on
+  the crosshair. Seam counters: 9 calls / 9 substitutions / 0 skips.
+  Left-hand plasmids are unchanged (their rotator out-param is all-zero - the
+  ability direction comes from the damage factory, next session's target).
+- Harness note: a `command.txt` written with PowerShell's
+  `Set-Content -Encoding utf8` gets a **BOM**, which corrupts the first command
+  token and is silently ignored by the poller. Use `tools/game-cmd.ps1` (it
+  writes via `File::WriteAllText`, no BOM). Also: with `vrinput` off, synthetic
+  pad presses are inert - drive menus with a real `VK_RETURN` on the highlighted
+  item instead.
 - Session ends: game closed, DLLs installed, branch `m6-decoupled-aim` pushed,
-  PR opened for review. No crashes and no new dumps across ~6 boots of hooking
+  PR opened for review. No crashes and no new dumps across ~8 boots of hooking
   engine internals.
 
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,6 +2,62 @@
 
 > Handoff file. Rewrite "Current state" and "Next steps" every session; append to the session log.
 
+## Current state (2026-07-25, session 10)
+
+**M6 is UNDER WAY: the fire flow is mapped, the aim seam is shipped and
+command-gated, and the plasmid seam is live-confirmed - but the aim is NOT yet
+decoupled end to end.** What changed today, in the order it matters:
+
+**1. The fire flow is no longer a mystery** (full map + every address in
+ENGINE_NOTES "Fire flow / aim"). Attacks in this engine are ABILITIES: trigger
+-> `Weapon.BeginFiring` -> the `Firing` state -> an ANIM NOTIFY -> the ability's
+`UseAbility` -> native `InitiateDamage` -> **`GetPerfectFireStart`** -> a damage
+factory that runs the trace. Guns/melee go through `AWeapon`, plasmids through
+`UAttackAbility`; the wrench damages through a **Havok collision phantom** and
+never traces at all (so melee aim is an M7 hands matter, not an aim vector).
+
+**2. Two discoveries made the search fast, and both are reusable.** (a) The
+engine ships a readable **symbol table for name-based natives** (registration
+string `int<Class>exec<Func>` -> a 12-byte `.data` entry -> the impl pointer);
+`pattern_scan::find_native_function` now resolves natives with no hardcoded
+addresses, and dumping that table offline (1822 entries) is the first stop for
+any future engine question - M7's `AHands` natives are already visible in it.
+(b) **UnrealScript `exec` thunks are not hookable seams**: hooking all four aim
+thunks caught ZERO calls while shooting, because native callers go straight to
+the C++ implementation. The shipped seams hook implementations (weapon side via
+the RTTI-derived vtable slot, ability side via a prologue-checked RVA).
+
+**3. The aim module is shipped, gated, and half-proven.**
+`game/bioshock1r/aim.cpp` + `vraim ...` commands: per-hand rays built in the
+CalcView frame from the XR grip poses (now located at the frame's predicted
+display time in `core/vr/openxr_input`), self-expiring `vraim test l|r <yaw>
+<pitch>` synthetic aim for headset-free testing, ownership gates that use the
+same instigator check the engine makes itself, and value-driven substitution so
+the engine's own spread (`ApplyAimError`) still applies on top. Live-verified:
+the ability seam fires on an Electro Bolt cast, the hand map learns from the
+trigger ("learned LEFT-hand (plasmid) object"), and ORIGIN substitution lands
+(`SUB(L)` with our numbers).
+
+**4. What is NOT done - the direction.** `GetPerfectFireStart` fills POSITIONS
+only (live: out-params were the player location, a zero, and location+lean); the
+trace DIRECTION is produced one layer deeper in the damage factory. Ruled out
+live: `APawn::GetViewDirection` and `AShockPlayer::GetViewPoint` (never called
+during a shot). The next probe target is the factory virtual at `+0xEC`
+(ENGINE_NOTES has the address). Also unverified: the WEAPON path end to end -
+the only save in the tree spawns with wrench + Electro Bolt, and the wrench
+never traces, so a ranged weapon is needed (see "Next steps" #1).
+
+**5. Tooling that will keep paying off.** Headless UELib decompiling
+(`tools/uscript/dump.ps1`, package loads in <1 s), `vraim scan <Class> <Func>`
+(hook any name-based native read-only) and `vraim scanimpl <rva> <args>` (hook
+any C++ implementation) - so "does this function run when X happens" is a
+command, not a rebuild. Harness gotcha worth remembering: the FIRST trigger pull
+only switches hands (`SwitchAndFireWeapon`/`SwitchAndFireAbility`), so a single
+synthetic pull looks like nothing happened.
+
+Branch: **`m6-decoupled-aim`** (this phase is being reviewed by PR rather than
+pushed to main).
+
 ## Current state (2026-07-25, session 9)
 
 **M5 rung 1 - the synthetic-XInput lane - is BUILT, FLAT-VERIFIED, and
@@ -332,40 +388,39 @@ https://github.com/mohamad-balouza/bioshock-vr. Em dashes banned repo-wide.
 
 ## Next steps
 
-1. ~~USER: in-headset controller test~~ - DONE 2026-07-25: "controllers are
-   working perfectly as expected." Combat feel with a starter loadout was good;
-   rebinds wanted later (parked to M9). Aiming is right-stick / head-crosshair
-   as expected (M6 decoupled aim replaces it). Mapping tweaks are cheap (all in
-   openxr_input.cpp).
-2. **M5 rung 2 - menu mode (next session)**: whole frame on a quad when paused/
-   in-menu; controller laser -> virtual mouse (DR-6 decides synthetic Win32 mouse
-   vs DirectInput; we now have GetState-lane telemetry to probe which path the
-   gameswf menus read). Note: menu NAV already works via the synthetic dpad/stick/
-   A through the gamepad lane - the quad + laser is the immersion piece.
-3. **M6 - decoupled aim (the aiming fix the user flagged)**: hook the
-   GetPlayerViewPoint-equivalent used by fire traces so the weapon aims where
-   the RIGHT CONTROLLER points while the camera keeps the head pose. This is
-   what makes shooting feel VR-native rather than stick-aimed.
-4. **Controller polish surfaced by the headset test**: deadzone tuning (overlay
-   slider live), stick response curve, menu long-press START/BACK timing, and
-   whether grips-as-bumpers for weapon/plasmid cycling holds up vs. wanting the
-   M8 radial wheels sooner. Rebinds parked to M9 by user choice.
-5. **Console-command seam (M6 groundwork)**: the `exec`/`execc`/`exece` lanes
-   reach native engine handlers; the script-command path needs the player-object
-   Exec signature reversed (slot 65 unbalanced the stack; ENGINE_NOTES). Do NOT
-   re-enable a player-vtable Exec call without reversing that first.
-6. **Remaining stereo polish**: HUD-in-stereo decision (renders in both eyes; verify
-   on a HUD-bearing spawn, M9 ties in), world-scale/IPD calibration pass (parked M9).
-6. If the init-crash flake (bioshockvr.dll+0x30BE5, one occurrence, pre-SEH-guards)
-   recurs: the crash log now prints module+RVA - symbolize against the PDB and fix.
-7. Still open from M3: cutscene cameras are head-driven too (may need a viewactor == pc
-   guard).
-8. DR-7: borderless/windowed stability; DR-6: menu input path (session-5 note: synthetic
-   clicks sometimes only highlight a gameswf item - VK_RETURN activates it, TESTING.md).
-9. Optional anytime: Steam Link / SteamVR cross-check.
-10. **Parked in M9 (user's call, 2026-07-24)**: IPD slider verification (exaggerated-offset
-    test first, world scale before IPD), small head-motion bobbing, and the vrstereo
-    off/re-arm state bug (details in the M9 list).
+1. **USER, flat, ~2 minutes: give the player a ranged weapon and fire it.** This
+   is the one thing blocking the weapon half of M6. Run the external trainer for
+   a loadout (a pistol or tommy gun with ammo is enough), stand facing a wall a
+   few metres away, then: `.\tools\game-cmd.ps1 "vraim probe on" "vraim dump 40"`
+   and fire ~5 shots (mouse or pad) plus a couple of plasmid casts. The log lines
+   `[aim] weapon this=... A=(...) B=(...) C=(...)` then say whether the weapon
+   path carries a DIRECTION out-param (the disassembly says its out-param B
+   should) - if it does, the right hand is one line of gating away from done.
+2. **Find the plasmid trace direction** (the last unknown in the fire flow):
+   `vraim scanimpl` the damage-factory virtual at factory vtbl `+0xEC` (factory
+   fetched by 0x231E70, called from `UAttackAbility::InitiateDamage` 0x1BBD80),
+   then substitute the direction there. ENGINE_NOTES "Fire flow / aim" has the
+   whole chain and the ruled-out candidates.
+3. **Reticle at the aim ray** (M6 rung 2, not started): XR quad-layer dot along
+   the ray at the hit distance (fallback fixed distance, overlay slider) plus a
+   flat ImGui crosshair at the projected point for harness proof. The user also
+   asked to try hiding the game's head-centred crosshair if it is cheap through
+   the `exec` seam; if it turns exploratory it drops to the M9 HUD work.
+4. **Then the M6 acceptance run**: `vraim test r/l` + fire, assert impacts follow
+   the injected hand aim and not the camera (img-diff + seam telemetry), both
+   hands independent, `vraim off` restores view-aim, and one soak with
+   `vrstereo on` + `vraim on`.
+5. M5 rung 2 - menu mode (quad + controller laser -> virtual mouse, DR-6).
+   Controller polish (deadzone/curve/menu timing) and rebinds stay parked in M9.
+6. Still open from M3: cutscene cameras are head-driven. The aim path already
+   guards on the view actor's vtable (AShockPlayer) - reuse that predicate for
+   the camera when it is addressed.
+7. If the init-crash flake (bioshockvr.dll+0x30BE5, one occurrence pre-SEH
+   guards) recurs: the crash log prints module+RVA - symbolize against the PDB.
+8. DR-7 borderless/windowed stability; DR-6 menu input path; optional Steam
+   Link / SteamVR cross-check any time.
+9. **Parked in M9** (user's call 2026-07-24): IPD slider verification, small
+   head-motion bobbing, the vrstereo off/re-arm state bug, HUD-in-both-eyes.
 
 ## Open questions / blockers
 
@@ -384,6 +439,71 @@ https://github.com/mohamad-balouza/bioshock-vr. Em dashes banned repo-wide.
   (install.ps1 backs theirs up automatically).
 
 ## Session log (newest first)
+
+### 2026-07-25 - Session 10 (M6 part 1, branch `m6-decoupled-aim`)
+
+- **Investigation first, and it paid off.** Parsed ShockGame.U's name table
+  directly (UTF-16 names with a positive char count, 8-byte flags on this
+  licensee build), which surfaced `LastTraceFireStart`, `ApplyAimError`,
+  `GetPerfectFireStart`, `AutoAim`... Then found the engine's **native-function
+  symbol table**: every name-based native has a `.data` entry
+  `{ "int<Class>exec<Func>", impl, 0 }`. Enumerated all 1822 entries offline
+  (scratchpad `natives.py`/`nativemap.py`) and shipped
+  `pattern_scan::find_native_function` so the mod resolves natives with zero
+  hardcoded addresses. All five session-10 lookups hit their documented RVAs on
+  the first boot.
+- **Headless decompiling now works**: UE Explorer's portable build ships
+  `Eliot.UELib.dll`, driven from PowerShell by `tools/uscript/dump.ps1` (<1 s to
+  load ShockGame.U; lists classes/functions/states, decompiles by name). Two
+  quirks recorded in ENGINE_NOTES (name encoding, and ~40% of UFunctions failing
+  to deserialize on this build - the rest are plenty).
+- **The fire flow, mapped end to end** (ENGINE_NOTES "Fire flow / aim"):
+  trigger -> `Weapon.BeginFiring` -> `Firing` state -> anim notify ->
+  `AttackAbility.UseAbility` -> native `InitiateDamage` (AWeapon 0x226050 /
+  UAttackAbility 0x1BBD80) -> `GetPerfectFireStart` (0x226840 / 0x1BC220) ->
+  damage factory. Plus the AActor field layout (+0x1D8 Location, +0x1E4
+  FRotator Rotation, +0x550 eye height) cross-checked against a live pawn
+  hexdump, and the RTTI vtables for AShockPlayer/APlayerWeapon/UAttackAbility/
+  AHands.
+- **Dead end recorded honestly: the exec thunks.** The first build hooked all
+  four aim `exec*` thunks; a full live session of swinging, casting and clicking
+  produced ZERO calls, because native callers reach the C++ implementation
+  directly. Rebuilt against the implementations (weapon side by reading the
+  RTTI-derived vtable slot +0x304, ability side by a prologue-checked RVA) and
+  the ability seam fired on the very next cast.
+- **`game/bioshock1r/aim.cpp` shipped** (command-gated `vraim on|off|probe|dump|
+  origin|seam|test|scan|scanimpl|scanoff|status`): per-hand rays built inside the
+  CalcView frame from XR grip poses, `ue_math.h` extracted so the camera and the
+  aim ray can never drift apart, ownership gates using the engine's own
+  instigator check, value-driven out-param substitution (positions get the
+  hand's origin, directions get the hand's direction, zeros untouched) so
+  `ApplyAimError` still applies the weapon's spread on top, and self-expiring
+  `vraim test l|r <yaw> <pitch>` synthetic aim for headset-free testing.
+- **Core plumbing**: `core/vr/openxr_input` locates the (already existing)
+  grip-pose action spaces at the frame's predicted display time - the same
+  instant as the head pose - and `vr::get_hand_pose` exposes them with the same
+  mutex/no-XR-stub shape as `get_head_pose`. `xinput_bridge` publishes the last
+  composed triggers, which is what seeds hand attribution.
+- **Live results**: ability seam fires on Electro Bolt (`this` vtable =
+  UAttackAbility), hand map learns from the trigger ("learned LEFT-hand
+  (plasmid) object"), ORIGIN substitution proven (`SUB(L)` with our values).
+  `GetPerfectFireStart` turns out to fill POSITIONS only - so the trace
+  DIRECTION lives one layer deeper, in the damage factory. `APawn::
+  GetViewDirection` and `AShockPlayer::GetViewPoint` implementations were probed
+  and are never called during a shot (ruled out).
+- **Two harness lessons** (now in TESTING): the FIRST trigger pull only switches
+  hands (`XENON_LT/RT = SwitchAndFireAbility/Weapon`), so single synthetic pulls
+  look inert; and the wrench never traces (Havok collision phantom), so it is
+  useless as a fire-path control - the weapon seam needs a ranged weapon, which
+  the only available save does not have.
+- New investigation tools that remove rebuild cycles: `vraim scan <Class>
+  <Func>` (any name-based native, read-only) and `vraim scanimpl <rva>
+  <stackArgs>` (any C++ implementation, one detour family per arity so the
+  callee-pop stays correct).
+- Session ends: game closed, DLLs installed, branch `m6-decoupled-aim` pushed,
+  PR opened for review. No crashes and no new dumps across ~6 boots of hooking
+  engine internals.
+
 
 ### 2026-07-25 - Session 9
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -89,6 +89,48 @@ Verified flat procedure (2026-07-25, no physical pad connected):
    ENGINE_NOTES "Gamepad architecture"), xi14/xi13 are diagnostic hooks on
    the system DLLs.
 
+## Decoupled aim (M6 `vraim`) - flat verification
+
+Commands (all through the seam, so they work with no headset):
+
+- `vraim probe on|off` - install the fire seams in telemetry mode;
+  `vraim dump <n>` gives each seam n detailed log lines
+  (`this`/vtable/out-params).
+- `vraim on|off` - arm substitution (right hand aims weapons, left hand aims
+  plasmids); `vraim status` prints seam counters, both rays and the learned
+  object->hand map.
+- `vraim test l|r <yawDeg> <pitchDeg> [holdMs]` - synthetic hand aim as an
+  OFFSET from the current view rotation, feeding the exact slot the XR grip
+  pose will. `vraim test clear` drops it. Holds self-expire inside the DLL.
+- `vraim origin on|off` - hand origin + direction (default) vs direction only.
+- `vraim seam weapon|ability on|off` - per-family substitution.
+- **Investigation tools** (these are how the fire flow was mapped, keep them):
+  `vraim scan <Class> <Func> [n]` hooks ANY name-based native read-only via the
+  engine's own native table; `vraim scanimpl <rvaHex> <stackArgs 1..3> [n]`
+  hooks any C++ implementation (arg count MUST match the target's `ret <n>`);
+  `vraim scanoff` disables both. No rebuild per candidate.
+
+Firing the game from the harness - the gotchas that cost a session:
+
+1. **The first trigger pull only SWITCHES HANDS.** `XENON_RT =
+   SwitchAndFireWeapon`, `XENON_LT = SwitchAndFireAbility` (ENGINE_NOTES
+   "UnrealScript findings"), so a single `vrinput test trig l 255 400` looks
+   like nothing happened. Send two pulls ~2 s apart (the seam polls at 1 Hz):
+   the second one fires. Right mouse = switch hands, left mouse = fire the
+   active hand.
+2. **The wrench never traces** (Havok collision phantom), so no aim seam fires
+   for melee no matter how it connects - not a bug, and not a useful control.
+   The only save in the tree spawns with wrench + Electro Bolt; testing the
+   WEAPON seam needs a ranged weapon (external trainer loadout).
+3. Aim at something within range. A cast into open air still runs the ability
+   fire-start seam; damage-side natives (`CanHit`, `InitiateDamage` on the
+   weapon) only run on a hit.
+4. After a force-kill the game shows a **"revert Options?" dialog** on the next
+   launch and its window title is `Message`, not `Bioshock`; answer No by
+   `BM_CLICK`-ing the `&No` button (scratchpad `boot2.ps1` does this). The game
+   window can also report a 0x0 rect for a few seconds after it appears -
+   retry `game-shot.ps1` instead of treating that as an error.
+
 ## Automated in-game testing (no human in the loop)
 
 - **Command seam**: the mod polls `%LOCALAPPDATA%\BioshockVR\command.txt` at 1 Hz on the game

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -110,6 +110,24 @@ Commands (all through the seam, so they work with no headset):
   hooks any C++ implementation (arg count MUST match the target's `ret <n>`);
   `vraim scanoff` disables both. No rebuild per candidate.
 
+**Before handing ANY build to the user, run the flat fire test.** A build that
+compiles and boots can still crash on the first shot (it did, session 10): load
+the save, open the F10 overlay once (exercises the ImGui path), then
+`vraim on` + `vraim test r 14 0 60000` and fire 3+ shots with
+`vrinput test trig r 255 400` (two pulls if the weapon hand is not active),
+finally assert (a) the game is still running, (b) NO new dump in
+`%LOCALAPPDATA%\BioshockVR\crash\`, (c) `vraim status` shows subs > 0, and
+(d) a screenshot puts the fresh decal off the crosshair. Scratchpad
+`firetest.ps1`/`fire5.ps1` do exactly this.
+
+**ImGui rule:** widgets may ONLY be called from `draw_debug_ui()` (render
+thread, inside the overlay's Begin/End). An ImGui call anywhere the game thread
+reaches - a hooked engine function, the command handler, the CalcView path -
+faults on a null current window (`GetCurrentWindow()` -> `window->WriteAccessed`,
+crash at bioshockvr.dll+... with fault address 0xBE). Session 10 hit this by
+letting an unbounded string replace inject overlay widgets into the fire-path
+substitution function.
+
 Firing the game from the harness - the gotchas that cost a session:
 
 1. **The first trigger pull only SWITCHES HANDS.** `XENON_RT =

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,8 @@ add_library(bioshockvr SHARED
     core/util/crash.cpp
     core/util/crash.h
     game/igame_adapter.h
+    game/bioshock1r/aim.cpp
+    game/bioshock1r/aim.h
     game/bioshock1r/bioshock1r_adapter.cpp
     game/bioshock1r/bioshock1r_adapter.h
     game/bioshock1r/camera.cpp
@@ -48,6 +50,7 @@ add_library(bioshockvr SHARED
     game/bioshock1r/patterns.h
     game/bioshock1r/scenedraw.cpp
     game/bioshock1r/scenedraw.h
+    game/bioshock1r/ue_math.h
 )
 set_target_properties(bioshockvr PROPERTIES PREFIX "")
 target_include_directories(bioshockvr PRIVATE .)

--- a/src/core/hooks/pattern_scan.cpp
+++ b/src/core/hooks/pattern_scan.cpp
@@ -16,6 +16,7 @@
 #define PSAPI_VERSION 2 // K32GetModuleInformation from kernel32; no psapi.lib
 #include <psapi.h>
 
+#include <cstdio>
 #include <cstring>
 
 namespace bvr::pattern_scan {
@@ -190,6 +191,43 @@ bool find_event_function(const ProcessImage& img, const char* eventName, EventSc
                     return true;
                 }
             }
+        }
+    }
+    return false;
+}
+
+bool find_native_function(const ProcessImage& img, const char* className,
+                          const char* funcName, NativeScanResult& out) {
+    out = {};
+
+    char name[160];
+    if (_snprintf_s(name, sizeof name, _TRUNCATE, "int%sexec%s", className, funcName) < 0)
+        return false;
+
+    std::vector<const uint8_t*> strings = find_wide_string(img, name);
+    out.stringMatches = strings.size();
+
+    for (const uint8_t* ws : strings) {
+        // A shorter registration name can be a SUFFIX of a longer one (the
+        // linker pools wide strings by suffix), so only an occurrence whose
+        // own terminator follows the last character is the real entry.
+        size_t len = strlen(name);
+        const uint8_t* term = ws + 2 * len;
+        if (!is_memory_valid(term, 2) || term[0] != 0 || term[1] != 0) continue;
+
+        std::vector<const uint8_t*> refs = find_references(img, ws);
+        out.tableRefs += refs.size();
+
+        for (const uint8_t* entry : refs) {
+            if (!is_memory_valid(entry, 12)) continue;
+            uint32_t impl;
+            memcpy(&impl, entry + 4, sizeof(impl));
+            const uint8_t* fn = reinterpret_cast<const uint8_t*>(static_cast<uintptr_t>(impl));
+            if (fn < img.base || fn >= img.base + img.size) continue; // not code in this image
+            if (!is_memory_valid(fn, 16)) continue;
+            out.tableEntry = entry;
+            out.function = const_cast<uint8_t*>(fn);
+            return true;
         }
     }
     return false;

--- a/src/core/hooks/pattern_scan.h
+++ b/src/core/hooks/pattern_scan.h
@@ -63,4 +63,27 @@ struct EventScanResult {
 // wins. Returns true and fills out.function on success.
 bool find_event_function(const ProcessImage& img, const char* eventName, EventScanResult& out);
 
+// Stage-by-stage diagnostics of find_native_function.
+struct NativeScanResult {
+    size_t stringMatches = 0;  // occurrences of the registration name
+    size_t tableRefs = 0;      // dword references to it (candidate table entries)
+    const void* tableEntry = nullptr;
+    void* function = nullptr;  // resolved execFoo implementation
+};
+
+// UE2 native-function lookup: every `native` UnrealScript function implemented
+// in C++ is registered through a 12-byte table entry
+// `{ const TCHAR* name; Native impl; 0 }` whose name is the wide string
+// "int<Class>exec<Function>" (e.g. "intAWeaponexecApplyAimError") in .rdata.
+// The impl pointer is written into the entry by static initialization, so at
+// runtime the entry IS the symbol table: find the name string, find the dword
+// that references it, and read the next dword.
+//
+// Derived 2026-07-25 (M6) by dumping the registration strings out of the exe's
+// .rdata and following their .data references (docs/ENGINE_NOTES.md "Native
+// function table"). Nothing here is game-specific - it is how the engine
+// registers name-based natives, so BioShock 2 will resolve the same way.
+bool find_native_function(const ProcessImage& img, const char* className,
+                          const char* funcName, NativeScanResult& out);
+
 } // namespace bvr::pattern_scan

--- a/src/core/input/xinput_bridge.cpp
+++ b/src/core/input/xinput_bridge.cpp
@@ -48,6 +48,10 @@ TimedTrig  g_testTrigL, g_testTrigR;
 uint64_t g_testBtnDeadline[16] = {}; // per XINPUT button bit index
 
 Gamepad g_lastComposed{};
+// Last composed triggers (lt low byte, rt high byte) for the M6 aim path -
+// an atomic rather than a peek at g_lastComposed so a hooked engine native on
+// the game thread never has to take g_mutex.
+std::atomic<uint16_t> g_lastTriggers{0};
 uint32_t g_packet = 0;            // bridge-owned monotonic dwPacketNumber
 bool g_packetBump = false;        // forced bump on enable/disable edges
 
@@ -149,7 +153,17 @@ Gamepad compose_synthetic(uint64_t now) {
 void compose_over(DWORD userIndex, XINPUT_STATE* xs, DWORD* result) {
     if (userIndex != 0) return;
     g_lastRealResult.store(*result, std::memory_order_relaxed);
-    if (!g_enabled.load(std::memory_order_relaxed)) return;
+    if (!g_enabled.load(std::memory_order_relaxed)) {
+        // Publish the real pad's triggers anyway: the M6 aim path reads them to
+        // tell weapon fire from plasmid fire, and that has to work for a player
+        // on a physical pad too.
+        uint16_t t = 0;
+        if (*result == ERROR_SUCCESS)
+            t = static_cast<uint16_t>(xs->Gamepad.bLeftTrigger) |
+                static_cast<uint16_t>(static_cast<uint16_t>(xs->Gamepad.bRightTrigger) << 8);
+        g_lastTriggers.store(t, std::memory_order_relaxed);
+        return;
+    }
 
     Gamepad real{};
     if (*result == ERROR_SUCCESS) {
@@ -170,6 +184,9 @@ void compose_over(DWORD userIndex, XINPUT_STATE* xs, DWORD* result) {
     memcpy(&xs->Gamepad, &out, sizeof out);
     xs->dwPacketNumber = g_packet;
     *result = ERROR_SUCCESS;
+    g_lastTriggers.store(static_cast<uint16_t>(out.lt) |
+                             static_cast<uint16_t>(static_cast<uint16_t>(out.rt) << 8),
+                         std::memory_order_relaxed);
 
     if (!g_loggedFirstCompose.exchange(true, std::memory_order_relaxed))
         BVR_LOG("input: first synthetic compose served (packet %u)", g_packet);
@@ -446,6 +463,12 @@ void publish_xr_state(const Gamepad& pad, bool active) {
 }
 
 float stick_deadzone() { return g_deadzone.load(std::memory_order_relaxed); }
+
+void last_composed_triggers(uint8_t* lt, uint8_t* rt) {
+    uint16_t t = g_lastTriggers.load(std::memory_order_relaxed);
+    if (lt) *lt = static_cast<uint8_t>(t & 0xFF);
+    if (rt) *rt = static_cast<uint8_t>(t >> 8);
+}
 
 void handle_command(const char* args) {
     install_dll_hooks(); // lazy retry in case xinput1_4 loaded after init

--- a/src/core/input/xinput_bridge.h
+++ b/src/core/input/xinput_bridge.h
@@ -35,6 +35,11 @@ void publish_xr_state(const Gamepad& pad, bool active);
 // Radial stick deadzone (fraction 0..0.5) applied by the XR composer.
 float stick_deadzone();
 
+// Last composed trigger pair (0..255). The M6 aim path uses it to tell which
+// hand a fire event belongs to: we compose this state ourselves, so "which
+// trigger is the player pulling" is information the mod already owns.
+void last_composed_triggers(uint8_t* lt, uint8_t* rt);
+
 // Install the bridge's composing XInputGetState wrapper into an import slot
 // (e.g. the game module's IAT entry for xinput1_3 ordinal 2). The slot's
 // previous target becomes the passthrough, so a hook chain already wrapping

--- a/src/core/vr/openxr_input.cpp
+++ b/src/core/vr/openxr_input.cpp
@@ -42,11 +42,17 @@ XrAction g_btnY = XR_NULL_HANDLE;
 XrAction g_stickClickL = XR_NULL_HANDLE;
 XrAction g_stickClickR = XR_NULL_HANDLE;
 XrAction g_menu = XR_NULL_HANDLE;
-XrAction g_poseL = XR_NULL_HANDLE;     // grip poses - M6 consumers
+XrAction g_poseL = XR_NULL_HANDLE;     // grip poses - hand position (M7 hands)
 XrAction g_poseR = XR_NULL_HANDLE;
+XrAction g_aimL = XR_NULL_HANDLE;      // AIM poses - where the controller POINTS.
+XrAction g_aimR = XR_NULL_HANDLE;      // The runtime's own pointing ray; the grip
+                                       // pose runs along the handle and reads
+                                       // tens of degrees low as an aim vector.
 
 XrSpace g_gripSpaceL = XR_NULL_HANDLE; // session children
 XrSpace g_gripSpaceR = XR_NULL_HANDLE;
+XrSpace g_aimSpaceL = XR_NULL_HANDLE;
+XrSpace g_aimSpaceR = XR_NULL_HANDLE;
 XrSpace g_baseSpace = XR_NULL_HANDLE;  // app space, owned by the runtime
 bool g_attached = false;
 bool g_created = false;
@@ -67,7 +73,8 @@ struct HandSlot {
     float px = 0.0f, py = 0.0f, pz = 0.0f;
     float qx = 0.0f, qy = 0.0f, qz = 0.0f, qw = 1.0f;
 };
-HandSlot g_hands[2]; // 0 = left, 1 = right
+HandSlot g_hands[2]; // grip pose: 0 = left, 1 = right
+HandSlot g_aims[2];  // aim pose, same indexing
 
 // Telemetry for the overlay (render thread writes, overlay reads same thread).
 std::atomic<uint32_t> g_syncOk{0};
@@ -169,6 +176,13 @@ void locate_hand(XrSession session, XrAction poseAction, XrSpace space, XrTime w
     slot.valid.store(true, std::memory_order_relaxed);
 }
 
+void invalidate_hand_slots() {
+    for (int i = 0; i < 2; ++i) {
+        g_hands[i].valid.store(false, std::memory_order_relaxed);
+        g_aims[i].valid.store(false, std::memory_order_relaxed);
+    }
+}
+
 bool read_vec2(XrSession session, XrAction action, float* x, float* y) {
     XrActionStateGetInfo gi{XR_TYPE_ACTION_STATE_GET_INFO};
     gi.action = action;
@@ -213,6 +227,8 @@ void input_create(XrInstance instance) {
     made += make_action("menu", "Menu", XR_ACTION_TYPE_BOOLEAN_INPUT, &g_menu);
     made += make_action("pose_l", "Left grip pose", XR_ACTION_TYPE_POSE_INPUT, &g_poseL);
     made += make_action("pose_r", "Right grip pose", XR_ACTION_TYPE_POSE_INPUT, &g_poseR);
+    made += make_action("aim_l", "Left aim pose", XR_ACTION_TYPE_POSE_INPUT, &g_aimL);
+    made += make_action("aim_r", "Right aim pose", XR_ACTION_TYPE_POSE_INPUT, &g_aimR);
 
     // Quest 3 Touch. Never bind .../input/system/click - reserved by runtimes.
     XrActionSuggestedBinding touch[] = {
@@ -231,6 +247,8 @@ void input_create(XrInstance instance) {
         {g_menu, path(instance, "/user/hand/left/input/menu/click")},
         {g_poseL, path(instance, "/user/hand/left/input/grip/pose")},
         {g_poseR, path(instance, "/user/hand/right/input/grip/pose")},
+        {g_aimL, path(instance, "/user/hand/left/input/aim/pose")},
+        {g_aimR, path(instance, "/user/hand/right/input/aim/pose")},
     };
     XrInteractionProfileSuggestedBinding sb{XR_TYPE_INTERACTION_PROFILE_SUGGESTED_BINDING};
     sb.interactionProfile = path(instance, "/interaction_profiles/oculus/touch_controller");
@@ -248,6 +266,8 @@ void input_create(XrInstance instance) {
         {g_menu, path(instance, "/user/hand/left/input/menu/click")},
         {g_poseL, path(instance, "/user/hand/left/input/grip/pose")},
         {g_poseR, path(instance, "/user/hand/right/input/grip/pose")},
+        {g_aimL, path(instance, "/user/hand/left/input/aim/pose")},
+        {g_aimR, path(instance, "/user/hand/right/input/aim/pose")},
     };
     sb.interactionProfile = path(instance, "/interaction_profiles/khr/simple_controller");
     sb.suggestedBindings = simple;
@@ -271,6 +291,12 @@ void input_on_session_created(XrSession session, XrSpace baseSpace) {
     asci.action = g_poseR;
     if (XR_FAILED(xrCreateActionSpace(session, &asci, &g_gripSpaceR)))
         g_gripSpaceR = XR_NULL_HANDLE;
+    asci.action = g_aimL;
+    if (XR_FAILED(xrCreateActionSpace(session, &asci, &g_aimSpaceL)))
+        g_aimSpaceL = XR_NULL_HANDLE;
+    asci.action = g_aimR;
+    if (XR_FAILED(xrCreateActionSpace(session, &asci, &g_aimSpaceR)))
+        g_aimSpaceR = XR_NULL_HANDLE;
 
     XrSessionActionSetsAttachInfo sai{XR_TYPE_SESSION_ACTION_SETS_ATTACH_INFO};
     sai.countActionSets = 1;
@@ -292,9 +318,10 @@ void input_on_session_created(XrSession session, XrSpace baseSpace) {
 void input_on_session_teardown() {
     if (g_gripSpaceL != XR_NULL_HANDLE) { xrDestroySpace(g_gripSpaceL); g_gripSpaceL = XR_NULL_HANDLE; }
     if (g_gripSpaceR != XR_NULL_HANDLE) { xrDestroySpace(g_gripSpaceR); g_gripSpaceR = XR_NULL_HANDLE; }
+    if (g_aimSpaceL != XR_NULL_HANDLE) { xrDestroySpace(g_aimSpaceL); g_aimSpaceL = XR_NULL_HANDLE; }
+    if (g_aimSpaceR != XR_NULL_HANDLE) { xrDestroySpace(g_aimSpaceR); g_aimSpaceR = XR_NULL_HANDLE; }
     g_baseSpace = XR_NULL_HANDLE;
-    g_hands[0].valid.store(false, std::memory_order_relaxed);
-    g_hands[1].valid.store(false, std::memory_order_relaxed);
+    invalidate_hand_slots();
     g_attached = false;
     g_gripLatchedL = g_gripLatchedR = false;
     g_menuDownMs = 0;
@@ -313,8 +340,7 @@ void input_sync(XrSession session, XrTime predictedDisplayTime) {
     if (r == XR_SESSION_NOT_FOCUSED) {
         g_syncNotFocused.fetch_add(1, std::memory_order_relaxed);
         g_lastActive.store(false, std::memory_order_relaxed);
-        g_hands[0].valid.store(false, std::memory_order_relaxed);
-        g_hands[1].valid.store(false, std::memory_order_relaxed);
+        invalidate_hand_slots();
         bvr::input::publish_xr_state({}, false);
         return;
     }
@@ -322,8 +348,7 @@ void input_sync(XrSession session, XrTime predictedDisplayTime) {
         // Never tear the session down from the input path - display first.
         g_syncFailed.fetch_add(1, std::memory_order_relaxed);
         g_lastActive.store(false, std::memory_order_relaxed);
-        g_hands[0].valid.store(false, std::memory_order_relaxed);
-        g_hands[1].valid.store(false, std::memory_order_relaxed);
+        invalidate_hand_slots();
         bvr::input::publish_xr_state({}, false);
         return;
     }
@@ -333,6 +358,8 @@ void input_sync(XrSession session, XrTime predictedDisplayTime) {
     // locate just leaves its slot invalid and the aim falls back to the view).
     locate_hand(session, g_poseL, g_gripSpaceL, predictedDisplayTime, g_hands[0]);
     locate_hand(session, g_poseR, g_gripSpaceR, predictedDisplayTime, g_hands[1]);
+    locate_hand(session, g_aimL, g_aimSpaceL, predictedDisplayTime, g_aims[0]);
+    locate_hand(session, g_aimR, g_aimSpaceR, predictedDisplayTime, g_aims[1]);
 
     bvr::input::Gamepad pad{};
 
@@ -383,9 +410,9 @@ void input_sync(XrSession session, XrTime predictedDisplayTime) {
     bvr::input::publish_xr_state(pad, true);
 }
 
-bool input_get_hand_pose(int hand, float* pos3, float* quat4) {
+bool input_get_hand_pose(int hand, bool aimPose, float* pos3, float* quat4) {
     if (hand < 0 || hand > 1 || !pos3 || !quat4) return false;
-    const HandSlot& s = g_hands[hand];
+    const HandSlot& s = aimPose ? g_aims[hand] : g_hands[hand];
     if (!s.valid.load(std::memory_order_relaxed)) return false;
     pos3[0] = s.px; pos3[1] = s.py; pos3[2] = s.pz;
     quat4[0] = s.qx; quat4[1] = s.qy; quat4[2] = s.qz; quat4[3] = s.qw;
@@ -393,9 +420,11 @@ bool input_get_hand_pose(int hand, float* pos3, float* quat4) {
 }
 
 void input_draw_debug_ui() {
-    ImGui::Text("xr hands: L %s R %s",
-                g_hands[0].valid.load(std::memory_order_relaxed) ? "tracked" : "-",
-                g_hands[1].valid.load(std::memory_order_relaxed) ? "tracked" : "-");
+    ImGui::Text("xr hands: grip L %s R %s | aim L %s R %s",
+                g_hands[0].valid.load(std::memory_order_relaxed) ? "ok" : "-",
+                g_hands[1].valid.load(std::memory_order_relaxed) ? "ok" : "-",
+                g_aims[0].valid.load(std::memory_order_relaxed) ? "ok" : "-",
+                g_aims[1].valid.load(std::memory_order_relaxed) ? "ok" : "-");
     ImGui::Text("xr actions: %s | sync ok %u nf %u fail %u | %s",
                 g_attached ? "attached" : (g_created ? "created" : "off"),
                 g_syncOk.load(std::memory_order_relaxed),

--- a/src/core/vr/openxr_input.cpp
+++ b/src/core/vr/openxr_input.cpp
@@ -47,6 +47,7 @@ XrAction g_poseR = XR_NULL_HANDLE;
 
 XrSpace g_gripSpaceL = XR_NULL_HANDLE; // session children
 XrSpace g_gripSpaceR = XR_NULL_HANDLE;
+XrSpace g_baseSpace = XR_NULL_HANDLE;  // app space, owned by the runtime
 bool g_attached = false;
 bool g_created = false;
 bool g_loggedAttachFail = false;
@@ -56,6 +57,17 @@ bool g_gripLatchedL = false;
 bool g_gripLatchedR = false;
 uint64_t g_menuDownMs = 0;
 uint64_t g_startPulseUntilMs = 0;
+
+// M6 hand poses. Located on the render thread in input_sync; read from the
+// GAME thread by the adapter's aim path, so publish through atomics-guarded
+// snapshots (relaxed is fine: a group torn by one frame is invisible at
+// 90 Hz, and the valid flag is what gates use of the numbers).
+struct HandSlot {
+    std::atomic<bool> valid{false};
+    float px = 0.0f, py = 0.0f, pz = 0.0f;
+    float qx = 0.0f, qy = 0.0f, qz = 0.0f, qw = 1.0f;
+};
+HandSlot g_hands[2]; // 0 = left, 1 = right
 
 // Telemetry for the overlay (render thread writes, overlay reads same thread).
 std::atomic<uint32_t> g_syncOk{0};
@@ -120,6 +132,41 @@ bool read_bool(XrSession session, XrAction action) {
     if (XR_FAILED(xrGetActionStateBoolean(session, &gi, &st)) || !st.isActive)
         return false;
     return st.currentState == XR_TRUE;
+}
+
+// Locate one grip space against the app space at the frame's predicted display
+// time - the same instant the head pose is located, so hand and head belong to
+// the same moment and the aim ray cannot lag the camera.
+void locate_hand(XrSession session, XrAction poseAction, XrSpace space, XrTime when,
+                 HandSlot& slot) {
+    if (space == XR_NULL_HANDLE || g_baseSpace == XR_NULL_HANDLE) {
+        slot.valid.store(false, std::memory_order_relaxed);
+        return;
+    }
+    // The action must be active (controller present + bound) before its space
+    // is meaningful.
+    XrActionStateGetInfo gi{XR_TYPE_ACTION_STATE_GET_INFO};
+    gi.action = poseAction;
+    XrActionStatePose ps{XR_TYPE_ACTION_STATE_POSE};
+    if (XR_FAILED(xrGetActionStatePose(session, &gi, &ps)) || !ps.isActive) {
+        slot.valid.store(false, std::memory_order_relaxed);
+        return;
+    }
+    XrSpaceLocation sl{XR_TYPE_SPACE_LOCATION};
+    if (XR_FAILED(xrLocateSpace(space, g_baseSpace, when, &sl)) ||
+        !(sl.locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT) ||
+        !(sl.locationFlags & XR_SPACE_LOCATION_ORIENTATION_VALID_BIT)) {
+        slot.valid.store(false, std::memory_order_relaxed);
+        return;
+    }
+    slot.px = sl.pose.position.x;
+    slot.py = sl.pose.position.y;
+    slot.pz = sl.pose.position.z;
+    slot.qx = sl.pose.orientation.x;
+    slot.qy = sl.pose.orientation.y;
+    slot.qz = sl.pose.orientation.z;
+    slot.qw = sl.pose.orientation.w;
+    slot.valid.store(true, std::memory_order_relaxed);
 }
 
 bool read_vec2(XrSession session, XrAction action, float* x, float* y) {
@@ -212,8 +259,9 @@ void input_create(XrInstance instance) {
             "suggested)", made);
 }
 
-void input_on_session_created(XrSession session, XrSpace /*baseSpace*/) {
+void input_on_session_created(XrSession session, XrSpace baseSpace) {
     if (!g_created) return;
+    g_baseSpace = baseSpace; // M6: hand poses locate against the app space
 
     XrActionSpaceCreateInfo asci{XR_TYPE_ACTION_SPACE_CREATE_INFO};
     asci.poseInActionSpace.orientation.w = 1.0f;
@@ -244,6 +292,9 @@ void input_on_session_created(XrSession session, XrSpace /*baseSpace*/) {
 void input_on_session_teardown() {
     if (g_gripSpaceL != XR_NULL_HANDLE) { xrDestroySpace(g_gripSpaceL); g_gripSpaceL = XR_NULL_HANDLE; }
     if (g_gripSpaceR != XR_NULL_HANDLE) { xrDestroySpace(g_gripSpaceR); g_gripSpaceR = XR_NULL_HANDLE; }
+    g_baseSpace = XR_NULL_HANDLE;
+    g_hands[0].valid.store(false, std::memory_order_relaxed);
+    g_hands[1].valid.store(false, std::memory_order_relaxed);
     g_attached = false;
     g_gripLatchedL = g_gripLatchedR = false;
     g_menuDownMs = 0;
@@ -251,7 +302,7 @@ void input_on_session_teardown() {
     bvr::input::publish_xr_state({}, false);
 }
 
-void input_sync(XrSession session, XrTime /*predictedDisplayTime*/) {
+void input_sync(XrSession session, XrTime predictedDisplayTime) {
     if (!g_attached) return;
 
     XrActiveActionSet active{g_actionSet, XR_NULL_PATH};
@@ -262,6 +313,8 @@ void input_sync(XrSession session, XrTime /*predictedDisplayTime*/) {
     if (r == XR_SESSION_NOT_FOCUSED) {
         g_syncNotFocused.fetch_add(1, std::memory_order_relaxed);
         g_lastActive.store(false, std::memory_order_relaxed);
+        g_hands[0].valid.store(false, std::memory_order_relaxed);
+        g_hands[1].valid.store(false, std::memory_order_relaxed);
         bvr::input::publish_xr_state({}, false);
         return;
     }
@@ -269,10 +322,17 @@ void input_sync(XrSession session, XrTime /*predictedDisplayTime*/) {
         // Never tear the session down from the input path - display first.
         g_syncFailed.fetch_add(1, std::memory_order_relaxed);
         g_lastActive.store(false, std::memory_order_relaxed);
+        g_hands[0].valid.store(false, std::memory_order_relaxed);
+        g_hands[1].valid.store(false, std::memory_order_relaxed);
         bvr::input::publish_xr_state({}, false);
         return;
     }
     g_syncOk.fetch_add(1, std::memory_order_relaxed);
+
+    // M6: hand grip poses for the aim ray (never fatal - a hand that fails to
+    // locate just leaves its slot invalid and the aim falls back to the view).
+    locate_hand(session, g_poseL, g_gripSpaceL, predictedDisplayTime, g_hands[0]);
+    locate_hand(session, g_poseR, g_gripSpaceR, predictedDisplayTime, g_hands[1]);
 
     bvr::input::Gamepad pad{};
 
@@ -323,7 +383,19 @@ void input_sync(XrSession session, XrTime /*predictedDisplayTime*/) {
     bvr::input::publish_xr_state(pad, true);
 }
 
+bool input_get_hand_pose(int hand, float* pos3, float* quat4) {
+    if (hand < 0 || hand > 1 || !pos3 || !quat4) return false;
+    const HandSlot& s = g_hands[hand];
+    if (!s.valid.load(std::memory_order_relaxed)) return false;
+    pos3[0] = s.px; pos3[1] = s.py; pos3[2] = s.pz;
+    quat4[0] = s.qx; quat4[1] = s.qy; quat4[2] = s.qz; quat4[3] = s.qw;
+    return true;
+}
+
 void input_draw_debug_ui() {
+    ImGui::Text("xr hands: L %s R %s",
+                g_hands[0].valid.load(std::memory_order_relaxed) ? "tracked" : "-",
+                g_hands[1].valid.load(std::memory_order_relaxed) ? "tracked" : "-");
     ImGui::Text("xr actions: %s | sync ok %u nf %u fail %u | %s",
                 g_attached ? "attached" : (g_created ? "created" : "off"),
                 g_syncOk.load(std::memory_order_relaxed),

--- a/src/core/vr/openxr_input.h
+++ b/src/core/vr/openxr_input.h
@@ -36,4 +36,11 @@ void input_sync(XrSession session, XrTime predictedDisplayTime);
 // One status line inside vr::draw_debug_ui().
 void input_draw_debug_ui();
 
+// M6: latest predicted GRIP pose of a hand (0 = left, 1 = right), located in
+// input_sync against the app space at the same predicted display time as the
+// head pose. False while that hand is not tracked. Position in meters,
+// orientation as a quaternion - XR convention, exactly like HeadPose; the game
+// adapter owns the conversion to Unreal units.
+bool input_get_hand_pose(int hand, float* pos3, float* quat4);
+
 } // namespace bvr::vr

--- a/src/core/vr/openxr_input.h
+++ b/src/core/vr/openxr_input.h
@@ -36,11 +36,14 @@ void input_sync(XrSession session, XrTime predictedDisplayTime);
 // One status line inside vr::draw_debug_ui().
 void input_draw_debug_ui();
 
-// M6: latest predicted GRIP pose of a hand (0 = left, 1 = right), located in
+// M6: latest predicted pose of a hand (0 = left, 1 = right), located in
 // input_sync against the app space at the same predicted display time as the
-// head pose. False while that hand is not tracked. Position in meters,
-// orientation as a quaternion - XR convention, exactly like HeadPose; the game
-// adapter owns the conversion to Unreal units.
-bool input_get_hand_pose(int hand, float* pos3, float* quat4);
+// head pose. `aimPose` picks the runtime's AIM pose - "where this controller
+// points", which is what aiming wants - over the GRIP pose, which runs along the
+// handle and reads tens of degrees low as a pointing ray (hand rendering wants
+// grip). False while that hand is not tracked. Position in meters, orientation
+// as a quaternion - XR convention, like HeadPose; the adapter converts to
+// Unreal units.
+bool input_get_hand_pose(int hand, bool aimPose, float* pos3, float* quat4);
 
 } // namespace bvr::vr

--- a/src/core/vr/openxr_runtime.cpp
+++ b/src/core/vr/openxr_runtime.cpp
@@ -853,6 +853,13 @@ bool get_head_pose(HeadPose& out) {
     return true;
 }
 
+bool get_hand_pose(int hand, HeadPose& out) {
+    float p[3], q[4];
+    if (!input_get_hand_pose(hand, p, q)) return false;
+    out = {p[0], p[1], p[2], q[0], q[1], q[2], q[3]};
+    return true;
+}
+
 bool vr_camera_mode() {
     return g_cameraMode.load(std::memory_order_relaxed) &&
            g_sessionBegun.load(std::memory_order_relaxed) &&
@@ -907,6 +914,7 @@ void on_present_end(IDXGISwapChain*) {}
 void on_resize() {}
 void draw_debug_ui() {}
 bool get_head_pose(HeadPose&) { return false; }
+bool get_hand_pose(int, HeadPose&) { return false; }
 bool vr_camera_mode() { return false; }
 void set_camera_mode(bool) {}
 float suggested_hfov_deg() { return 0.0f; }

--- a/src/core/vr/openxr_runtime.cpp
+++ b/src/core/vr/openxr_runtime.cpp
@@ -853,9 +853,9 @@ bool get_head_pose(HeadPose& out) {
     return true;
 }
 
-bool get_hand_pose(int hand, HeadPose& out) {
+bool get_hand_pose(int hand, bool aimPose, HeadPose& out) {
     float p[3], q[4];
-    if (!input_get_hand_pose(hand, p, q)) return false;
+    if (!input_get_hand_pose(hand, aimPose, p, q)) return false;
     out = {p[0], p[1], p[2], q[0], q[1], q[2], q[3]};
     return true;
 }
@@ -914,7 +914,7 @@ void on_present_end(IDXGISwapChain*) {}
 void on_resize() {}
 void draw_debug_ui() {}
 bool get_head_pose(HeadPose&) { return false; }
-bool get_hand_pose(int, HeadPose&) { return false; }
+bool get_hand_pose(int, bool, HeadPose&) { return false; }
 bool vr_camera_mode() { return false; }
 void set_camera_mode(bool) {}
 float suggested_hfov_deg() { return 0.0f; }

--- a/src/core/vr/openxr_runtime.h
+++ b/src/core/vr/openxr_runtime.h
@@ -49,7 +49,9 @@ bool get_head_pose(HeadPose& out);
 // it belongs to the same instant as the camera. False while that hand is not
 // tracked (no session, unfocused, controller asleep) - callers must then fall
 // back to the game's own aim rather than freezing on a stale pose.
-bool get_hand_pose(int hand, HeadPose& out);
+// `aimPose` true = the runtime's pointing ray (aiming), false = the grip pose
+// (hand/weapon placement).
+bool get_hand_pose(int hand, bool aimPose, HeadPose& out);
 
 // True when the user enabled VR camera mode AND a session is running; the
 // adapter drives the game camera from the HMD only while this holds. Frame

--- a/src/core/vr/openxr_runtime.h
+++ b/src/core/vr/openxr_runtime.h
@@ -43,6 +43,14 @@ struct HeadPose {
 // display time). False while not tracking.
 bool get_head_pose(HeadPose& out);
 
+// --- M6: controller poses for decoupled aim ---------------------------------
+// Latest predicted GRIP pose of a hand (0 = left, 1 = right), located at the
+// SAME predicted display time as the head pose above, so an aim ray built from
+// it belongs to the same instant as the camera. False while that hand is not
+// tracked (no session, unfocused, controller asleep) - callers must then fall
+// back to the game's own aim rather than freezing on a stale pose.
+bool get_hand_pose(int hand, HeadPose& out);
+
 // True when the user enabled VR camera mode AND a session is running; the
 // adapter drives the game camera from the HMD only while this holds. Frame
 // submission switches from the quad to a projection layer at the same time.

--- a/src/game/bioshock1r/aim.cpp
+++ b/src/game/bioshock1r/aim.cpp
@@ -42,6 +42,10 @@ std::atomic<bool> g_subWeapon{true};  // right hand aims weapons
 std::atomic<bool> g_subAbility{true}; // left hand aims plasmids
 std::atomic<bool> g_handOrigin{true}; // hand origin + direction (user's choice)
 std::atomic<bool> g_probe{false};     // telemetry mode
+// The overlay runs on the RENDER thread and must never install a MinHook itself
+// (same rule as scenedraw's vrstereo checkbox): it posts a request here and the
+// game thread applies it from on_calcview, outside any hooked engine call.
+std::atomic<int> g_pendingEnable{-1}; // -1 none, 0 off, 1 on
 std::atomic<int32_t> g_dumpBudget{0}; // per-seam detailed log budget
 
 // Per-frame aim rays, game thread only (built in on_calcview, read in the
@@ -711,6 +715,21 @@ void on_calcview(const FrameContext& ctx) {
     uint64_t now = GetTickCount64();
     g_rayStampMs = now;
 
+    // Apply an overlay request from THIS thread (see g_pendingEnable).
+    int pending = g_pendingEnable.exchange(-1, std::memory_order_relaxed);
+    if (pending == 1) {
+        if (install_all()) {
+            g_enabled.store(true, std::memory_order_relaxed);
+            BVR_LOG("[aim] ON (overlay) - controller aim substitutes the view aim");
+        } else {
+            BVR_LOG("[aim] overlay enable REFUSED: no aim seam hooked");
+        }
+    } else if (pending == 0) {
+        g_enabled.store(false, std::memory_order_relaxed);
+        if (!g_probe.load(std::memory_order_relaxed)) disable_all();
+        BVR_LOG("[aim] OFF (overlay) - engine aim restored");
+    }
+
     // Cutscene guard (the open M3 item): the view actor during normal play is
     // the player's own pawn - an AShockPlayer. A scripted camera swaps the
     // view target for some other actor, and then nothing about the player's
@@ -891,14 +910,8 @@ void draw_debug_ui() {
     if (!ImGui::CollapsingHeader("Decoupled aim (M6)", ImGuiTreeNodeFlags_DefaultOpen)) return;
 
     bool on = g_enabled.load(std::memory_order_relaxed);
-    if (ImGui::Checkbox("Controller aim (right = weapon, left = plasmid)", &on)) {
-        if (on) {
-            if (install_all()) g_enabled.store(true, std::memory_order_relaxed);
-        } else {
-            g_enabled.store(false, std::memory_order_relaxed);
-            if (!g_probe.load(std::memory_order_relaxed)) disable_all();
-        }
-    }
+    if (ImGui::Checkbox("Controller aim (right = weapon, left = plasmid)", &on))
+        g_pendingEnable.store(on ? 1 : 0, std::memory_order_relaxed);
     bool handOrigin = g_handOrigin.load(std::memory_order_relaxed);
     if (ImGui::Checkbox("Ray starts at the hand (off = engine origin, direction only)",
                         &handOrigin))

--- a/src/game/bioshock1r/aim.cpp
+++ b/src/game/bioshock1r/aim.cpp
@@ -223,6 +223,34 @@ void note_substitution(Hand h, const FVector& o, const FRotator& r) {
     g_lastSubHand.store(h == Hand::Right ? 1u : 0u, std::memory_order_relaxed);
 }
 
+// What did the engine just put in this 12-byte out-param? Decide from the
+// value, because the fire-start functions hand back a mix and the order differs
+// between the weapon and the ability signature:
+//   FRotator - three rotation-unit int32s (65536 per turn). Their FLOAT
+//              reinterpretation is a denormal, which is why a rotator prints as
+//              "0.000 0.000 0.000" - the trap that cost session 10 a detour.
+//   FVector direction - ordinary floats, length ~1.
+//   FVector position  - ordinary floats, thousands of Unreal units.
+enum SlotKind { kUnused, kRotator, kDirection, kPosition };
+
+SlotKind classify_slot(const float v[3]) {
+    int32_t i[3];
+    memcpy(i, v, sizeof i);
+    if (i[0] == 0 && i[1] == 0 && i[2] == 0) return kUnused;
+    bool allSmallInts = true;
+    for (int k = 0; k < 3; ++k) {
+        int32_t a = i[k] < 0 ? -i[k] : i[k];
+        if (a > (1 << 21)) allSmallInts = false; // 2 million rot units is nonsense
+    }
+    if (allSmallInts) return kRotator;
+    float len2 = v[0] * v[0] + v[1] * v[1] + v[2] * v[2];
+    return len2 < 4.0f ? kDirection : kPosition;
+}
+
+const char* slot_kind_name(SlotKind k) {
+    return k == kRotator ? "rot" : k == kDirection ? "dir" : k == kPosition ? "pos" : "-";
+}
+
 // ---- detours ---------------------------------------------------------------
 // Both seams are __thiscall C++ methods, which is register/stack-identical to
 // __fastcall with a dummy EDX slot. Substitution happens AFTER the original
@@ -234,25 +262,19 @@ void log_call(Slot& slot, void* self, const float* a, const float* b, const floa
     --slot.dumpLeft;
     void* vtbl = nullptr;
     read_ptr(self, &vtbl);
-    BVR_LOG("[aim] %s this=%p vtbl=0x%X A=(%.1f %.1f %.1f) B=(%.3f %.3f %.3f) "
-            "C=(%.3f %.3f %.3f) %s",
-            slot.name, self, to_rva(vtbl), a[0], a[1], a[2], b[0], b[1], b[2], c[0], c[1], c[2],
-            note);
+    int32_t bi[3];
+    memcpy(bi, b, sizeof bi);
+    BVR_LOG("[aim] %s this=%p vtbl=0x%X A[%s]=(%.1f %.1f %.1f) B[%s]=(%d %d %d) "
+            "C[%s]=(%.1f %.1f %.1f) %s",
+            slot.name, self, to_rva(vtbl), slot_kind_name(classify_slot(a)), a[0], a[1], a[2],
+            slot_kind_name(classify_slot(b)), bi[0], bi[1], bi[2],
+            slot_kind_name(classify_slot(c)), c[0], c[1], c[2], note);
 }
 
 // The two out-params are a POSITION (thousands of Unreal units) and a unit
 // DIRECTION, and which slot holds which differs between the weapon and the
 // ability signature. Rather than trust the disassembly's labels, decide per
 // call from the magnitudes - a direction is never longer than ~1.
-bool looks_like_direction(const float v[3]) {
-    float len2 = v[0] * v[0] + v[1] * v[1] + v[2] * v[2];
-    return len2 < 4.0f;
-}
-
-bool is_zero(const float v[3]) {
-    return v[0] == 0.0f && v[1] == 0.0f && v[2] == 0.0f;
-}
-
 // Write our ray into the out-params: every slot the engine filled with a
 // POSITION gets the hand's origin, every slot it filled with a DIRECTION gets
 // the hand's direction. Which index is which differs between the two
@@ -270,16 +292,32 @@ bool substitute(Slot& slot, Hand h, float* const* out, int count) {
     float pos[3] = {o.x, o.y, o.z};
     bool handOrigin = g_handOrigin.load(std::memory_order_relaxed);
 
+    // An FRotator carries the engine's roll through untouched: aim owns pitch
+    // and yaw, the weapon's own roll is none of our business.
     bool wrote = false;
     for (int i = 0; i < count; ++i) {
         if (!out[i]) continue;
         float cur[3];
         if (!read12(out[i], cur)) continue;
-        if (is_zero(cur)) continue; // engine left this one alone; so do we
-        if (looks_like_direction(cur)) {
-            wrote |= write12(out[i], dir);
-        } else if (handOrigin) {
-            wrote |= write12(out[i], pos);
+        switch (classify_slot(cur)) {
+            case kRotator: {
+                int32_t curInt[3];
+                memcpy(curInt, cur, sizeof curInt);
+                int32_t rot[3] = {r.pitch, r.yaw, curInt[2]};
+                float packed[3];
+                memcpy(packed, rot, sizeof packed);
+                wrote |= write12(out[i], packed);
+                break;
+            }
+            case kDirection:
+                wrote |= write12(out[i], dir);
+                break;
+            case kPosition:
+                if (handOrigin) wrote |= write12(out[i], pos);
+                break;
+            case kUnused:
+            default:
+                break; // engine left it alone; so do we
         }
     }
     if (!wrote) return false;

--- a/src/game/bioshock1r/aim.cpp
+++ b/src/game/bioshock1r/aim.cpp
@@ -301,16 +301,6 @@ bool substitute(Slot& slot, Hand h, float* const* out, int count) {
     float dir[3];
     ue_rot_to_dir(r, dir);
     float pos[3] = {o.x, o.y, o.z};
-    bool useAim = g_useAimPose.load(std::memory_order_relaxed);
-    if (ImGui::Checkbox("Use the runtime AIM pose (off = grip pose)", &useAim))
-        g_useAimPose.store(useAim, std::memory_order_relaxed);
-    float pitchCal = g_pitchOffsetDeg.load(std::memory_order_relaxed);
-    if (ImGui::SliderFloat("Aim pitch trim (deg)", &pitchCal, -30.0f, 30.0f))
-        g_pitchOffsetDeg.store(pitchCal, std::memory_order_relaxed);
-    float yawCal = g_yawOffsetDeg.load(std::memory_order_relaxed);
-    if (ImGui::SliderFloat("Aim yaw trim (deg)", &yawCal, -30.0f, 30.0f))
-        g_yawOffsetDeg.store(yawCal, std::memory_order_relaxed);
-
     bool handOrigin = g_handOrigin.load(std::memory_order_relaxed);
 
     // An FRotator carries the engine's roll through untouched: aim owns pitch

--- a/src/game/bioshock1r/aim.cpp
+++ b/src/game/bioshock1r/aim.cpp
@@ -400,6 +400,121 @@ void* const kProbeDetours[kProbeSlots] = {
 
 bvr::pattern_scan::ProcessImage g_image{};
 
+// ---- arbitrary-implementation probe ----------------------------------------
+// `vraim scanimpl <rva> <stackArgs>` hooks any C++ method read-only. The fire
+// flow runs through virtuals and direct calls that no name lookup can reach, so
+// answering "does THIS function run when a shot happens" has to be possible
+// from the command file - a rebuild per candidate is how a session evaporates.
+// The stack-arg count must match the target's `ret <n>`, hence one detour
+// family per arity.
+
+constexpr int kImplSlotsPerArity = 2;
+
+struct ImplSlot {
+    uint32_t rva = 0;
+    void* target = nullptr;
+    void* original = nullptr;
+    bool created = false;
+    std::atomic<bool> enabled{false};
+    std::atomic<uint32_t> calls{0};
+    int32_t dumpLeft = 0;
+};
+ImplSlot g_impl[3][kImplSlotsPerArity]; // [arity-1][slot]
+
+void impl_note(ImplSlot& p, void* self, void* a1, void* a2, void* a3) {
+    p.calls.fetch_add(1, std::memory_order_relaxed);
+    if (p.dumpLeft <= 0) return;
+    --p.dumpLeft;
+    void* vtbl = nullptr;
+    read_ptr(self, &vtbl);
+    float v1[3] = {0, 0, 0};
+    read12(a1, v1);
+    BVR_LOG("[aim] impl 0x%X this=%p vtbl=0x%X a1=%p(%.2f %.2f %.2f) a2=%p a3=%p", p.rva, self,
+            to_rva(vtbl), a1, v1[0], v1[1], v1[2], a2, a3);
+}
+
+template <int N>
+void* __fastcall Impl1Detour(void* self, void* edx, void* a1) {
+    using Fn = void*(__fastcall*)(void*, void*, void*);
+    void* r = reinterpret_cast<Fn>(g_impl[0][N].original)(self, edx, a1);
+    impl_note(g_impl[0][N], self, a1, nullptr, nullptr);
+    return r;
+}
+
+template <int N>
+void* __fastcall Impl2Detour(void* self, void* edx, void* a1, void* a2) {
+    using Fn = void*(__fastcall*)(void*, void*, void*, void*);
+    void* r = reinterpret_cast<Fn>(g_impl[1][N].original)(self, edx, a1, a2);
+    impl_note(g_impl[1][N], self, a1, a2, nullptr);
+    return r;
+}
+
+template <int N>
+void* __fastcall Impl3Detour(void* self, void* edx, void* a1, void* a2, void* a3) {
+    using Fn = void*(__fastcall*)(void*, void*, void*, void*, void*);
+    void* r = reinterpret_cast<Fn>(g_impl[2][N].original)(self, edx, a1, a2, a3);
+    impl_note(g_impl[2][N], self, a1, a2, a3);
+    return r;
+}
+
+void* const kImplDetours[3][kImplSlotsPerArity] = {
+    {reinterpret_cast<void*>(&Impl1Detour<0>), reinterpret_cast<void*>(&Impl1Detour<1>)},
+    {reinterpret_cast<void*>(&Impl2Detour<0>), reinterpret_cast<void*>(&Impl2Detour<1>)},
+    {reinterpret_cast<void*>(&Impl3Detour<0>), reinterpret_cast<void*>(&Impl3Detour<1>)},
+};
+
+void scan_impl(uint32_t rva, int args, int32_t dump) {
+    if (args < 1 || args > 3) {
+        BVR_LOG("[aim] scanimpl: stackArgs must be 1..3 (must match the target's ret size)");
+        return;
+    }
+    if (!g_imageBase) return;
+    void* target = const_cast<uint8_t*>(g_imageBase) + rva;
+    for (int i = 0; i < kImplSlotsPerArity; ++i) {
+        ImplSlot& p = g_impl[args - 1][i];
+        if (p.target == target) {
+            p.dumpLeft = dump;
+            BVR_LOG("[aim] impl 0x%X re-armed (%d lines)", rva, dump);
+            return;
+        }
+    }
+    for (int i = 0; i < kImplSlotsPerArity; ++i) {
+        ImplSlot& p = g_impl[args - 1][i];
+        if (p.created) continue;
+        p.rva = rva;
+        p.target = target;
+        p.dumpLeft = dump;
+        MH_STATUS st = MH_CreateHook(target, kImplDetours[args - 1][i], &p.original);
+        if (st != MH_OK) {
+            BVR_LOG("[aim] scanimpl 0x%X: MH_CreateHook failed: %s", rva, MH_StatusToString(st));
+            p.target = nullptr;
+            return;
+        }
+        p.created = true;
+        st = MH_EnableHook(target);
+        if (st != MH_OK) {
+            BVR_LOG("[aim] scanimpl 0x%X: MH_EnableHook failed: %s", rva, MH_StatusToString(st));
+            return;
+        }
+        p.enabled.store(true, std::memory_order_relaxed);
+        BVR_LOG("[aim] scanimpl 0x%X hooked (%d stack args, %d dump lines)", rva, args, dump);
+        return;
+    }
+    BVR_LOG("[aim] scanimpl: no free %d-arg slot (`vraim scanoff` first)", args);
+}
+
+void impl_scan_off() {
+    for (auto& arity : g_impl) {
+        for (ImplSlot& p : arity) {
+            if (!p.enabled.load(std::memory_order_relaxed)) continue;
+            MH_DisableHook(p.target);
+            p.enabled.store(false, std::memory_order_relaxed);
+            BVR_LOG("[aim] impl 0x%X disabled (calls %u)", p.rva,
+                    p.calls.load(std::memory_order_relaxed));
+        }
+    }
+}
+
 void scan_and_hook(const char* cls, const char* fn, int32_t dump) {
     bvr::pattern_scan::NativeScanResult scan{};
     if (!bvr::pattern_scan::find_native_function(g_image, cls, fn, scan)) {
@@ -644,8 +759,15 @@ void handle_command(const char* args) {
                          static_cast<unsigned>(sizeof fn), &dump);
         if (n >= 2) scan_and_hook(cls, fn, dump > 0 ? dump : 8);
         else BVR_LOG("[aim] usage: vraim scan <Class> <Func> [dumpLines]");
+    } else if (strcmp(verb, "scanimpl") == 0) {
+        unsigned rva = 0;
+        int args = 0, dump = 8;
+        int n = sscanf_s(rest, "%x %d %d", &rva, &args, &dump);
+        if (n >= 2) scan_impl(rva, args, dump > 0 ? dump : 8);
+        else BVR_LOG("[aim] usage: vraim scanimpl <rvaHex> <stackArgs 1..3> [dumpLines]");
     } else if (strcmp(verb, "scanoff") == 0) {
         scan_off();
+        impl_scan_off();
     } else if (strcmp(verb, "probe") == 0) {
         bool on = strncmp(rest, "on", 2) == 0;
         g_probe.store(on, std::memory_order_relaxed);
@@ -713,7 +835,8 @@ void handle_command(const char* args) {
         log_status();
     } else {
         BVR_LOG("[aim] unknown command '%s' "
-                "(on|off|probe|dump|origin|seam|test|scan|scanoff|status)", verb);
+                "(on|off|probe|dump|origin|seam|test|scan|scanimpl|scanoff|status)",
+                verb);
     }
 }
 

--- a/src/game/bioshock1r/aim.cpp
+++ b/src/game/bioshock1r/aim.cpp
@@ -46,6 +46,13 @@ std::atomic<bool> g_probe{false};     // telemetry mode
 // (same rule as scenedraw's vrstereo checkbox): it posts a request here and the
 // game thread applies it from on_calcview, outside any hooked engine call.
 std::atomic<int> g_pendingEnable{-1}; // -1 none, 0 off, 1 on
+// Pose source + calibration. The runtime's AIM pose is the pointing ray and is
+// the default; the offsets are there because "where it points" is still a matter
+// of taste (grip angle, wrist posture) - the user's first in-headset run wanted
+// the ray a little lower than the raw pose gave.
+std::atomic<bool> g_useAimPose{true};
+std::atomic<float> g_pitchOffsetDeg{0.0f};
+std::atomic<float> g_yawOffsetDeg{0.0f};
 std::atomic<int32_t> g_dumpBudget{0}; // per-seam detailed log budget
 
 // Per-frame aim rays, game thread only (built in on_calcview, read in the
@@ -294,6 +301,16 @@ bool substitute(Slot& slot, Hand h, float* const* out, int count) {
     float dir[3];
     ue_rot_to_dir(r, dir);
     float pos[3] = {o.x, o.y, o.z};
+    bool useAim = g_useAimPose.load(std::memory_order_relaxed);
+    if (ImGui::Checkbox("Use the runtime AIM pose (off = grip pose)", &useAim))
+        g_useAimPose.store(useAim, std::memory_order_relaxed);
+    float pitchCal = g_pitchOffsetDeg.load(std::memory_order_relaxed);
+    if (ImGui::SliderFloat("Aim pitch trim (deg)", &pitchCal, -30.0f, 30.0f))
+        g_pitchOffsetDeg.store(pitchCal, std::memory_order_relaxed);
+    float yawCal = g_yawOffsetDeg.load(std::memory_order_relaxed);
+    if (ImGui::SliderFloat("Aim yaw trim (deg)", &yawCal, -30.0f, 30.0f))
+        g_yawOffsetDeg.store(yawCal, std::memory_order_relaxed);
+
     bool handOrigin = g_handOrigin.load(std::memory_order_relaxed);
 
     // An FRotator carries the engine's roll through untouched: aim owns pitch
@@ -674,6 +691,10 @@ std::atomic<bool>* sub_flag_by_name(const char* name) {
 }
 
 void log_status() {
+    BVR_LOG("[aim] pose=%s cal pitch%+.1f yaw%+.1f deg",
+            g_useAimPose.load(std::memory_order_relaxed) ? "aim" : "grip",
+            g_pitchOffsetDeg.load(std::memory_order_relaxed),
+            g_yawOffsetDeg.load(std::memory_order_relaxed));
     BVR_LOG("[aim] status: %s | seams weapon=%d ability=%d | handOrigin=%d probe=%d",
             g_enabled.load(std::memory_order_relaxed) ? "ON" : "off",
             g_subWeapon.load(std::memory_order_relaxed) ? 1 : 0,
@@ -765,12 +786,17 @@ void on_calcview(const FrameContext& ctx) {
         // 2) The real thing: the hand's grip pose, mapped through EXACTLY the
         //    transform the camera drive used this frame.
         bvr::vr::HeadPose hp{};
-        if (!ctx.vrDriving || !bvr::vr::get_hand_pose(i, hp)) continue;
+        bool useAim = g_useAimPose.load(std::memory_order_relaxed);
+        if (!ctx.vrDriving || !bvr::vr::get_hand_pose(i, useAim, hp)) continue;
 
         UeAngles a = ue_angles_from_xr_quat(hp.qx, hp.qy, hp.qz, hp.qw);
         out.rot.yaw = static_cast<int32_t>((gameYawRad + (a.yawRad - ctx.recenterYawRad)) *
-                                          kRotUnitsPerRadian);
-        out.rot.pitch = static_cast<int32_t>(a.pitchRad * kRotUnitsPerRadian);
+                                          kRotUnitsPerRadian) +
+                      static_cast<int32_t>(g_yawOffsetDeg.load(std::memory_order_relaxed) *
+                                           kRotUnitsPerDegree);
+        out.rot.pitch = static_cast<int32_t>(a.pitchRad * kRotUnitsPerRadian) +
+                        static_cast<int32_t>(g_pitchOffsetDeg.load(std::memory_order_relaxed) *
+                                             kRotUnitsPerDegree);
         out.rot.roll = 0; // aim carries no roll; the camera owns roll
 
         float dxr[3] = {hp.px - ctx.recenterPx, hp.py - ctx.recenterPy, hp.pz - ctx.recenterPz};
@@ -842,6 +868,19 @@ void handle_command(const char* args) {
             set_dump(n);
             BVR_LOG("[aim] dump budget %d per seam", n);
         }
+    } else if (strcmp(verb, "pose") == 0) {
+        bool aim = strncmp(rest, "aim", 3) == 0;
+        g_useAimPose.store(aim, std::memory_order_relaxed);
+        BVR_LOG("[aim] pose source = %s", aim ? "AIM (pointing ray)" : "GRIP (handle axis)");
+    } else if (strcmp(verb, "cal") == 0) {
+        float pitch = 0.0f, yaw = 0.0f;
+        if (sscanf_s(rest, "%f %f", &pitch, &yaw) >= 1) {
+            g_pitchOffsetDeg.store(pitch, std::memory_order_relaxed);
+            g_yawOffsetDeg.store(yaw, std::memory_order_relaxed);
+            BVR_LOG("[aim] calibration offset: pitch %+.1f yaw %+.1f deg", pitch, yaw);
+        } else {
+            BVR_LOG("[aim] usage: vraim cal <pitchDeg> [yawDeg]  (+pitch aims higher)");
+        }
     } else if (strcmp(verb, "origin") == 0) {
         bool on = strncmp(rest, "on", 2) == 0;
         g_handOrigin.store(on, std::memory_order_relaxed);
@@ -912,6 +951,16 @@ void draw_debug_ui() {
     bool on = g_enabled.load(std::memory_order_relaxed);
     if (ImGui::Checkbox("Controller aim (right = weapon, left = plasmid)", &on))
         g_pendingEnable.store(on ? 1 : 0, std::memory_order_relaxed);
+    bool useAim = g_useAimPose.load(std::memory_order_relaxed);
+    if (ImGui::Checkbox("Use the runtime AIM pose (off = grip pose)", &useAim))
+        g_useAimPose.store(useAim, std::memory_order_relaxed);
+    float pitchCal = g_pitchOffsetDeg.load(std::memory_order_relaxed);
+    if (ImGui::SliderFloat("Aim pitch trim (deg)", &pitchCal, -30.0f, 30.0f))
+        g_pitchOffsetDeg.store(pitchCal, std::memory_order_relaxed);
+    float yawCal = g_yawOffsetDeg.load(std::memory_order_relaxed);
+    if (ImGui::SliderFloat("Aim yaw trim (deg)", &yawCal, -30.0f, 30.0f))
+        g_yawOffsetDeg.store(yawCal, std::memory_order_relaxed);
+
     bool handOrigin = g_handOrigin.load(std::memory_order_relaxed);
     if (ImGui::Checkbox("Ray starts at the hand (off = engine origin, direction only)",
                         &handOrigin))

--- a/src/game/bioshock1r/aim.cpp
+++ b/src/game/bioshock1r/aim.cpp
@@ -1,0 +1,741 @@
+// M6 decoupled aim. Hook behavior (call the original, then adjust the writable
+// out-param) follows the same shape as the CalcView camera hook, i.e.
+// itsloopyo/bioshock-remastered-headtracking (MIT), src/engine_hook.rs.
+//
+// Seams, all UnrealScript native thunks resolved through the engine's own
+// native lookup table (no hardcoded addresses - see patterns.cpp):
+//   AWeapon::execGetPerfectFireStart  result FVector  = trace origin
+//   AWeapon::execApplyAimError        result vec/rot  = trace direction
+//   APawn::execGetViewPoint           result FVector  = eye position
+//   APawn::execGetViewDirection       result FVector  = view direction
+//   AActor::execTrace                 read-only telemetry (hit point)
+// ENGINE_NOTES "Fire flow / aim" carries the derivation and the live findings.
+
+#include "game/bioshock1r/aim.h"
+
+#include "core/input/xinput_bridge.h"
+#include "core/util/log.h"
+#include "core/vr/openxr_runtime.h"
+#include "game/bioshock1r/ue_math.h"
+
+#include <windows.h>
+#include <MinHook.h>
+
+#include <imgui.h>
+
+#include <atomic>
+#include <cstdio>
+#include <cstring>
+
+namespace bvr::b1r::aim {
+namespace {
+
+// ---- state -----------------------------------------------------------------
+
+const uint8_t* g_imageBase = nullptr;
+
+// Master switch + per-seam substitution switches. The seam set is command
+// controlled because which native actually decides a shot is a live question
+// per weapon type (see the probe): flipping these needs no rebuild.
+std::atomic<bool> g_enabled{false};
+std::atomic<bool> g_subFireStart{true};
+std::atomic<bool> g_subAimError{true};
+std::atomic<bool> g_subViewPoint{false};
+std::atomic<bool> g_subViewDir{true};
+std::atomic<bool> g_handOrigin{true};   // hand origin + direction (user's choice)
+std::atomic<bool> g_probe{false};       // telemetry mode
+std::atomic<int32_t> g_dumpBudget{0};   // per-seam detailed log budget
+
+// Per-frame aim rays, game thread only (built in on_calcview, read in the
+// detours - all on the game thread, so no locking).
+struct Ray {
+    bool valid = false;
+    bool synthetic = false; // came from a `vraim test` slot
+    FVector origin{};
+    FRotator rot{};
+};
+Ray g_ray[2]; // 0 = left (plasmid), 1 = right (weapon)
+uint64_t g_rayStampMs = 0;
+bool g_gameplayView = false;
+
+// Self-expiring synthetic aim, mirroring the xinput_bridge test slots: the
+// command file is polled at 1 Hz, so a hold has to outlive its command inside
+// the DLL. Yaw/pitch are OFFSETS from the current view rotation, which is what
+// makes "aim 30 degrees right of where the camera looks" directly assertable.
+struct TestAim {
+    float yawDeg = 0.0f, pitchDeg = 0.0f;
+    uint64_t deadline = 0;
+};
+TestAim g_test[2];
+
+// Object -> hand mapping. BioShock dual-wields: the gun and the plasmid are
+// two live weapon objects, and the natives are called on whichever is firing.
+// Seed the map from the trigger the bridge itself is holding (we compose that
+// state, so we know), then it is pure pointer identity - and it re-learns for
+// free when the player switches weapon or plasmid.
+void* g_objRight = nullptr;
+void* g_objLeft = nullptr;
+std::atomic<uint32_t> g_learnEvents{0};
+
+struct Slot {
+    const char* name;
+    void* target = nullptr;
+    void* original = nullptr;
+    bool created = false;
+    std::atomic<bool> enabled{false};
+    std::atomic<uint32_t> calls{0};
+    std::atomic<uint32_t> subs{0};
+    std::atomic<uint32_t> skips{0}; // ran, but not ours to touch (AI, no ray)
+    int32_t dumpLeft = 0;
+    int resultType = 0; // ResultType, learned from the engine's own values
+};
+Slot g_fireStart{"firestart"};
+Slot g_aimError{"aimerror"};
+Slot g_viewPoint{"viewpoint"};
+Slot g_viewDir{"viewdir"};
+Slot g_trace{"trace"};
+
+// Last substituted values, for the overlay + the flat-test assertions.
+std::atomic<float> g_lastSubX{0.0f}, g_lastSubY{0.0f}, g_lastSubZ{0.0f};
+std::atomic<int32_t> g_lastSubYaw{0}, g_lastSubPitch{0};
+std::atomic<uint32_t> g_lastSubHand{0};
+
+using ExecFn = void(__fastcall*)(void* self, void* edx, void* stack, void* result);
+
+uint32_t to_rva(const void* p) {
+    if (!p || !g_imageBase) return 0;
+    return static_cast<uint32_t>(static_cast<const uint8_t*>(p) - g_imageBase);
+}
+
+// ---- guarded memory helpers (no C++ objects in an SEH frame) ---------------
+
+bool read12(const void* src, float* out3) {
+    __try {
+        memcpy(out3, src, 12);
+        return true;
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        return false;
+    }
+}
+
+bool write12(void* dst, const float* in3) {
+    __try {
+        memcpy(dst, in3, 12);
+        return true;
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        return false;
+    }
+}
+
+bool read_ptr(const void* src, void** out) {
+    __try {
+        *out = *static_cast<void* const*>(src);
+        return true;
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        return false;
+    }
+}
+
+// ---- ownership gates -------------------------------------------------------
+// AI weapons inherit AWeapon and AI pawns inherit APawn, so these natives run
+// for the whole level - substituting blindly would aim every splicer's gun with
+// the player's controller. Class identity comes from the vtable (RTTI-derived
+// RVAs in patterns.h).
+
+bool has_vtable(void* obj, uint32_t wantRva) {
+    if (!obj) return false;
+    void* vtbl = nullptr;
+    if (!read_ptr(obj, &vtbl)) return false;
+    return to_rva(vtbl) == wantRva;
+}
+
+bool is_player_weapon(void* obj) {
+    return has_vtable(obj, patterns::kPlayerWeaponVtableRva);
+}
+
+bool is_player_pawn(void* obj) {
+    return has_vtable(obj, patterns::kShockPlayerVtableRva);
+}
+
+// ---- hand selection --------------------------------------------------------
+
+bool trigger_held(bool right) {
+    uint8_t lt = 0, rt = 0;
+    bvr::input::last_composed_triggers(&lt, &rt);
+    return (right ? rt : lt) >= 64; // ~25% pull, same ballpark as the game's own
+}
+
+Hand hand_for_object(void* obj) {
+    if (obj && obj == g_objRight) return Hand::Right;
+    if (obj && obj == g_objLeft) return Hand::Left;
+
+    bool r = trigger_held(true), l = trigger_held(false);
+    if (obj && is_player_weapon(obj)) {
+        // Exactly one trigger -> that hand owns this object. Both triggers with
+        // one slot already known -> the other hand owns it by elimination.
+        bool takeRight = false, takeLeft = false;
+        if (r && !l) takeRight = true;
+        else if (l && !r) takeLeft = true;
+        else if (r && l) { takeRight = (g_objRight == nullptr && g_objLeft != nullptr);
+                           takeLeft = (g_objLeft == nullptr && g_objRight != nullptr); }
+        if (takeRight) {
+            g_objRight = obj;
+            if (g_objLeft == obj) g_objLeft = nullptr;
+            g_learnEvents.fetch_add(1, std::memory_order_relaxed);
+            BVR_LOG("[aim] learned RIGHT-hand (weapon) object %p", obj);
+            return Hand::Right;
+        }
+        if (takeLeft) {
+            g_objLeft = obj;
+            if (g_objRight == obj) g_objRight = nullptr;
+            g_learnEvents.fetch_add(1, std::memory_order_relaxed);
+            BVR_LOG("[aim] learned LEFT-hand (plasmid) object %p", obj);
+            return Hand::Left;
+        }
+    }
+    // Unknown and no usable trigger evidence: the right hand is the weapon
+    // hand, which is the safer default for a stray query.
+    return Hand::Right;
+}
+
+// ---- the ray ---------------------------------------------------------------
+
+bool ray_for(Hand h, FVector* origin, FRotator* rot) {
+    if (!g_enabled.load(std::memory_order_relaxed)) return false;
+    if (!g_gameplayView) return false; // scripted camera: leave the engine alone
+    const Ray& r = g_ray[static_cast<int>(h)];
+    if (!r.valid) return false;
+    // A ray older than a few frames means CalcView stopped running (load
+    // screen, teardown) - never aim from a stale pose.
+    if (GetTickCount64() - g_rayStampMs > 250) return false;
+    if (origin) *origin = r.origin;
+    if (rot) *rot = r.rot;
+    return true;
+}
+
+void note_substitution(Hand h, const FVector& o, const FRotator& r) {
+    g_lastSubX.store(o.x, std::memory_order_relaxed);
+    g_lastSubY.store(o.y, std::memory_order_relaxed);
+    g_lastSubZ.store(o.z, std::memory_order_relaxed);
+    g_lastSubYaw.store(r.yaw, std::memory_order_relaxed);
+    g_lastSubPitch.store(r.pitch, std::memory_order_relaxed);
+    g_lastSubHand.store(h == Hand::Right ? 1u : 0u, std::memory_order_relaxed);
+}
+
+// A 12-byte engine "direction" result is either an FVector (unit-ish floats)
+// or an FRotator (65536-per-turn int32s), and which one depends on the script
+// signature we never see. Classify from what the ORIGINAL produced: rotator
+// components are small integers, whose float reinterpretation is a denormal,
+// while float components are ordinary floats whose int reinterpretation is
+// enormous. All-zero is ambiguous, so the verdict is cached per seam from the
+// first confident call and only then does that seam substitute.
+enum ResultType { kUnknown = 0, kVector = 1, kRotator = 2 };
+
+ResultType classify(const float raw[3]) {
+    int32_t v[3];
+    memcpy(v, raw, sizeof v);
+    bool allZero = (v[0] == 0 && v[1] == 0 && v[2] == 0);
+    if (allZero) return kUnknown;
+    for (int i = 0; i < 3; ++i) {
+        int32_t a = v[i] < 0 ? -v[i] : v[i];
+        if (a > (1 << 21)) return kVector; // 2 million rotation units is nonsense
+    }
+    return kRotator;
+}
+
+void write_direction(void* result, const FRotator& rot, ResultType type, int32_t rollIn) {
+    if (type == kRotator) {
+        int32_t v[3] = {rot.pitch, rot.yaw, rollIn};
+        float packed[3];
+        memcpy(packed, v, sizeof packed);
+        write12(result, packed);
+        return;
+    }
+    float dir[3];
+    ue_rot_to_dir(rot, dir);
+    write12(result, dir);
+}
+
+// ---- detours ---------------------------------------------------------------
+// Every thunk is `void __thiscall execFoo(FFrame& Stack, void* Result)`, which
+// is register/stack-identical to __fastcall with a dummy EDX slot.
+
+void log_call(Slot& slot, void* self, void* stack, const float raw[3], const char* note) {
+    if (slot.dumpLeft <= 0) return;
+    --slot.dumpLeft;
+    void* obj = nullptr;
+    void* node = nullptr;
+    if (stack) {
+        read_ptr(static_cast<const uint8_t*>(stack) + patterns::kFFrameObjectOffset, &obj);
+        read_ptr(static_cast<const uint8_t*>(stack) + patterns::kFFrameNodeOffset, &node);
+    }
+    int32_t asInt[3];
+    memcpy(asInt, raw, sizeof asInt);
+    BVR_LOG("[aim] %s this=%p vtbl=0x%X obj=%p node=%p result f=(%.2f %.2f %.2f) "
+            "i=(%d %d %d) %s",
+            slot.name, self, self ? to_rva(*static_cast<void**>(self)) : 0, obj, node,
+            raw[0], raw[1], raw[2], asInt[0], asInt[1], asInt[2], note);
+}
+
+// Learn (and remember) what type this seam's 12-byte result is.
+ResultType learn_type(Slot& slot, const float raw[3]) {
+    ResultType t = classify(raw);
+    if (t != kUnknown && slot.resultType == kUnknown) {
+        slot.resultType = t;
+        BVR_LOG("[aim] %s result type = %s", slot.name, t == kRotator ? "FRotator" : "FVector");
+    }
+    return static_cast<ResultType>(slot.resultType);
+}
+
+void __fastcall FireStartDetour(void* self, void* edx, void* stack, void* result) {
+    reinterpret_cast<ExecFn>(g_fireStart.original)(self, edx, stack, result);
+    g_fireStart.calls.fetch_add(1, std::memory_order_relaxed);
+
+    float raw[3] = {0, 0, 0};
+    if (!read12(result, raw)) return;
+
+    const char* note = "";
+    if (g_subFireStart.load(std::memory_order_relaxed) &&
+        g_handOrigin.load(std::memory_order_relaxed) && is_player_weapon(self)) {
+        Hand h = hand_for_object(self);
+        FVector o{};
+        FRotator r{};
+        if (ray_for(h, &o, &r)) {
+            float v[3] = {o.x, o.y, o.z};
+            if (write12(result, v)) {
+                g_fireStart.subs.fetch_add(1, std::memory_order_relaxed);
+                note = (h == Hand::Right) ? "SUB(R)" : "SUB(L)";
+                note_substitution(h, o, r);
+            }
+        } else {
+            g_fireStart.skips.fetch_add(1, std::memory_order_relaxed);
+        }
+    }
+    log_call(g_fireStart, self, stack, raw, note);
+}
+
+void __fastcall AimErrorDetour(void* self, void* edx, void* stack, void* result) {
+    reinterpret_cast<ExecFn>(g_aimError.original)(self, edx, stack, result);
+    g_aimError.calls.fetch_add(1, std::memory_order_relaxed);
+
+    float raw[3] = {0, 0, 0};
+    if (!read12(result, raw)) return;
+    ResultType type = learn_type(g_aimError, raw);
+
+    const char* note = "";
+    if (g_subAimError.load(std::memory_order_relaxed) && type != kUnknown &&
+        is_player_weapon(self)) {
+        Hand h = hand_for_object(self);
+        FVector o{};
+        FRotator r{};
+        if (ray_for(h, &o, &r)) {
+            int32_t rollIn = 0;
+            if (type == kRotator) {
+                int32_t asInt[3];
+                memcpy(asInt, raw, sizeof asInt);
+                rollIn = asInt[2]; // keep the engine's roll
+            }
+            write_direction(result, r, type, rollIn);
+            g_aimError.subs.fetch_add(1, std::memory_order_relaxed);
+            note = (h == Hand::Right) ? "SUB(R)" : "SUB(L)";
+            note_substitution(h, o, r);
+        } else {
+            g_aimError.skips.fetch_add(1, std::memory_order_relaxed);
+        }
+    }
+    log_call(g_aimError, self, stack, raw, note);
+}
+
+void __fastcall ViewPointDetour(void* self, void* edx, void* stack, void* result) {
+    reinterpret_cast<ExecFn>(g_viewPoint.original)(self, edx, stack, result);
+    g_viewPoint.calls.fetch_add(1, std::memory_order_relaxed);
+
+    float raw[3] = {0, 0, 0};
+    if (!read12(result, raw)) return;
+
+    const char* note = "";
+    if (g_subViewPoint.load(std::memory_order_relaxed) &&
+        g_handOrigin.load(std::memory_order_relaxed) && is_player_pawn(self)) {
+        // The pawn's view point has no weapon object to key on; the hand that
+        // is actually firing owns it (right hand when both or neither).
+        Hand h = trigger_held(false) && !trigger_held(true) ? Hand::Left : Hand::Right;
+        FVector o{};
+        if (ray_for(h, &o, nullptr)) {
+            float v[3] = {o.x, o.y, o.z};
+            if (write12(result, v)) {
+                g_viewPoint.subs.fetch_add(1, std::memory_order_relaxed);
+                note = "SUB";
+            }
+        } else {
+            g_viewPoint.skips.fetch_add(1, std::memory_order_relaxed);
+        }
+    }
+    log_call(g_viewPoint, self, stack, raw, note);
+}
+
+void __fastcall ViewDirDetour(void* self, void* edx, void* stack, void* result) {
+    reinterpret_cast<ExecFn>(g_viewDir.original)(self, edx, stack, result);
+    g_viewDir.calls.fetch_add(1, std::memory_order_relaxed);
+
+    float raw[3] = {0, 0, 0};
+    if (!read12(result, raw)) return;
+    ResultType type = learn_type(g_viewDir, raw);
+
+    const char* note = "";
+    if (g_subViewDir.load(std::memory_order_relaxed) && type != kUnknown &&
+        is_player_pawn(self)) {
+        Hand h = trigger_held(false) && !trigger_held(true) ? Hand::Left : Hand::Right;
+        FVector o{};
+        FRotator r{};
+        if (ray_for(h, &o, &r)) {
+            write_direction(result, r, type, 0);
+            g_viewDir.subs.fetch_add(1, std::memory_order_relaxed);
+            note = (h == Hand::Right) ? "SUB(R)" : "SUB(L)";
+            note_substitution(h, o, r);
+        } else {
+            g_viewDir.skips.fetch_add(1, std::memory_order_relaxed);
+        }
+    }
+    log_call(g_viewDir, self, stack, raw, note);
+}
+
+// Read-only: AActor::Trace is the hitscan primitive, so its result IS the
+// impact point - the objective number the flat verification asserts on. Hot
+// path (AI line-of-sight uses it too), so it only ever logs from a dump budget.
+void __fastcall TraceDetour(void* self, void* edx, void* stack, void* result) {
+    reinterpret_cast<ExecFn>(g_trace.original)(self, edx, stack, result);
+    g_trace.calls.fetch_add(1, std::memory_order_relaxed);
+    if (g_trace.dumpLeft <= 0) return;
+    float raw[3] = {0, 0, 0};
+    if (!read12(result, raw)) return;
+    log_call(g_trace, self, stack, raw, "hitactor");
+}
+
+// ---- hook lifecycle --------------------------------------------------------
+
+bool install_slot(Slot& slot, void* target, void* detour) {
+    if (!target) {
+        BVR_LOG("[aim] %s: native not resolved - seam unavailable", slot.name);
+        return false;
+    }
+    if (slot.enabled.load(std::memory_order_relaxed)) return true;
+    slot.target = target;
+    if (!slot.created) {
+        MH_STATUS st = MH_CreateHook(target, detour, &slot.original);
+        if (st != MH_OK) {
+            BVR_LOG("[aim] MH_CreateHook(%s) failed: %s", slot.name, MH_StatusToString(st));
+            return false;
+        }
+        slot.created = true;
+    }
+    MH_STATUS st = MH_EnableHook(target);
+    if (st != MH_OK) {
+        BVR_LOG("[aim] MH_EnableHook(%s) failed: %s", slot.name, MH_StatusToString(st));
+        return false;
+    }
+    slot.enabled.store(true, std::memory_order_relaxed);
+    BVR_LOG("[aim] %s hook ENABLED (target %p, rva 0x%X)", slot.name, target, to_rva(target));
+    return true;
+}
+
+void disable_slot(Slot& slot) {
+    if (!slot.enabled.load(std::memory_order_relaxed)) return;
+    // Disable, never remove: a thread could still be returning through the
+    // trampoline (same rule as scenedraw).
+    MH_STATUS st = MH_DisableHook(slot.target);
+    slot.enabled.store(false, std::memory_order_relaxed);
+    BVR_LOG("[aim] %s hook disabled (%s)", slot.name, MH_StatusToString(st));
+}
+
+patterns::Symbols g_syms{};
+
+bool install_all() {
+    bool any = false;
+    any |= install_slot(g_fireStart, g_syms.execWeaponFireStart,
+                        reinterpret_cast<void*>(&FireStartDetour));
+    any |= install_slot(g_aimError, g_syms.execWeaponAimError,
+                        reinterpret_cast<void*>(&AimErrorDetour));
+    any |= install_slot(g_viewPoint, g_syms.execPawnViewPoint,
+                        reinterpret_cast<void*>(&ViewPointDetour));
+    any |= install_slot(g_viewDir, g_syms.execPawnViewDir,
+                        reinterpret_cast<void*>(&ViewDirDetour));
+    any |= install_slot(g_trace, g_syms.execActorTrace,
+                        reinterpret_cast<void*>(&TraceDetour));
+    return any;
+}
+
+void disable_all() {
+    disable_slot(g_fireStart);
+    disable_slot(g_aimError);
+    disable_slot(g_viewPoint);
+    disable_slot(g_viewDir);
+    disable_slot(g_trace);
+}
+
+void set_dump(int32_t n) {
+    g_dumpBudget.store(n, std::memory_order_relaxed);
+    g_fireStart.dumpLeft = n;
+    g_aimError.dumpLeft = n;
+    g_viewPoint.dumpLeft = n;
+    g_viewDir.dumpLeft = n;
+    g_trace.dumpLeft = n;
+}
+
+Slot* slot_by_name(const char* name) {
+    if (strcmp(name, "firestart") == 0) return &g_fireStart;
+    if (strcmp(name, "aimerror") == 0) return &g_aimError;
+    if (strcmp(name, "viewpoint") == 0) return &g_viewPoint;
+    if (strcmp(name, "viewdir") == 0) return &g_viewDir;
+    if (strcmp(name, "trace") == 0) return &g_trace;
+    return nullptr;
+}
+
+std::atomic<bool>* sub_flag_by_name(const char* name) {
+    if (strcmp(name, "firestart") == 0) return &g_subFireStart;
+    if (strcmp(name, "aimerror") == 0) return &g_subAimError;
+    if (strcmp(name, "viewpoint") == 0) return &g_subViewPoint;
+    if (strcmp(name, "viewdir") == 0) return &g_subViewDir;
+    return nullptr;
+}
+
+void log_status() {
+    BVR_LOG("[aim] status: %s | seams fs=%d ae=%d vp=%d vd=%d | handOrigin=%d probe=%d",
+            g_enabled.load(std::memory_order_relaxed) ? "ON" : "off",
+            g_subFireStart.load(std::memory_order_relaxed),
+            g_subAimError.load(std::memory_order_relaxed),
+            g_subViewPoint.load(std::memory_order_relaxed),
+            g_subViewDir.load(std::memory_order_relaxed),
+            g_handOrigin.load(std::memory_order_relaxed) ? 1 : 0,
+            g_probe.load(std::memory_order_relaxed) ? 1 : 0);
+    Slot* all[] = {&g_fireStart, &g_aimError, &g_viewPoint, &g_viewDir, &g_trace};
+    for (Slot* s : all) {
+        BVR_LOG("[aim]   %-9s hook=%s calls=%u subs=%u skips=%u type=%s", s->name,
+                s->enabled.load(std::memory_order_relaxed) ? "on " : "off",
+                s->calls.load(std::memory_order_relaxed),
+                s->subs.load(std::memory_order_relaxed),
+                s->skips.load(std::memory_order_relaxed),
+                s->resultType == kRotator ? "rot" : s->resultType == kVector ? "vec" : "?");
+    }
+    uint64_t now = GetTickCount64();
+    for (int i = 0; i < 2; ++i) {
+        const Ray& r = g_ray[i];
+        BVR_LOG("[aim]   ray %s valid=%d synth=%d origin=(%.1f %.1f %.1f) rot=(%d %d) "
+                "testHold=%dms", i ? "R" : "L", r.valid ? 1 : 0, r.synthetic ? 1 : 0,
+                r.origin.x, r.origin.y, r.origin.z, r.rot.pitch, r.rot.yaw,
+                g_test[i].deadline > now ? static_cast<int>(g_test[i].deadline - now) : 0);
+    }
+    BVR_LOG("[aim]   objects: right=%p left=%p (learn events %u), gameplayView=%d",
+            g_objRight, g_objLeft, g_learnEvents.load(std::memory_order_relaxed),
+            g_gameplayView ? 1 : 0);
+}
+
+} // namespace
+
+void init(const bvr::pattern_scan::ProcessImage& image, const patterns::Symbols& symbols) {
+    g_imageBase = image.base;
+    g_syms = symbols;
+    BVR_LOG("[aim] init: firestart=%p aimerror=%p viewpoint=%p viewdir=%p trace=%p",
+            g_syms.execWeaponFireStart, g_syms.execWeaponAimError, g_syms.execPawnViewPoint,
+            g_syms.execPawnViewDir, g_syms.execActorTrace);
+}
+
+void on_calcview(const FrameContext& ctx) {
+    uint64_t now = GetTickCount64();
+    g_rayStampMs = now;
+
+    // Cutscene guard (the open M3 item): the view actor during normal play is
+    // the player's own pawn - an AShockPlayer. A scripted camera swaps the
+    // view target for some other actor, and then nothing about the player's
+    // aim should be touched.
+    g_gameplayView = false;
+    if (ctx.viewActor) {
+        void* vtbl = nullptr;
+        if (read_ptr(ctx.viewActor, &vtbl))
+            g_gameplayView = (to_rva(vtbl) == patterns::kShockPlayerVtableRva);
+        if (!g_gameplayView && ctx.viewActor == ctx.pc)
+            g_gameplayView = true; // menu attract scene views through the PC itself
+    }
+
+    float gameYawRad = static_cast<float>(ctx.camYaw) / kRotUnitsPerRadian - ctx.driveYawOffsetRad;
+
+    for (int i = 0; i < 2; ++i) {
+        Ray& out = g_ray[i];
+        out = {};
+
+        // 1) Synthetic injection wins (this is the no-headset test lane).
+        if (now < g_test[i].deadline) {
+            out.valid = true;
+            out.synthetic = true;
+            out.origin = {ctx.camX, ctx.camY, ctx.camZ};
+            out.rot.yaw = ctx.camYaw +
+                          static_cast<int32_t>(g_test[i].yawDeg * kRotUnitsPerDegree);
+            out.rot.pitch = ctx.camPitch +
+                            static_cast<int32_t>(g_test[i].pitchDeg * kRotUnitsPerDegree);
+            out.rot.roll = 0;
+            continue;
+        }
+
+        // 2) The real thing: the hand's grip pose, mapped through EXACTLY the
+        //    transform the camera drive used this frame.
+        bvr::vr::HeadPose hp{};
+        if (!ctx.vrDriving || !bvr::vr::get_hand_pose(i, hp)) continue;
+
+        UeAngles a = ue_angles_from_xr_quat(hp.qx, hp.qy, hp.qz, hp.qw);
+        out.rot.yaw = static_cast<int32_t>((gameYawRad + (a.yawRad - ctx.recenterYawRad)) *
+                                          kRotUnitsPerRadian);
+        out.rot.pitch = static_cast<int32_t>(a.pitchRad * kRotUnitsPerRadian);
+        out.rot.roll = 0; // aim carries no roll; the camera owns roll
+
+        float dxr[3] = {hp.px - ctx.recenterPx, hp.py - ctx.recenterPy, hp.pz - ctx.recenterPz};
+        float d[3];
+        xr_to_ue(dxr, d);
+        float c = cosf(-ctx.recenterYawRad), s = sinf(-ctx.recenterYawRad);
+        float lx = d[0] * c - d[1] * s;
+        float ly = d[0] * s + d[1] * c;
+        float cg = cosf(gameYawRad), sg = sinf(gameYawRad);
+        out.origin.x = ctx.baseX + (lx * cg - ly * sg) * ctx.worldScale;
+        out.origin.y = ctx.baseY + (lx * sg + ly * cg) * ctx.worldScale;
+        out.origin.z = ctx.baseZ + d[2] * ctx.worldScale;
+        out.valid = true;
+    }
+}
+
+void handle_command(const char* args) {
+    char verb[16] = {};
+    int consumed = 0;
+    if (sscanf_s(args, "%15s%n", verb, static_cast<unsigned>(sizeof verb), &consumed) != 1) {
+        log_status();
+        return;
+    }
+    const char* rest = args + consumed;
+    while (*rest == ' ' || *rest == '\t') ++rest;
+
+    if (strcmp(verb, "on") == 0) {
+        if (!install_all()) {
+            BVR_LOG("[aim] on REFUSED: no aim seam hooked (natives unresolved?)");
+            return;
+        }
+        g_enabled.store(true, std::memory_order_relaxed);
+        BVR_LOG("[aim] ON - controller aim substitutes the view aim");
+        log_status();
+    } else if (strcmp(verb, "off") == 0) {
+        g_enabled.store(false, std::memory_order_relaxed);
+        if (!g_probe.load(std::memory_order_relaxed)) disable_all();
+        BVR_LOG("[aim] OFF - engine aim restored");
+    } else if (strcmp(verb, "probe") == 0) {
+        bool on = strncmp(rest, "on", 2) == 0;
+        g_probe.store(on, std::memory_order_relaxed);
+        if (on) {
+            install_all();
+            if (g_dumpBudget.load(std::memory_order_relaxed) <= 0) set_dump(24);
+            BVR_LOG("[aim] probe ON (telemetry only; `vraim dump <n>` for more lines)");
+        } else {
+            if (!g_enabled.load(std::memory_order_relaxed)) disable_all();
+            BVR_LOG("[aim] probe off");
+        }
+    } else if (strcmp(verb, "dump") == 0) {
+        int n = 0;
+        if (sscanf_s(rest, "%d", &n) == 1 && n >= 0) {
+            set_dump(n);
+            BVR_LOG("[aim] dump budget %d per seam", n);
+        }
+    } else if (strcmp(verb, "origin") == 0) {
+        bool on = strncmp(rest, "on", 2) == 0;
+        g_handOrigin.store(on, std::memory_order_relaxed);
+        BVR_LOG("[aim] hand origin %s (off = engine's own origin, direction only)",
+                on ? "ON" : "off");
+    } else if (strcmp(verb, "seam") == 0) {
+        char name[16] = {};
+        char state[8] = {};
+        if (sscanf_s(rest, "%15s %7s", name, static_cast<unsigned>(sizeof name), state,
+                     static_cast<unsigned>(sizeof state)) == 2) {
+            std::atomic<bool>* flag = sub_flag_by_name(name);
+            if (!flag) {
+                BVR_LOG("[aim] unknown seam '%s'", name);
+                return;
+            }
+            bool on = strncmp(state, "on", 2) == 0;
+            flag->store(on, std::memory_order_relaxed);
+            BVR_LOG("[aim] seam %s substitution %s", name, on ? "ON" : "off");
+        }
+    } else if (strcmp(verb, "test") == 0) {
+        char what[8] = {};
+        int c2 = 0;
+        if (sscanf_s(rest, "%7s%n", what, static_cast<unsigned>(sizeof what), &c2) != 1) return;
+        const char* p = rest + c2;
+        if (strcmp(what, "clear") == 0) {
+            g_test[0] = {};
+            g_test[1] = {};
+            BVR_LOG("[aim] test aim cleared");
+            return;
+        }
+        // "test l|r <yaw> <pitch> [holdMs]"
+        float yaw = 0.0f, pitch = 0.0f;
+        int hold = 0;
+        int n = sscanf_s(p, "%f %f %d", &yaw, &pitch, &hold);
+        if (n < 2) {
+            BVR_LOG("[aim] usage: vraim test l|r <yawDeg> <pitchDeg> [holdMs]");
+            return;
+        }
+        int idx = (what[0] == 'r' || what[0] == 'R') ? 1 : 0;
+        if (hold <= 0) hold = 3000;
+        if (hold > 60000) hold = 60000;
+        g_test[idx].yawDeg = yaw;
+        g_test[idx].pitchDeg = pitch;
+        g_test[idx].deadline = GetTickCount64() + static_cast<uint64_t>(hold);
+        BVR_LOG("[aim] test aim %s: yaw %+.1f pitch %+.1f for %d ms", idx ? "RIGHT" : "LEFT",
+                yaw, pitch, hold);
+    } else if (strcmp(verb, "status") == 0) {
+        log_status();
+    } else {
+        BVR_LOG("[aim] unknown command '%s' (on|off|probe|dump|origin|seam|test|status)", verb);
+    }
+}
+
+bool hook_live() {
+    return g_fireStart.enabled.load(std::memory_order_relaxed) ||
+           g_aimError.enabled.load(std::memory_order_relaxed) ||
+           g_viewPoint.enabled.load(std::memory_order_relaxed) ||
+           g_viewDir.enabled.load(std::memory_order_relaxed);
+}
+
+bool active() {
+    return g_enabled.load(std::memory_order_relaxed) && hook_live();
+}
+
+void draw_debug_ui() {
+    if (!ImGui::CollapsingHeader("Decoupled aim (M6)", ImGuiTreeNodeFlags_DefaultOpen)) return;
+
+    bool on = g_enabled.load(std::memory_order_relaxed);
+    if (ImGui::Checkbox("Controller aim (right = weapon, left = plasmid)", &on)) {
+        if (on) {
+            if (install_all()) g_enabled.store(true, std::memory_order_relaxed);
+        } else {
+            g_enabled.store(false, std::memory_order_relaxed);
+            if (!g_probe.load(std::memory_order_relaxed)) disable_all();
+        }
+    }
+    bool handOrigin = g_handOrigin.load(std::memory_order_relaxed);
+    if (ImGui::Checkbox("Ray starts at the hand (off = engine origin, direction only)",
+                        &handOrigin))
+        g_handOrigin.store(handOrigin, std::memory_order_relaxed);
+
+    ImGui::Text("seam calls: fs %u/%u  ae %u/%u  vp %u/%u  vd %u/%u  (subs/calls)",
+                g_fireStart.subs.load(std::memory_order_relaxed),
+                g_fireStart.calls.load(std::memory_order_relaxed),
+                g_aimError.subs.load(std::memory_order_relaxed),
+                g_aimError.calls.load(std::memory_order_relaxed),
+                g_viewPoint.subs.load(std::memory_order_relaxed),
+                g_viewPoint.calls.load(std::memory_order_relaxed),
+                g_viewDir.subs.load(std::memory_order_relaxed),
+                g_viewDir.calls.load(std::memory_order_relaxed));
+    ImGui::Text("last sub: %s origin (%.0f %.0f %.0f) yaw %d pitch %d",
+                g_lastSubHand.load(std::memory_order_relaxed) ? "RIGHT" : "LEFT",
+                g_lastSubX.load(std::memory_order_relaxed),
+                g_lastSubY.load(std::memory_order_relaxed),
+                g_lastSubZ.load(std::memory_order_relaxed),
+                g_lastSubYaw.load(std::memory_order_relaxed),
+                g_lastSubPitch.load(std::memory_order_relaxed));
+}
+
+} // namespace bvr::b1r::aim

--- a/src/game/bioshock1r/aim.cpp
+++ b/src/game/bioshock1r/aim.cpp
@@ -38,13 +38,11 @@ const uint8_t* g_imageBase = nullptr;
 // controlled because which native actually decides a shot is a live question
 // per weapon type (see the probe): flipping these needs no rebuild.
 std::atomic<bool> g_enabled{false};
-std::atomic<bool> g_subFireStart{true};
-std::atomic<bool> g_subAimError{true};
-std::atomic<bool> g_subViewPoint{false};
-std::atomic<bool> g_subViewDir{true};
-std::atomic<bool> g_handOrigin{true};   // hand origin + direction (user's choice)
-std::atomic<bool> g_probe{false};       // telemetry mode
-std::atomic<int32_t> g_dumpBudget{0};   // per-seam detailed log budget
+std::atomic<bool> g_subWeapon{true};  // right hand aims weapons
+std::atomic<bool> g_subAbility{true}; // left hand aims plasmids
+std::atomic<bool> g_handOrigin{true}; // hand origin + direction (user's choice)
+std::atomic<bool> g_probe{false};     // telemetry mode
+std::atomic<int32_t> g_dumpBudget{0}; // per-seam detailed log budget
 
 // Per-frame aim rays, game thread only (built in on_calcview, read in the
 // detours - all on the game thread, so no locking).
@@ -87,13 +85,9 @@ struct Slot {
     std::atomic<uint32_t> subs{0};
     std::atomic<uint32_t> skips{0}; // ran, but not ours to touch (AI, no ray)
     int32_t dumpLeft = 0;
-    int resultType = 0; // ResultType, learned from the engine's own values
 };
-Slot g_fireStart{"firestart"};
-Slot g_aimError{"aimerror"};
-Slot g_viewPoint{"viewpoint"};
-Slot g_viewDir{"viewdir"};
-Slot g_trace{"trace"};
+Slot g_weaponFire{"weapon"};  // AWeapon::GetPerfectFireStart impl
+Slot g_abilityFire{"ability"}; // UAttackAbility::GetPerfectFireStart impl
 
 // Last substituted values, for the overlay + the flat-test assertions.
 std::atomic<float> g_lastSubX{0.0f}, g_lastSubY{0.0f}, g_lastSubZ{0.0f};
@@ -149,12 +143,19 @@ bool has_vtable(void* obj, uint32_t wantRva) {
     return to_rva(vtbl) == wantRva;
 }
 
-bool is_player_weapon(void* obj) {
-    return has_vtable(obj, patterns::kPlayerWeaponVtableRva);
-}
-
 bool is_player_pawn(void* obj) {
     return has_vtable(obj, patterns::kShockPlayerVtableRva);
+}
+
+// A weapon's owning pawn sits at [weapon+0x454] (the fire-start implementation
+// reads it), so "is this the player's gun" is one dereference plus the pawn
+// vtable check - and an AI's weapon fails it.
+bool owner_is_player_pawn(void* weapon) {
+    if (!weapon) return false;
+    void* owner = nullptr;
+    if (!read_ptr(static_cast<const uint8_t*>(weapon) + patterns::kWeaponOwnerOffset, &owner))
+        return false;
+    return is_player_pawn(owner);
 }
 
 // ---- hand selection --------------------------------------------------------
@@ -165,12 +166,14 @@ bool trigger_held(bool right) {
     return (right ? rt : lt) >= 64; // ~25% pull, same ballpark as the game's own
 }
 
-Hand hand_for_object(void* obj) {
+// `fallback` is the hand this seam belongs to when there is no trigger
+// evidence yet (weapons right, abilities left).
+Hand hand_for_object(void* obj, Hand fallback) {
     if (obj && obj == g_objRight) return Hand::Right;
     if (obj && obj == g_objLeft) return Hand::Left;
 
     bool r = trigger_held(true), l = trigger_held(false);
-    if (obj && is_player_weapon(obj)) {
+    if (obj) {
         // Exactly one trigger -> that hand owns this object. Both triggers with
         // one slot already known -> the other hand owns it by elimination.
         bool takeRight = false, takeLeft = false;
@@ -193,9 +196,7 @@ Hand hand_for_object(void* obj) {
             return Hand::Left;
         }
     }
-    // Unknown and no usable trigger evidence: the right hand is the weapon
-    // hand, which is the safer default for a stray query.
-    return Hand::Right;
+    return fallback; // no trigger evidence yet
 }
 
 // ---- the ray ---------------------------------------------------------------
@@ -222,193 +223,233 @@ void note_substitution(Hand h, const FVector& o, const FRotator& r) {
     g_lastSubHand.store(h == Hand::Right ? 1u : 0u, std::memory_order_relaxed);
 }
 
-// A 12-byte engine "direction" result is either an FVector (unit-ish floats)
-// or an FRotator (65536-per-turn int32s), and which one depends on the script
-// signature we never see. Classify from what the ORIGINAL produced: rotator
-// components are small integers, whose float reinterpretation is a denormal,
-// while float components are ordinary floats whose int reinterpretation is
-// enormous. All-zero is ambiguous, so the verdict is cached per seam from the
-// first confident call and only then does that seam substitute.
-enum ResultType { kUnknown = 0, kVector = 1, kRotator = 2 };
-
-ResultType classify(const float raw[3]) {
-    int32_t v[3];
-    memcpy(v, raw, sizeof v);
-    bool allZero = (v[0] == 0 && v[1] == 0 && v[2] == 0);
-    if (allZero) return kUnknown;
-    for (int i = 0; i < 3; ++i) {
-        int32_t a = v[i] < 0 ? -v[i] : v[i];
-        if (a > (1 << 21)) return kVector; // 2 million rotation units is nonsense
-    }
-    return kRotator;
-}
-
-void write_direction(void* result, const FRotator& rot, ResultType type, int32_t rollIn) {
-    if (type == kRotator) {
-        int32_t v[3] = {rot.pitch, rot.yaw, rollIn};
-        float packed[3];
-        memcpy(packed, v, sizeof packed);
-        write12(result, packed);
-        return;
-    }
-    float dir[3];
-    ue_rot_to_dir(rot, dir);
-    write12(result, dir);
-}
-
 // ---- detours ---------------------------------------------------------------
-// Every thunk is `void __thiscall execFoo(FFrame& Stack, void* Result)`, which
-// is register/stack-identical to __fastcall with a dummy EDX slot.
+// Both seams are __thiscall C++ methods, which is register/stack-identical to
+// __fastcall with a dummy EDX slot. Substitution happens AFTER the original
+// ran, so the engine's own numbers are what we log and what we fall back to.
 
-void log_call(Slot& slot, void* self, void* stack, const float raw[3], const char* note) {
+void log_call(Slot& slot, void* self, const float* a, const float* b, const float* c,
+              const char* note) {
     if (slot.dumpLeft <= 0) return;
     --slot.dumpLeft;
+    void* vtbl = nullptr;
+    read_ptr(self, &vtbl);
+    BVR_LOG("[aim] %s this=%p vtbl=0x%X A=(%.1f %.1f %.1f) B=(%.3f %.3f %.3f) "
+            "C=(%.3f %.3f %.3f) %s",
+            slot.name, self, to_rva(vtbl), a[0], a[1], a[2], b[0], b[1], b[2], c[0], c[1], c[2],
+            note);
+}
+
+// The two out-params are a POSITION (thousands of Unreal units) and a unit
+// DIRECTION, and which slot holds which differs between the weapon and the
+// ability signature. Rather than trust the disassembly's labels, decide per
+// call from the magnitudes - a direction is never longer than ~1.
+bool looks_like_direction(const float v[3]) {
+    float len2 = v[0] * v[0] + v[1] * v[1] + v[2] * v[2];
+    return len2 < 4.0f;
+}
+
+bool is_zero(const float v[3]) {
+    return v[0] == 0.0f && v[1] == 0.0f && v[2] == 0.0f;
+}
+
+// Write our ray into the out-params: every slot the engine filled with a
+// POSITION gets the hand's origin, every slot it filled with a DIRECTION gets
+// the hand's direction. Which index is which differs between the two
+// signatures (and an unused slot reads as zero), so this stays value-driven
+// rather than trusting a fixed index. True if anything was written.
+bool substitute(Slot& slot, Hand h, float* const* out, int count) {
+    FVector o{};
+    FRotator r{};
+    if (!ray_for(h, &o, &r)) {
+        slot.skips.fetch_add(1, std::memory_order_relaxed);
+        return false;
+    }
+    float dir[3];
+    ue_rot_to_dir(r, dir);
+    float pos[3] = {o.x, o.y, o.z};
+    bool handOrigin = g_handOrigin.load(std::memory_order_relaxed);
+
+    bool wrote = false;
+    for (int i = 0; i < count; ++i) {
+        if (!out[i]) continue;
+        float cur[3];
+        if (!read12(out[i], cur)) continue;
+        if (is_zero(cur)) continue; // engine left this one alone; so do we
+        if (looks_like_direction(cur)) {
+            wrote |= write12(out[i], dir);
+        } else if (handOrigin) {
+            wrote |= write12(out[i], pos);
+        }
+    }
+    if (!wrote) return false;
+    slot.subs.fetch_add(1, std::memory_order_relaxed);
+    note_substitution(h, o, r);
+    return true;
+}
+
+// AWeapon::GetPerfectFireStart(FVector* outA, FVector* outB, void* outC).
+// `this` is the weapon; [this+0x454] is the pawn holding it, which is how a
+// player shot is told from a splicer's.
+void __fastcall WeaponFireDetour(void* self, void* edx, float* outA, float* outB, float* outC) {
+    using WeaponFireFn = void(__fastcall*)(void*, void*, float*, float*, float*);
+    reinterpret_cast<WeaponFireFn>(g_weaponFire.original)(self, edx, outA, outB, outC);
+    g_weaponFire.calls.fetch_add(1, std::memory_order_relaxed);
+
+    float a[3] = {0, 0, 0}, b[3] = {0, 0, 0}, c[3] = {0, 0, 0};
+    read12(outA, a);
+    read12(outB, b);
+    read12(outC, c);
+
+    const char* note = "";
+    if (g_subWeapon.load(std::memory_order_relaxed) && owner_is_player_pawn(self)) {
+        Hand h = hand_for_object(self, Hand::Right);
+        float* outs[3] = {outA, outB, outC};
+        if (substitute(g_weaponFire, h, outs, 3))
+            note = (h == Hand::Right) ? "SUB(R)" : "SUB(L)";
+    }
+    log_call(g_weaponFire, self, a, b, c, note);
+}
+
+// UAttackAbility::GetPerfectFireStart(void* instigator, FVector* outA,
+//                                    FVector* outB, void* outC).
+// The instigator argument IS the ownership check the engine itself does here.
+void __fastcall AbilityFireDetour(void* self, void* edx, void* instigator, float* outA,
+                                  float* outB, float* outC) {
+    using AbilityFireFn = void(__fastcall*)(void*, void*, void*, float*, float*, float*);
+    reinterpret_cast<AbilityFireFn>(g_abilityFire.original)(self, edx, instigator, outA, outB,
+                                                           outC);
+    g_abilityFire.calls.fetch_add(1, std::memory_order_relaxed);
+
+    float a[3] = {0, 0, 0}, b[3] = {0, 0, 0}, c[3] = {0, 0, 0};
+    read12(outA, a);
+    read12(outB, b);
+    read12(outC, c);
+
+    const char* note = "";
+    if (g_subAbility.load(std::memory_order_relaxed) && is_player_pawn(instigator)) {
+        // Plasmids are the left hand; the wrench's melee ability also lands
+        // here, and the trigger-keyed map moves it back to the right hand the
+        // first time it swings.
+        Hand h = hand_for_object(self, Hand::Left);
+        float* outs[3] = {outA, outB, outC};
+        if (substitute(g_abilityFire, h, outs, 3))
+            note = (h == Hand::Right) ? "SUB(R)" : "SUB(L)";
+    }
+    log_call(g_abilityFire, self, a, b, c, note);
+}
+
+// ---- generic native probe --------------------------------------------------
+// `vraim scan <Class> <Func>` resolves ANY name-based native through the
+// engine's lookup table and hooks it read-only. The whole fire flow is a
+// question of which natives run when a trigger is pulled, and answering it
+// from the command file beats a rebuild per guess. Eight slots is plenty for
+// one investigation; template instantiation gives each its own detour address.
+
+constexpr int kProbeSlots = 8;
+
+struct ProbeSlot {
+    char name[64] = {};
+    void* target = nullptr;
+    void* original = nullptr;
+    bool created = false;
+    std::atomic<bool> enabled{false};
+    std::atomic<uint32_t> calls{0};
+    int32_t dumpLeft = 0;
+};
+ProbeSlot g_probes[kProbeSlots];
+
+void probe_note(int n, void* self, void* stack, void* result) {
+    ProbeSlot& p = g_probes[n];
+    p.calls.fetch_add(1, std::memory_order_relaxed);
+    if (p.dumpLeft <= 0) return;
+    --p.dumpLeft;
+    float raw[3] = {0, 0, 0};
+    read12(result, raw);
+    int32_t asInt[3];
+    memcpy(asInt, raw, sizeof asInt);
     void* obj = nullptr;
     void* node = nullptr;
     if (stack) {
         read_ptr(static_cast<const uint8_t*>(stack) + patterns::kFFrameObjectOffset, &obj);
         read_ptr(static_cast<const uint8_t*>(stack) + patterns::kFFrameNodeOffset, &node);
     }
-    int32_t asInt[3];
-    memcpy(asInt, raw, sizeof asInt);
-    BVR_LOG("[aim] %s this=%p vtbl=0x%X obj=%p node=%p result f=(%.2f %.2f %.2f) "
-            "i=(%d %d %d) %s",
-            slot.name, self, self ? to_rva(*static_cast<void**>(self)) : 0, obj, node,
-            raw[0], raw[1], raw[2], asInt[0], asInt[1], asInt[2], note);
+    void* vtbl = nullptr;
+    read_ptr(self, &vtbl);
+    BVR_LOG("[aim] scan %s this=%p vtbl=0x%X obj=%p node=%p res f=(%.2f %.2f %.2f) "
+            "i=(%d %d %d)", p.name, self, to_rva(vtbl), obj, node, raw[0], raw[1], raw[2],
+            asInt[0], asInt[1], asInt[2]);
 }
 
-// Learn (and remember) what type this seam's 12-byte result is.
-ResultType learn_type(Slot& slot, const float raw[3]) {
-    ResultType t = classify(raw);
-    if (t != kUnknown && slot.resultType == kUnknown) {
-        slot.resultType = t;
-        BVR_LOG("[aim] %s result type = %s", slot.name, t == kRotator ? "FRotator" : "FVector");
+template <int N>
+void __fastcall GenericProbeDetour(void* self, void* edx, void* stack, void* result) {
+    reinterpret_cast<ExecFn>(g_probes[N].original)(self, edx, stack, result);
+    probe_note(N, self, stack, result);
+}
+
+void* const kProbeDetours[kProbeSlots] = {
+    reinterpret_cast<void*>(&GenericProbeDetour<0>),
+    reinterpret_cast<void*>(&GenericProbeDetour<1>),
+    reinterpret_cast<void*>(&GenericProbeDetour<2>),
+    reinterpret_cast<void*>(&GenericProbeDetour<3>),
+    reinterpret_cast<void*>(&GenericProbeDetour<4>),
+    reinterpret_cast<void*>(&GenericProbeDetour<5>),
+    reinterpret_cast<void*>(&GenericProbeDetour<6>),
+    reinterpret_cast<void*>(&GenericProbeDetour<7>),
+};
+
+bvr::pattern_scan::ProcessImage g_image{};
+
+void scan_and_hook(const char* cls, const char* fn, int32_t dump) {
+    bvr::pattern_scan::NativeScanResult scan{};
+    if (!bvr::pattern_scan::find_native_function(g_image, cls, fn, scan)) {
+        BVR_LOG("[aim] scan %s::%s NOT FOUND (%zu string match(es), %zu table ref(s))", cls, fn,
+                scan.stringMatches, scan.tableRefs);
+        return;
     }
-    return static_cast<ResultType>(slot.resultType);
-}
-
-void __fastcall FireStartDetour(void* self, void* edx, void* stack, void* result) {
-    reinterpret_cast<ExecFn>(g_fireStart.original)(self, edx, stack, result);
-    g_fireStart.calls.fetch_add(1, std::memory_order_relaxed);
-
-    float raw[3] = {0, 0, 0};
-    if (!read12(result, raw)) return;
-
-    const char* note = "";
-    if (g_subFireStart.load(std::memory_order_relaxed) &&
-        g_handOrigin.load(std::memory_order_relaxed) && is_player_weapon(self)) {
-        Hand h = hand_for_object(self);
-        FVector o{};
-        FRotator r{};
-        if (ray_for(h, &o, &r)) {
-            float v[3] = {o.x, o.y, o.z};
-            if (write12(result, v)) {
-                g_fireStart.subs.fetch_add(1, std::memory_order_relaxed);
-                note = (h == Hand::Right) ? "SUB(R)" : "SUB(L)";
-                note_substitution(h, o, r);
-            }
-        } else {
-            g_fireStart.skips.fetch_add(1, std::memory_order_relaxed);
+    for (int i = 0; i < kProbeSlots; ++i) {
+        ProbeSlot& p = g_probes[i];
+        if (p.target == scan.function) { // re-arm an existing slot
+            p.dumpLeft = dump;
+            BVR_LOG("[aim] scan %s re-armed (%d lines)", p.name, dump);
+            return;
         }
     }
-    log_call(g_fireStart, self, stack, raw, note);
-}
-
-void __fastcall AimErrorDetour(void* self, void* edx, void* stack, void* result) {
-    reinterpret_cast<ExecFn>(g_aimError.original)(self, edx, stack, result);
-    g_aimError.calls.fetch_add(1, std::memory_order_relaxed);
-
-    float raw[3] = {0, 0, 0};
-    if (!read12(result, raw)) return;
-    ResultType type = learn_type(g_aimError, raw);
-
-    const char* note = "";
-    if (g_subAimError.load(std::memory_order_relaxed) && type != kUnknown &&
-        is_player_weapon(self)) {
-        Hand h = hand_for_object(self);
-        FVector o{};
-        FRotator r{};
-        if (ray_for(h, &o, &r)) {
-            int32_t rollIn = 0;
-            if (type == kRotator) {
-                int32_t asInt[3];
-                memcpy(asInt, raw, sizeof asInt);
-                rollIn = asInt[2]; // keep the engine's roll
-            }
-            write_direction(result, r, type, rollIn);
-            g_aimError.subs.fetch_add(1, std::memory_order_relaxed);
-            note = (h == Hand::Right) ? "SUB(R)" : "SUB(L)";
-            note_substitution(h, o, r);
-        } else {
-            g_aimError.skips.fetch_add(1, std::memory_order_relaxed);
+    for (int i = 0; i < kProbeSlots; ++i) {
+        ProbeSlot& p = g_probes[i];
+        if (p.created) continue;
+        _snprintf_s(p.name, sizeof p.name, _TRUNCATE, "%s::%s", cls, fn);
+        p.target = scan.function;
+        p.dumpLeft = dump;
+        MH_STATUS st = MH_CreateHook(p.target, kProbeDetours[i], &p.original);
+        if (st != MH_OK) {
+            BVR_LOG("[aim] scan %s: MH_CreateHook failed: %s", p.name, MH_StatusToString(st));
+            p.target = nullptr;
+            p.name[0] = 0;
+            return;
         }
-    }
-    log_call(g_aimError, self, stack, raw, note);
-}
-
-void __fastcall ViewPointDetour(void* self, void* edx, void* stack, void* result) {
-    reinterpret_cast<ExecFn>(g_viewPoint.original)(self, edx, stack, result);
-    g_viewPoint.calls.fetch_add(1, std::memory_order_relaxed);
-
-    float raw[3] = {0, 0, 0};
-    if (!read12(result, raw)) return;
-
-    const char* note = "";
-    if (g_subViewPoint.load(std::memory_order_relaxed) &&
-        g_handOrigin.load(std::memory_order_relaxed) && is_player_pawn(self)) {
-        // The pawn's view point has no weapon object to key on; the hand that
-        // is actually firing owns it (right hand when both or neither).
-        Hand h = trigger_held(false) && !trigger_held(true) ? Hand::Left : Hand::Right;
-        FVector o{};
-        if (ray_for(h, &o, nullptr)) {
-            float v[3] = {o.x, o.y, o.z};
-            if (write12(result, v)) {
-                g_viewPoint.subs.fetch_add(1, std::memory_order_relaxed);
-                note = "SUB";
-            }
-        } else {
-            g_viewPoint.skips.fetch_add(1, std::memory_order_relaxed);
+        p.created = true;
+        st = MH_EnableHook(p.target);
+        if (st != MH_OK) {
+            BVR_LOG("[aim] scan %s: MH_EnableHook failed: %s", p.name, MH_StatusToString(st));
+            return;
         }
+        p.enabled.store(true, std::memory_order_relaxed);
+        BVR_LOG("[aim] scan %s hooked at %p (rva 0x%X), %d dump lines", p.name, p.target,
+                to_rva(p.target), dump);
+        return;
     }
-    log_call(g_viewPoint, self, stack, raw, note);
+    BVR_LOG("[aim] scan: all %d probe slots in use (`vraim scanoff` first)", kProbeSlots);
 }
 
-void __fastcall ViewDirDetour(void* self, void* edx, void* stack, void* result) {
-    reinterpret_cast<ExecFn>(g_viewDir.original)(self, edx, stack, result);
-    g_viewDir.calls.fetch_add(1, std::memory_order_relaxed);
-
-    float raw[3] = {0, 0, 0};
-    if (!read12(result, raw)) return;
-    ResultType type = learn_type(g_viewDir, raw);
-
-    const char* note = "";
-    if (g_subViewDir.load(std::memory_order_relaxed) && type != kUnknown &&
-        is_player_pawn(self)) {
-        Hand h = trigger_held(false) && !trigger_held(true) ? Hand::Left : Hand::Right;
-        FVector o{};
-        FRotator r{};
-        if (ray_for(h, &o, &r)) {
-            write_direction(result, r, type, 0);
-            g_viewDir.subs.fetch_add(1, std::memory_order_relaxed);
-            note = (h == Hand::Right) ? "SUB(R)" : "SUB(L)";
-            note_substitution(h, o, r);
-        } else {
-            g_viewDir.skips.fetch_add(1, std::memory_order_relaxed);
-        }
+void scan_off() {
+    for (ProbeSlot& p : g_probes) {
+        if (!p.enabled.load(std::memory_order_relaxed)) continue;
+        MH_DisableHook(p.target);
+        p.enabled.store(false, std::memory_order_relaxed);
+        BVR_LOG("[aim] scan %s disabled (calls %u)", p.name,
+                p.calls.load(std::memory_order_relaxed));
     }
-    log_call(g_viewDir, self, stack, raw, note);
-}
-
-// Read-only: AActor::Trace is the hitscan primitive, so its result IS the
-// impact point - the objective number the flat verification asserts on. Hot
-// path (AI line-of-sight uses it too), so it only ever logs from a dump budget.
-void __fastcall TraceDetour(void* self, void* edx, void* stack, void* result) {
-    reinterpret_cast<ExecFn>(g_trace.original)(self, edx, stack, result);
-    g_trace.calls.fetch_add(1, std::memory_order_relaxed);
-    if (g_trace.dumpLeft <= 0) return;
-    float raw[3] = {0, 0, 0};
-    if (!read12(result, raw)) return;
-    log_call(g_trace, self, stack, raw, "hitactor");
 }
 
 // ---- hook lifecycle --------------------------------------------------------
@@ -451,70 +492,44 @@ patterns::Symbols g_syms{};
 
 bool install_all() {
     bool any = false;
-    any |= install_slot(g_fireStart, g_syms.execWeaponFireStart,
-                        reinterpret_cast<void*>(&FireStartDetour));
-    any |= install_slot(g_aimError, g_syms.execWeaponAimError,
-                        reinterpret_cast<void*>(&AimErrorDetour));
-    any |= install_slot(g_viewPoint, g_syms.execPawnViewPoint,
-                        reinterpret_cast<void*>(&ViewPointDetour));
-    any |= install_slot(g_viewDir, g_syms.execPawnViewDir,
-                        reinterpret_cast<void*>(&ViewDirDetour));
-    any |= install_slot(g_trace, g_syms.execActorTrace,
-                        reinterpret_cast<void*>(&TraceDetour));
+    any |= install_slot(g_weaponFire, g_syms.weaponFireStart,
+                        reinterpret_cast<void*>(&WeaponFireDetour));
+    any |= install_slot(g_abilityFire, g_syms.abilityFireStart,
+                        reinterpret_cast<void*>(&AbilityFireDetour));
     return any;
 }
 
 void disable_all() {
-    disable_slot(g_fireStart);
-    disable_slot(g_aimError);
-    disable_slot(g_viewPoint);
-    disable_slot(g_viewDir);
-    disable_slot(g_trace);
+    disable_slot(g_weaponFire);
+    disable_slot(g_abilityFire);
 }
 
 void set_dump(int32_t n) {
     g_dumpBudget.store(n, std::memory_order_relaxed);
-    g_fireStart.dumpLeft = n;
-    g_aimError.dumpLeft = n;
-    g_viewPoint.dumpLeft = n;
-    g_viewDir.dumpLeft = n;
-    g_trace.dumpLeft = n;
-}
-
-Slot* slot_by_name(const char* name) {
-    if (strcmp(name, "firestart") == 0) return &g_fireStart;
-    if (strcmp(name, "aimerror") == 0) return &g_aimError;
-    if (strcmp(name, "viewpoint") == 0) return &g_viewPoint;
-    if (strcmp(name, "viewdir") == 0) return &g_viewDir;
-    if (strcmp(name, "trace") == 0) return &g_trace;
-    return nullptr;
+    g_weaponFire.dumpLeft = n;
+    g_abilityFire.dumpLeft = n;
 }
 
 std::atomic<bool>* sub_flag_by_name(const char* name) {
-    if (strcmp(name, "firestart") == 0) return &g_subFireStart;
-    if (strcmp(name, "aimerror") == 0) return &g_subAimError;
-    if (strcmp(name, "viewpoint") == 0) return &g_subViewPoint;
-    if (strcmp(name, "viewdir") == 0) return &g_subViewDir;
+    if (strcmp(name, "weapon") == 0) return &g_subWeapon;
+    if (strcmp(name, "ability") == 0) return &g_subAbility;
     return nullptr;
 }
 
 void log_status() {
-    BVR_LOG("[aim] status: %s | seams fs=%d ae=%d vp=%d vd=%d | handOrigin=%d probe=%d",
+    BVR_LOG("[aim] status: %s | seams weapon=%d ability=%d | handOrigin=%d probe=%d",
             g_enabled.load(std::memory_order_relaxed) ? "ON" : "off",
-            g_subFireStart.load(std::memory_order_relaxed),
-            g_subAimError.load(std::memory_order_relaxed),
-            g_subViewPoint.load(std::memory_order_relaxed),
-            g_subViewDir.load(std::memory_order_relaxed),
+            g_subWeapon.load(std::memory_order_relaxed) ? 1 : 0,
+            g_subAbility.load(std::memory_order_relaxed) ? 1 : 0,
             g_handOrigin.load(std::memory_order_relaxed) ? 1 : 0,
             g_probe.load(std::memory_order_relaxed) ? 1 : 0);
-    Slot* all[] = {&g_fireStart, &g_aimError, &g_viewPoint, &g_viewDir, &g_trace};
+    Slot* all[] = {&g_weaponFire, &g_abilityFire};
     for (Slot* s : all) {
-        BVR_LOG("[aim]   %-9s hook=%s calls=%u subs=%u skips=%u type=%s", s->name,
+        BVR_LOG("[aim]   %-8s hook=%s calls=%u subs=%u skips=%u", s->name,
                 s->enabled.load(std::memory_order_relaxed) ? "on " : "off",
                 s->calls.load(std::memory_order_relaxed),
                 s->subs.load(std::memory_order_relaxed),
-                s->skips.load(std::memory_order_relaxed),
-                s->resultType == kRotator ? "rot" : s->resultType == kVector ? "vec" : "?");
+                s->skips.load(std::memory_order_relaxed));
     }
     uint64_t now = GetTickCount64();
     for (int i = 0; i < 2; ++i) {
@@ -533,10 +548,10 @@ void log_status() {
 
 void init(const bvr::pattern_scan::ProcessImage& image, const patterns::Symbols& symbols) {
     g_imageBase = image.base;
+    g_image = image;
     g_syms = symbols;
-    BVR_LOG("[aim] init: firestart=%p aimerror=%p viewpoint=%p viewdir=%p trace=%p",
-            g_syms.execWeaponFireStart, g_syms.execWeaponAimError, g_syms.execPawnViewPoint,
-            g_syms.execPawnViewDir, g_syms.execActorTrace);
+    BVR_LOG("[aim] init: weapon fire-start=%p ability fire-start=%p", g_syms.weaponFireStart,
+            g_syms.abilityFireStart);
 }
 
 void on_calcview(const FrameContext& ctx) {
@@ -622,6 +637,15 @@ void handle_command(const char* args) {
         g_enabled.store(false, std::memory_order_relaxed);
         if (!g_probe.load(std::memory_order_relaxed)) disable_all();
         BVR_LOG("[aim] OFF - engine aim restored");
+    } else if (strcmp(verb, "scan") == 0) {
+        char cls[48] = {}, fn[48] = {};
+        int dump = 8;
+        int n = sscanf_s(rest, "%47s %47s %d", cls, static_cast<unsigned>(sizeof cls), fn,
+                         static_cast<unsigned>(sizeof fn), &dump);
+        if (n >= 2) scan_and_hook(cls, fn, dump > 0 ? dump : 8);
+        else BVR_LOG("[aim] usage: vraim scan <Class> <Func> [dumpLines]");
+    } else if (strcmp(verb, "scanoff") == 0) {
+        scan_off();
     } else if (strcmp(verb, "probe") == 0) {
         bool on = strncmp(rest, "on", 2) == 0;
         g_probe.store(on, std::memory_order_relaxed);
@@ -688,15 +712,14 @@ void handle_command(const char* args) {
     } else if (strcmp(verb, "status") == 0) {
         log_status();
     } else {
-        BVR_LOG("[aim] unknown command '%s' (on|off|probe|dump|origin|seam|test|status)", verb);
+        BVR_LOG("[aim] unknown command '%s' "
+                "(on|off|probe|dump|origin|seam|test|scan|scanoff|status)", verb);
     }
 }
 
 bool hook_live() {
-    return g_fireStart.enabled.load(std::memory_order_relaxed) ||
-           g_aimError.enabled.load(std::memory_order_relaxed) ||
-           g_viewPoint.enabled.load(std::memory_order_relaxed) ||
-           g_viewDir.enabled.load(std::memory_order_relaxed);
+    return g_weaponFire.enabled.load(std::memory_order_relaxed) ||
+           g_abilityFire.enabled.load(std::memory_order_relaxed);
 }
 
 bool active() {
@@ -720,15 +743,11 @@ void draw_debug_ui() {
                         &handOrigin))
         g_handOrigin.store(handOrigin, std::memory_order_relaxed);
 
-    ImGui::Text("seam calls: fs %u/%u  ae %u/%u  vp %u/%u  vd %u/%u  (subs/calls)",
-                g_fireStart.subs.load(std::memory_order_relaxed),
-                g_fireStart.calls.load(std::memory_order_relaxed),
-                g_aimError.subs.load(std::memory_order_relaxed),
-                g_aimError.calls.load(std::memory_order_relaxed),
-                g_viewPoint.subs.load(std::memory_order_relaxed),
-                g_viewPoint.calls.load(std::memory_order_relaxed),
-                g_viewDir.subs.load(std::memory_order_relaxed),
-                g_viewDir.calls.load(std::memory_order_relaxed));
+    ImGui::Text("fire seams (subs/calls): weapon %u/%u  plasmid %u/%u",
+                g_weaponFire.subs.load(std::memory_order_relaxed),
+                g_weaponFire.calls.load(std::memory_order_relaxed),
+                g_abilityFire.subs.load(std::memory_order_relaxed),
+                g_abilityFire.calls.load(std::memory_order_relaxed));
     ImGui::Text("last sub: %s origin (%.0f %.0f %.0f) yaw %d pitch %d",
                 g_lastSubHand.load(std::memory_order_relaxed) ? "RIGHT" : "LEFT",
                 g_lastSubX.load(std::memory_order_relaxed),

--- a/src/game/bioshock1r/aim.h
+++ b/src/game/bioshock1r/aim.h
@@ -53,6 +53,8 @@ void on_calcview(const FrameContext& ctx);
 //   dump <n>                log the next n calls per seam in full detail
 //   test l|r <yawDeg> <pitchDeg> [holdMs]   synthetic hand aim (view-relative)
 //   test clear
+//   pose aim|grip           the runtime's pointing ray (default) vs the grip axis
+//   cal <pitchDeg> [yawDeg] aim trim, degrees; +pitch aims higher
 //   origin on|off           hand origin (default) vs the engine's own origin
 //   seam <weapon|ability> on|off
 //   scan <Class> <Func> [n] / scanoff   hook ANY name-based native read-only

--- a/src/game/bioshock1r/aim.h
+++ b/src/game/bioshock1r/aim.h
@@ -1,0 +1,70 @@
+#pragma once
+// M6 decoupled aim: the fire ray follows the CONTROLLERS while the camera
+// keeps following the HMD.
+//
+// The engine's fire path asks four UnrealScript natives for the numbers that
+// become a shot (ENGINE_NOTES "Fire flow / aim"):
+//   AWeapon::GetPerfectFireStart  -> trace origin
+//   AWeapon::ApplyAimError        -> trace direction (perfect dir in, spread dir out)
+//   APawn::GetViewPoint           -> eye position (the generic view query)
+//   APawn::GetViewDirection       -> view direction
+// Each is a `void __thiscall execFoo(FFrame& Stack, void* Result)` thunk, so
+// this module hooks them, calls the original, and rewrites `Result` with the
+// hand's ray - the same "call the original, adjust the out-params" shape the
+// CalcView camera hook uses. AActor::Trace is hooked read-only, as the
+// hit-point telemetry that makes flat verification objective.
+//
+// Everything is command-gated (`vraim ...`) and fail-soft: unresolved natives,
+// no hand pose, a scripted (cutscene) camera, or the master switch off all
+// leave the engine's own values untouched.
+
+#include "core/hooks/pattern_scan.h"
+#include "game/bioshock1r/patterns.h"
+
+#include <cstdint>
+
+namespace bvr::b1r::aim {
+
+enum class Hand { Left = 0, Right = 1 };
+
+// Resolve-time wiring. Nothing is hooked here (see `vraim probe`/`vraim on`).
+void init(const bvr::pattern_scan::ProcessImage& image, const patterns::Symbols& symbols);
+
+// Published once per frame by the CalcView drive, on the game thread, AFTER it
+// has produced the final camera. The hand rays are built in exactly this
+// frame - same recenter pose, same game yaw, same world scale - so the aim ray
+// and the camera can never disagree about where the player is standing.
+struct FrameContext {
+    bool vrDriving = false;   // HMD is driving the camera this frame
+    float camX = 0.0f, camY = 0.0f, camZ = 0.0f;   // final camera loc, UU (incl. head offset)
+    float baseX = 0.0f, baseY = 0.0f, baseZ = 0.0f; // camera loc BEFORE the head offset
+    int32_t camPitch = 0, camYaw = 0, camRoll = 0;  // final camera rot, 65536 units/turn
+    float driveYawOffsetRad = 0.0f; // yaw the head drive added on top of the game yaw
+    float recenterYawRad = 0.0f;    // XR yaw at recenter
+    float recenterPx = 0.0f, recenterPy = 0.0f, recenterPz = 0.0f; // XR meters at recenter
+    float worldScale = 50.0f;       // UU per meter
+    void* viewActor = nullptr;      // *view_actor out-param (cutscene guard)
+    void* pc = nullptr;             // the PlayerController the hook fired on
+};
+void on_calcview(const FrameContext& ctx);
+
+// Seam command handler: args after the "vraim" verb (game thread).
+//   on | off | status
+//   probe on|off            install/enable the seam hooks in telemetry mode
+//   dump <n>                log the next n calls per seam in full detail
+//   test l|r <yawDeg> <pitchDeg> [holdMs]   synthetic hand aim (view-relative)
+//   test clear
+//   origin on|off           hand origin (default) vs the engine's own origin
+//   seam <firestart|aimerror|viewpoint|viewdir> on|off
+void handle_command(const char* args);
+
+// Overlay section (render thread).
+void draw_debug_ui();
+
+// True while any seam hook is installed and enabled.
+bool hook_live();
+
+// True while substitution is armed (master switch + a usable hand ray).
+bool active();
+
+} // namespace bvr::b1r::aim

--- a/src/game/bioshock1r/aim.h
+++ b/src/game/bioshock1r/aim.h
@@ -2,21 +2,20 @@
 // M6 decoupled aim: the fire ray follows the CONTROLLERS while the camera
 // keeps following the HMD.
 //
-// The engine's fire path asks four UnrealScript natives for the numbers that
-// become a shot (ENGINE_NOTES "Fire flow / aim"):
-//   AWeapon::GetPerfectFireStart  -> trace origin
-//   AWeapon::ApplyAimError        -> trace direction (perfect dir in, spread dir out)
-//   APawn::GetViewPoint           -> eye position (the generic view query)
-//   APawn::GetViewDirection       -> view direction
-// Each is a `void __thiscall execFoo(FFrame& Stack, void* Result)` thunk, so
-// this module hooks them, calls the original, and rewrites `Result` with the
-// hand's ray - the same "call the original, adjust the out-params" shape the
-// CalcView camera hook uses. AActor::Trace is hooked read-only, as the
-// hit-point telemetry that makes flat verification objective.
+// Every shot in this engine starts by asking ONE function where it begins and
+// where it points (ENGINE_NOTES "Fire flow / aim"):
+//   AWeapon::GetPerfectFireStart        - guns and the wrench (right hand)
+//   UAttackAbility::GetPerfectFireStart - plasmids and abilities (left hand)
+// Both are C++ implementations called by the matching native InitiateDamage,
+// and both fill out-params that the engine THEN puts its own spread on - so
+// this module hooks them, lets the original run, and rewrites the out-params
+// with the hand's ray. Per-weapon accuracy still applies on top, and the shape
+// is the same "call the original, adjust the out-params" the CalcView camera
+// hook uses.
 //
-// Everything is command-gated (`vraim ...`) and fail-soft: unresolved natives,
-// no hand pose, a scripted (cutscene) camera, or the master switch off all
-// leave the engine's own values untouched.
+// Everything is command-gated (`vraim ...`) and fail-soft: unresolved symbols,
+// no hand pose, a scripted (cutscene) camera, an AI's weapon, or the master
+// switch off all leave the engine's own values untouched.
 
 #include "core/hooks/pattern_scan.h"
 #include "game/bioshock1r/patterns.h"
@@ -55,7 +54,9 @@ void on_calcview(const FrameContext& ctx);
 //   test l|r <yawDeg> <pitchDeg> [holdMs]   synthetic hand aim (view-relative)
 //   test clear
 //   origin on|off           hand origin (default) vs the engine's own origin
-//   seam <firestart|aimerror|viewpoint|viewdir> on|off
+//   seam <weapon|ability> on|off
+//   scan <Class> <Func> [n] / scanoff   hook ANY name-based native read-only
+//                           (fire-flow investigation without a rebuild)
 void handle_command(const char* args);
 
 // Overlay section (render thread).

--- a/src/game/bioshock1r/bioshock1r_adapter.cpp
+++ b/src/game/bioshock1r/bioshock1r_adapter.cpp
@@ -1,6 +1,7 @@
 #include "game/bioshock1r/bioshock1r_adapter.h"
 
 #include "core/util/log.h"
+#include "game/bioshock1r/aim.h"
 #include "game/bioshock1r/camera.h"
 #include "game/bioshock1r/input_drive.h"
 #include "game/bioshock1r/patterns.h"
@@ -11,6 +12,7 @@ namespace bvr::b1r {
 uint32_t Bioshock1RAdapter::capabilities() const {
     uint32_t caps = camera::hook_live() ? (game::CAP_CAMERA_OVERRIDE | game::CAP_FOV_WRITE) : 0u;
     if (scenedraw::hook_live()) caps |= game::CAP_SCENE_REENTRY;
+    if (aim::hook_live()) caps |= game::CAP_AIM_OVERRIDE;
     return caps;
 }
 
@@ -19,6 +21,7 @@ bool Bioshock1RAdapter::init(const bvr::pattern_scan::ProcessImage& image) {
     if (!patterns::resolve(image, symbols)) return false; // resolve() logged why
     if (!camera::install(symbols.eventPlayerCalcView)) return false;
     scenedraw::init(image); // stashes the image only - hooks are command-gated
+    aim::init(image, symbols); // same: M6 seam hooks are command-gated
     BVR_LOG("[b1r] adapter ready, capabilities 0x%X", capabilities());
     return true;
 }
@@ -29,6 +32,7 @@ void Bioshock1RAdapter::setFov(float hfovDeg) {
 
 void Bioshock1RAdapter::drawDebugUi() {
     camera::draw_debug_ui();
+    aim::draw_debug_ui();
     input_drive::draw_debug_ui();
     scenedraw::draw_debug_ui();
 }

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -8,11 +8,13 @@
 #include "core/gfx/frame_inspector.h"
 #include "core/input/xinput_bridge.h"
 #include "core/util/log.h"
+#include "game/bioshock1r/aim.h"
 #include "game/bioshock1r/console_exec.h"
 #include "core/vr/openxr_runtime.h"
 #include "game/bioshock1r/input_drive.h"
 #include "game/bioshock1r/patterns.h"
 #include "game/bioshock1r/scenedraw.h"
+#include "game/bioshock1r/ue_math.h"
 
 #include <windows.h>
 #include <MinHook.h>
@@ -29,12 +31,8 @@
 namespace bvr::b1r::camera {
 namespace {
 
-struct FVector { float x, y, z; };             // Unreal units
-struct FRotator { int32_t pitch, yaw, roll; }; // 65536 units per full turn
-
-constexpr float kPi = 3.14159265f;
-constexpr float kRotUnitsPerDegree = 65536.0f / 360.0f;
-constexpr float kRotUnitsPerRadian = 65536.0f / (2.0f * kPi);
+// FVector/FRotator, the rotation-unit constants and the XR->UE conversion all
+// live in ue_math.h so aim.cpp shares this file's exact conventions.
 
 // Controls: overlay thread writes, game thread reads. All relaxed - x86
 // lock-free, and a field arriving one frame late (or a torn group, e.g. new X
@@ -144,6 +142,10 @@ void apply_eye_offset(FVector* loc, const FRotator& rot, int sign) {
 //   vrinput test press <A|B|X|Y|LB|RB|START|BACK|LS|RS|DU|DD|DL|DR> [holdMs]
 //   vrinput test clear   (test holds self-expire; slots only feed the game
 //   while vrinput is on)
+// Decoupled aim (M6, routes to game/bioshock1r/aim):
+//   vraim on|off|status  vraim probe on|off  vraim dump <n>
+//   vraim origin on|off  vraim seam <firestart|aimerror|viewpoint|viewdir> on|off
+//   vraim test l|r <yawDeg> <pitchDeg> [holdMs]   vraim test clear
 // Engine console commands without the dead Tab console (console_exec):
 //   exec <command>   (enters at UWindowsViewport::Exec)
 //   execc <command>  (enters at UWindowsClient::Exec)
@@ -247,6 +249,8 @@ void apply_command(const char* cmd, const char* args) {
         bvr::frame_inspector::arm(strncmp(args, "full", 4) == 0 ? 2 : 1);
     } else if (strcmp(cmd, "vrinput") == 0) {
         input::handle_command(args); // M5 synthetic gamepad; logs its own echoes
+    } else if (strcmp(cmd, "vraim") == 0) {
+        aim::handle_command(args); // M6 decoupled aim; logs its own echoes
     } else if (strcmp(cmd, "exec") == 0) {
         console_exec::run_viewport(args); // engine console command, viewport chain
     } else if (strcmp(cmd, "execc") == 0) {
@@ -292,50 +296,9 @@ void poll_command_file(uint64_t now) {
     fclose(f);
 }
 
-// ---- XR -> Unreal conversion (adapter owns all unit/axis semantics) --------
-// XR LOCAL space: right +X, up +Y, forward -Z, meters, right-handed.
-// UE2.5: forward +X, right +Y, up +Z; FRotator 65536 units/turn, positive yaw
-// turns toward +Y (right), positive pitch looks up, positive roll tilts
-// clockwise (right).
-
-void quat_rotate(float qx, float qy, float qz, float qw, const float v[3], float out[3]) {
-    float t[3] = {2.0f * (qy * v[2] - qz * v[1]), 2.0f * (qz * v[0] - qx * v[2]),
-                  2.0f * (qx * v[1] - qy * v[0])};
-    out[0] = v[0] + qw * t[0] + (qy * t[2] - qz * t[1]);
-    out[1] = v[1] + qw * t[1] + (qz * t[0] - qx * t[2]);
-    out[2] = v[2] + qw * t[2] + (qx * t[1] - qy * t[0]);
-}
-
-void xr_to_ue(const float v[3], float out[3]) {
-    out[0] = -v[2]; // XR -Z (forward) -> UE +X
-    out[1] = v[0];  // XR +X (right)   -> UE +Y
-    out[2] = v[1];  // XR +Y (up)      -> UE +Z
-}
-
-struct UeAngles { float yawRad, pitchRad, rollRad; };
-
+// XR -> Unreal conversion lives in ue_math.h (shared with the aim ray).
 UeAngles hmd_angles(const bvr::vr::HeadPose& hp) {
-    const float kFwd[3] = {0.0f, 0.0f, -1.0f};
-    const float kUp[3] = {0.0f, 1.0f, 0.0f};
-    float fxr[3], uxr[3], f[3], u[3];
-    quat_rotate(hp.qx, hp.qy, hp.qz, hp.qw, kFwd, fxr);
-    quat_rotate(hp.qx, hp.qy, hp.qz, hp.qw, kUp, uxr);
-    xr_to_ue(fxr, f);
-    xr_to_ue(uxr, u);
-
-    UeAngles a{};
-    a.yawRad = atan2f(f[1], f[0]);
-    float len2d = sqrtf(f[0] * f[0] + f[1] * f[1]);
-    a.pitchRad = atan2f(f[2], len2d);
-    if (len2d > 0.001f) { // gimbal guard: keep roll 0 when looking straight up/down
-        // Zero-roll frame from the forward vector, then measure the actual up
-        // vector against it. rn = normalize(cross(worldUp, f)), un = cross(f, rn).
-        float rn[3] = {-f[1] / len2d, f[0] / len2d, 0.0f};
-        float un[3] = {-f[2] * rn[1], f[2] * rn[0], f[0] * rn[1] - f[1] * rn[0]};
-        a.rollRad = atan2f(u[0] * rn[0] + u[1] * rn[1],
-                           u[0] * un[0] + u[1] * un[1] + u[2] * un[2]);
-    }
-    return a;
+    return ue_angles_from_xr_quat(hp.qx, hp.qy, hp.qz, hp.qw);
 }
 
 // eventPlayerCalcView is __thiscall; __fastcall with a dummy EDX slot is
@@ -424,6 +387,10 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
     // into the game yaw frame and scaled UU-per-meter.
     bool vrDrove = false;
     float vrFov = 0.0f;
+    // M6: the aim ray must be built in the SAME frame as the camera, so keep
+    // the pre-head-offset camera loc and the yaw the drive added.
+    FVector baseLoc = loc ? *loc : FVector{};
+    float driveYawOffsetRad = 0.0f;
     bvr::vr::HeadPose hp{};
     if (loc && rot && bvr::vr::vr_camera_mode() && bvr::vr::get_head_pose(hp)) {
         UeAngles a = hmd_angles(hp);
@@ -438,6 +405,7 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
         float gameYawRad = static_cast<float>(gameYawUnits) / kRotUnitsPerRadian;
         rot->pitch = static_cast<int32_t>(a.pitchRad * kRotUnitsPerRadian);
         rot->roll = static_cast<int32_t>(a.rollRad * kRotUnitsPerRadian);
+        driveYawOffsetRad = a.yawRad - g_recenterYawRad;
         rot->yaw = gameYawUnits +
                    static_cast<int32_t>((a.yawRad - g_recenterYawRad) * kRotUnitsPerRadian);
 
@@ -526,6 +494,36 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
         rot->pitch += static_cast<int32_t>(g_pitchDeg.load(std::memory_order_relaxed) * kRotUnitsPerDegree);
         rot->yaw   += static_cast<int32_t>(g_yawDeg.load(std::memory_order_relaxed) * kRotUnitsPerDegree);
         rot->roll  += static_cast<int32_t>(g_rollDeg.load(std::memory_order_relaxed) * kRotUnitsPerDegree);
+    }
+
+    // M6: publish the frame the camera just produced so the aim path can put
+    // both hands in exactly this frame (pre eye-offset - the eye shift belongs
+    // to the render, not to where the player is standing).
+    {
+        aim::FrameContext fc{};
+        fc.vrDriving = vrDrove;
+        if (loc) {
+            fc.camX = loc->x;
+            fc.camY = loc->y;
+            fc.camZ = loc->z;
+        }
+        fc.baseX = baseLoc.x;
+        fc.baseY = baseLoc.y;
+        fc.baseZ = baseLoc.z;
+        if (rot) {
+            fc.camPitch = rot->pitch;
+            fc.camYaw = rot->yaw;
+            fc.camRoll = rot->roll;
+        }
+        fc.driveYawOffsetRad = driveYawOffsetRad;
+        fc.recenterYawRad = g_recenterYawRad;
+        fc.recenterPx = g_recenterPose.px;
+        fc.recenterPy = g_recenterPose.py;
+        fc.recenterPz = g_recenterPose.pz;
+        fc.worldScale = g_worldScale.load(std::memory_order_relaxed);
+        fc.viewActor = viewActor ? *viewActor : nullptr;
+        fc.pc = self;
+        aim::on_calcview(fc);
     }
 
     // SequentialReentry stereo (M4 rung 2): this normal pass is the LEFT eye.

--- a/src/game/bioshock1r/patterns.cpp
+++ b/src/game/bioshock1r/patterns.cpp
@@ -10,6 +10,8 @@
 
 #include <windows.h>
 
+#include <cstring>
+
 namespace bvr::b1r::patterns {
 namespace {
 
@@ -148,31 +150,58 @@ bool resolve(const bvr::pattern_scan::ProcessImage& image, Symbols& out) {
 void resolve_aim_natives(const bvr::pattern_scan::ProcessImage& image, Symbols& out) {
     using namespace bvr::pattern_scan;
 
-    struct Want {
-        const char* cls;
-        const char* fn;
-        void** slot;
-        uint32_t expectedRva;
-    } wants[] = {
-        {"AWeapon", "GetPerfectFireStart", &out.execWeaponFireStart, kExpectedWeaponFireStartRva},
-        {"AWeapon", "ApplyAimError", &out.execWeaponAimError, kExpectedWeaponAimErrorRva},
-        {"APawn", "GetViewPoint", &out.execPawnViewPoint, kExpectedPawnViewPointRva},
-        {"APawn", "GetViewDirection", &out.execPawnViewDir, kExpectedPawnViewDirRva},
-        {"AActor", "Trace", &out.execActorTrace, kExpectedActorTraceRva},
-    };
-
-    for (const Want& w : wants) {
-        NativeScanResult scan{};
-        if (!find_native_function(image, w.cls, w.fn, scan)) {
-            BVR_LOG("[b1r] native %s::%s NOT resolved (%zu string match(es), %zu table ref(s))",
-                    w.cls, w.fn, scan.stringMatches, scan.tableRefs);
-            continue;
+    // Weapon side: read the implementation straight out of the class vtable
+    // (RTTI-derived vtable RVA + the slot the InitiateDamage call site uses).
+    // A vtable read survives a rebuild that moves the function; the expected
+    // RVA is only a cross-check.
+    const void** weaponVtbl =
+        reinterpret_cast<const void**>(const_cast<uint8_t*>(image.base) + kPlayerWeaponVtableRva);
+    if (is_memory_valid(weaponVtbl, kWeaponFireStartVtblOffset + sizeof(void*))) {
+        const uint8_t* impl = *reinterpret_cast<const uint8_t* const*>(
+            reinterpret_cast<const uint8_t*>(weaponVtbl) + kWeaponFireStartVtblOffset);
+        if (impl >= image.base && impl < image.base + image.size) {
+            out.weaponFireStart = const_cast<uint8_t*>(impl);
+            uint32_t rva = static_cast<uint32_t>(impl - image.base);
+            BVR_LOG("[b1r] AWeapon::GetPerfectFireStart impl = %p (RVA 0x%X%s)", impl, rva,
+                    rva == kExpectedWeaponFireStartImplRva
+                        ? ""
+                        : " - DIFFERS from the documented build");
         }
-        *w.slot = scan.function;
-        uint32_t rva = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(scan.function) -
-                                            reinterpret_cast<uintptr_t>(image.base));
-        BVR_LOG("[b1r] native %s::%s = %p (RVA 0x%X%s)", w.cls, w.fn, scan.function, rva,
-                rva == w.expectedRva ? "" : " - DIFFERS from the documented build");
+    }
+    if (!out.weaponFireStart)
+        BVR_LOG("[b1r] AWeapon::GetPerfectFireStart impl NOT resolved (vtable read failed)");
+
+    // Same two functions one level up, for the probe's "a shot happened" line.
+    if (is_memory_valid(weaponVtbl, kWeaponInitDamageVtblOffset + sizeof(void*))) {
+        const uint8_t* impl = *reinterpret_cast<const uint8_t* const*>(
+            reinterpret_cast<const uint8_t*>(weaponVtbl) + kWeaponInitDamageVtblOffset);
+        if (impl >= image.base && impl < image.base + image.size) {
+            out.weaponInitDamage = const_cast<uint8_t*>(impl);
+            uint32_t rva = static_cast<uint32_t>(impl - image.base);
+            BVR_LOG("[b1r] AWeapon::InitiateDamage impl = %p (RVA 0x%X%s)", impl, rva,
+                    rva == kExpectedWeaponInitDamageRva ? "" : " - DIFFERS from the documented build");
+        }
+    }
+    const uint8_t* abilityInit = image.base + kAbilityInitDamageRva;
+    if (is_memory_valid(abilityInit, sizeof kAbilityInitDamagePrologue) &&
+        memcmp(abilityInit, kAbilityInitDamagePrologue, sizeof kAbilityInitDamagePrologue) == 0) {
+        out.abilityInitDamage = const_cast<uint8_t*>(abilityInit);
+        BVR_LOG("[b1r] UAttackAbility::InitiateDamage impl = %p (RVA 0x%X)", abilityInit,
+                kAbilityInitDamageRva);
+    }
+
+    // Ability side: the InitiateDamage call site calls it directly, so there is
+    // no slot to read - use the documented RVA, gated on a prologue match so a
+    // patched build refuses rather than hooking a stranger.
+    const uint8_t* ability = image.base + kAbilityFireStartImplRva;
+    if (is_memory_valid(ability, sizeof kAbilityFireStartPrologue) &&
+        memcmp(ability, kAbilityFireStartPrologue, sizeof kAbilityFireStartPrologue) == 0) {
+        out.abilityFireStart = const_cast<uint8_t*>(ability);
+        BVR_LOG("[b1r] UAttackAbility::GetPerfectFireStart impl = %p (RVA 0x%X)", ability,
+                kAbilityFireStartImplRva);
+    } else {
+        BVR_LOG("[b1r] UAttackAbility::GetPerfectFireStart impl prologue mismatch at RVA 0x%X"
+                " - plasmid aim unavailable", kAbilityFireStartImplRva);
     }
 }
 

--- a/src/game/bioshock1r/patterns.cpp
+++ b/src/game/bioshock1r/patterns.cpp
@@ -140,7 +140,40 @@ bool resolve(const bvr::pattern_scan::ProcessImage& image, Symbols& out) {
     BVR_LOG("[b1r] eventPlayerCalcView = %p (RVA 0x%X)", scan.function,
             static_cast<unsigned>(reinterpret_cast<uintptr_t>(scan.function) -
                                   reinterpret_cast<uintptr_t>(image.base)));
+
+    resolve_aim_natives(image, out); // fail-soft, logs each
     return true;
+}
+
+void resolve_aim_natives(const bvr::pattern_scan::ProcessImage& image, Symbols& out) {
+    using namespace bvr::pattern_scan;
+
+    struct Want {
+        const char* cls;
+        const char* fn;
+        void** slot;
+        uint32_t expectedRva;
+    } wants[] = {
+        {"AWeapon", "GetPerfectFireStart", &out.execWeaponFireStart, kExpectedWeaponFireStartRva},
+        {"AWeapon", "ApplyAimError", &out.execWeaponAimError, kExpectedWeaponAimErrorRva},
+        {"APawn", "GetViewPoint", &out.execPawnViewPoint, kExpectedPawnViewPointRva},
+        {"APawn", "GetViewDirection", &out.execPawnViewDir, kExpectedPawnViewDirRva},
+        {"AActor", "Trace", &out.execActorTrace, kExpectedActorTraceRva},
+    };
+
+    for (const Want& w : wants) {
+        NativeScanResult scan{};
+        if (!find_native_function(image, w.cls, w.fn, scan)) {
+            BVR_LOG("[b1r] native %s::%s NOT resolved (%zu string match(es), %zu table ref(s))",
+                    w.cls, w.fn, scan.stringMatches, scan.tableRefs);
+            continue;
+        }
+        *w.slot = scan.function;
+        uint32_t rva = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(scan.function) -
+                                            reinterpret_cast<uintptr_t>(image.base));
+        BVR_LOG("[b1r] native %s::%s = %p (RVA 0x%X%s)", w.cls, w.fn, scan.function, rva,
+                rva == w.expectedRva ? "" : " - DIFFERS from the documented build");
+    }
 }
 
 } // namespace bvr::b1r::patterns

--- a/src/game/bioshock1r/patterns.h
+++ b/src/game/bioshock1r/patterns.h
@@ -296,14 +296,60 @@ inline constexpr uint32_t kEngineVtableRva = 0xE0DFF4; // RTTI .?AVUGameEngine@@
 // Serialize entirely); vtbl+0x4 is Serialize(text, event), 2 args. The seam's
 // stub device returns 0 from every slot with callee-pop-8.
 
+// ---- M6 aim natives (session 10) -------------------------------------------
+// Resolved at runtime through the engine's own native-function lookup table
+// (pattern_scan::find_native_function - registration string
+// "int<Class>exec<Func>" -> its .data table entry -> impl pointer), so no
+// address below is hardcoded; the RVAs are recorded only as the expected
+// values for this build (2022-04-13) and as the cross-check the log prints.
+// Full derivation + the fire flow in ENGINE_NOTES "Fire flow / aim".
+//
+// All four are UnrealScript native thunks:
+//   void __thiscall execFoo(FFrame& Stack, void* Result)
+// FFrame layout used by the probe: +4 Node (UStruct* = the calling script
+// function), +8 Object (UObject* = the script object executing), +0xC Code.
+inline constexpr uint32_t kExpectedWeaponFireStartRva = 0x225B20; // AWeapon::GetPerfectFireStart
+inline constexpr uint32_t kExpectedWeaponAimErrorRva = 0x226A00;  // AWeapon::ApplyAimError
+inline constexpr uint32_t kExpectedPawnViewPointRva = 0x3CB990;   // APawn::GetViewPoint
+inline constexpr uint32_t kExpectedPawnViewDirRva = 0x3CB9D0;     // APawn::GetViewDirection
+inline constexpr uint32_t kExpectedActorTraceRva = 0x547BD0;      // AActor::Trace
+// APawn::GetViewPoint/GetViewDirection are thin exec wrappers around virtual
+// slots on the pawn vtable (byte offsets, from the disassembly of the thunks):
+// +0x360 returns the view point FVector*, +0x35C the view direction FVector*.
+inline constexpr uint32_t kPawnViewPointVtblOffset = 0x360;
+inline constexpr uint32_t kPawnViewDirVtblOffset = 0x35C;
+// FFrame field offsets (UE2 FFrame : FOutputDevice).
+inline constexpr uint32_t kFFrameNodeOffset = 0x4;
+inline constexpr uint32_t kFFrameObjectOffset = 0x8;
+inline constexpr uint32_t kFFrameCodeOffset = 0xC;
+// Class vtables (MSVC RTTI walk on the disk image: TypeDescriptor
+// `.?AV<name>@@` -> CompleteObjectLocator -> vtable). AShockPlayer is the
+// player's own pawn, which is what CalcView reports as the view actor during
+// normal gameplay - the cutscene guard is "view actor still has this vtable".
+inline constexpr uint32_t kShockPlayerVtableRva = 0xD82BB8;   // .?AVAShockPlayer@@
+inline constexpr uint32_t kPlayerWeaponVtableRva = 0xD8FF58;  // .?AVAPlayerWeapon@@
+inline constexpr uint32_t kHandsVtableRva = 0xD8A28C;         // .?AVAHands@@ (M7)
+
 struct Symbols {
     // void __thiscall(APlayerController* this, AActor** viewActor,
     //                 FVector* camLoc, FRotator* camRot)
     void* eventPlayerCalcView = nullptr;
+
+    // M6 aim seam natives; individually nullable (fail-soft: the aim probe
+    // just reports which ones resolved).
+    void* execWeaponFireStart = nullptr;
+    void* execWeaponAimError = nullptr;
+    void* execPawnViewPoint = nullptr;
+    void* execPawnViewDir = nullptr;
+    void* execActorTrace = nullptr;
 };
 
 // Runs all scans, logging each stage. False if anything failed to resolve.
 bool resolve(const bvr::pattern_scan::ProcessImage& image, Symbols& out);
+
+// The M6 aim natives only (called by resolve; separate so a rescan is cheap).
+// Fail-soft per symbol - each miss is logged and leaves its slot null.
+void resolve_aim_natives(const bvr::pattern_scan::ProcessImage& image, Symbols& out);
 
 // The live HorizontalFOV field of the UShockUserSettings singleton, or null.
 // Lazy by design: the object exists only after engine init, so this validates

--- a/src/game/bioshock1r/patterns.h
+++ b/src/game/bioshock1r/patterns.h
@@ -296,6 +296,51 @@ inline constexpr uint32_t kEngineVtableRva = 0xE0DFF4; // RTTI .?AVUGameEngine@@
 // Serialize entirely); vtbl+0x4 is Serialize(text, event), 2 args. The seam's
 // stub device returns 0 from every slot with callee-pop-8.
 
+// ---- M6 fire-flow seams (session 10) ---------------------------------------
+// THE aim seam. Both fire paths ask one function for "where does this shot
+// start and where does it point", and both are C++ implementations reached
+// through the class vtable / a direct call - NOT through the UnrealScript
+// exec thunks (native callers bypass those, which is why hooking the thunks
+// caught nothing). Derivation chain, all in ENGINE_NOTES "Fire flow / aim":
+//   script Ability.UseAbility -> native InitiateDamage (virtual)
+//     AWeapon::InitiateDamage      RVA 0x226050 -> calls [weaponVtbl+0x304]
+//     UAttackAbility::InitiateDamage RVA 0x1BBD80 -> calls 0x1BC220 directly
+//   ...each of which fills the out-params below, and THEN the engine applies
+//   its own spread (AWeapon::ApplyAimError impl 0x226AA0), so substituting
+//   here keeps per-weapon accuracy/spread intact.
+//
+// AWeapon::GetPerfectFireStart, __thiscall, ret 0xC:
+//   (FVector* outA, FVector* outB, FVector* outC)
+//   outA <- ownerPawn+0x1D8 (location-family field), outB <- [pawn+0x450]+0x1E4
+//   (direction-family field, the one ApplyAimError then perturbs).
+// UAttackAbility::GetPerfectFireStart, __thiscall, ret 0x10:
+//   (void* instigator, FVector* outA, FVector* outB, void* outC)
+//   same two sources, one slot over; the probe logs both so the labels are
+//   confirmed live rather than assumed.
+inline constexpr uint32_t kAttackAbilityVtableRva = 0xD7E9D4;   // .?AVUAttackAbility@@
+inline constexpr uint32_t kWeaponFireStartVtblOffset = 0x304;    // AWeapon vtable slot
+inline constexpr uint32_t kExpectedWeaponFireStartImplRva = 0x226840;
+inline constexpr uint32_t kAbilityFireStartImplRva = 0x1BC220;   // direct call target
+inline constexpr uint8_t kAbilityFireStartPrologue[6] = {0x55, 0x8B, 0xEC, 0x83, 0xE4, 0xF8};
+inline constexpr uint32_t kWeaponOwnerOffset = 0x454;      // AWeapon -> owning pawn
+inline constexpr uint32_t kAbilityInstigatorOffset = 0xF0; // UAttackAbility -> instigator
+// AActor field offsets used by the fire path (from the APawn::GetViewPoint /
+// GetViewDirection implementations, vtable slots +0x360 / +0x35C):
+//   +0x1D8 location-family FVector, +0x1E4 direction-family FVector,
+//   +0x550 eye height (GetViewPoint = location + eyeHeight on Z).
+inline constexpr uint32_t kActorLocOffset = 0x1D8;
+inline constexpr uint32_t kActorViewDirOffset = 0x1E4;
+// The two InitiateDamage implementations that CALL the fire-start functions
+// above (weapon = AWeapon vtable slot +0x2FC, ability = the direct call target
+// of UAttackAbility::execInitiateDamage). Both `ret 8` - thiscall taking an
+// FName by value. Hooked read-only in `vraim probe` as the "a shot happened,
+// and it came from this family" signal, which is how the flat verification
+// tells a gun shot from a plasmid cast from a Havok melee swing.
+inline constexpr uint32_t kWeaponInitDamageVtblOffset = 0x2FC;
+inline constexpr uint32_t kExpectedWeaponInitDamageRva = 0x226050;
+inline constexpr uint32_t kAbilityInitDamageRva = 0x1BBD80;
+inline constexpr uint8_t kAbilityInitDamagePrologue[6] = {0x55, 0x8B, 0xEC, 0x83, 0xE4, 0xF8};
+
 // ---- M6 aim natives (session 10) -------------------------------------------
 // Resolved at runtime through the engine's own native-function lookup table
 // (pattern_scan::find_native_function - registration string
@@ -335,13 +380,12 @@ struct Symbols {
     //                 FVector* camLoc, FRotator* camRot)
     void* eventPlayerCalcView = nullptr;
 
-    // M6 aim seam natives; individually nullable (fail-soft: the aim probe
-    // just reports which ones resolved).
-    void* execWeaponFireStart = nullptr;
-    void* execWeaponAimError = nullptr;
-    void* execPawnViewPoint = nullptr;
-    void* execPawnViewDir = nullptr;
-    void* execActorTrace = nullptr;
+    // M6 fire-flow seams; individually nullable (fail-soft - aim just reports
+    // which ones resolved and stays off for the rest).
+    void* weaponFireStart = nullptr;  // AWeapon::GetPerfectFireStart impl
+    void* abilityFireStart = nullptr; // UAttackAbility::GetPerfectFireStart impl
+    void* weaponInitDamage = nullptr;  // AWeapon::InitiateDamage impl (telemetry)
+    void* abilityInitDamage = nullptr; // UAttackAbility::InitiateDamage impl (telemetry)
 };
 
 // Runs all scans, logging each stage. False if anything failed to resolve.

--- a/src/game/bioshock1r/ue_math.h
+++ b/src/game/bioshock1r/ue_math.h
@@ -1,0 +1,87 @@
+#pragma once
+// XR <-> Unreal (Vengeance/UE2.5) conventions for this adapter. ONE copy,
+// shared by the camera drive (camera.cpp) and the aim ray (aim.cpp): if these
+// ever disagree the crosshair and the bullet disagree, which is exactly the
+// bug M6 exists to fix.
+//
+// XR LOCAL space: right +X, up +Y, forward -Z, meters, right-handed.
+// UE2.5: forward +X, right +Y, up +Z; FRotator 65536 units per turn, positive
+// yaw turns toward +Y (right), positive pitch looks up, positive roll tilts
+// clockwise (right).
+
+#include <cmath>
+#include <cstdint>
+
+namespace bvr::b1r {
+
+struct FVector { float x, y, z; };             // Unreal units
+struct FRotator { int32_t pitch, yaw, roll; }; // 65536 units per full turn
+
+constexpr float kPi = 3.14159265f;
+constexpr float kRotUnitsPerDegree = 65536.0f / 360.0f;
+constexpr float kRotUnitsPerRadian = 65536.0f / (2.0f * kPi);
+constexpr float kRadToDeg = 57.29578f;
+
+inline void quat_rotate(float qx, float qy, float qz, float qw, const float v[3],
+                        float out[3]) {
+    float t[3] = {2.0f * (qy * v[2] - qz * v[1]), 2.0f * (qz * v[0] - qx * v[2]),
+                  2.0f * (qx * v[1] - qy * v[0])};
+    out[0] = v[0] + qw * t[0] + (qy * t[2] - qz * t[1]);
+    out[1] = v[1] + qw * t[1] + (qz * t[0] - qx * t[2]);
+    out[2] = v[2] + qw * t[2] + (qx * t[1] - qy * t[0]);
+}
+
+inline void xr_to_ue(const float v[3], float out[3]) {
+    out[0] = -v[2]; // XR -Z (forward) -> UE +X
+    out[1] = v[0];  // XR +X (right)   -> UE +Y
+    out[2] = v[1];  // XR +Y (up)      -> UE +Z
+}
+
+struct UeAngles { float yawRad, pitchRad, rollRad; };
+
+// Euler angles (UE frame) of an XR-space orientation quaternion.
+inline UeAngles ue_angles_from_xr_quat(float qx, float qy, float qz, float qw) {
+    const float kFwd[3] = {0.0f, 0.0f, -1.0f};
+    const float kUp[3] = {0.0f, 1.0f, 0.0f};
+    float fxr[3], uxr[3], f[3], u[3];
+    quat_rotate(qx, qy, qz, qw, kFwd, fxr);
+    quat_rotate(qx, qy, qz, qw, kUp, uxr);
+    xr_to_ue(fxr, f);
+    xr_to_ue(uxr, u);
+
+    UeAngles a{};
+    a.yawRad = atan2f(f[1], f[0]);
+    float len2d = sqrtf(f[0] * f[0] + f[1] * f[1]);
+    a.pitchRad = atan2f(f[2], len2d);
+    if (len2d > 0.001f) { // gimbal guard: keep roll 0 when looking straight up/down
+        // Zero-roll frame from the forward vector, then measure the actual up
+        // vector against it. rn = normalize(cross(worldUp, f)), un = cross(f, rn).
+        float rn[3] = {-f[1] / len2d, f[0] / len2d, 0.0f};
+        float un[3] = {-f[2] * rn[1], f[2] * rn[0], f[0] * rn[1] - f[1] * rn[0]};
+        a.rollRad = atan2f(u[0] * rn[0] + u[1] * rn[1],
+                           u[0] * un[0] + u[1] * un[1] + u[2] * un[2]);
+    }
+    return a;
+}
+
+// Unit forward vector of an FRotator (UE convention), for turning an aim
+// rotation back into a direction vector.
+inline void ue_rot_to_dir(const FRotator& r, float out[3]) {
+    float yaw = static_cast<float>(r.yaw) / kRotUnitsPerRadian;
+    float pitch = static_cast<float>(r.pitch) / kRotUnitsPerRadian;
+    float cp = cosf(pitch);
+    out[0] = cosf(yaw) * cp;
+    out[1] = sinf(yaw) * cp;
+    out[2] = sinf(pitch);
+}
+
+// FRotator (pitch/yaw, roll 0) of a UE-space direction vector.
+inline FRotator ue_dir_to_rot(const float d[3]) {
+    FRotator r{};
+    float len2d = sqrtf(d[0] * d[0] + d[1] * d[1]);
+    r.yaw = static_cast<int32_t>(atan2f(d[1], d[0]) * kRotUnitsPerRadian);
+    r.pitch = static_cast<int32_t>(atan2f(d[2], len2d) * kRotUnitsPerRadian);
+    return r;
+}
+
+} // namespace bvr::b1r


### PR DESCRIPTION
## What this is

M6 (decoupled aim) part 1: the engine's fire pipeline is mapped, the aim seam is
built and command-gated, and the plasmid side is confirmed firing live. The aim
is **not yet decoupled end to end** - the trace *direction* lives one layer
deeper than the seam (details below and in `docs/ENGINE_NOTES.md`).

## Highlights

- **The engine ships a symbol table for name-based natives.** Every `native`
  UnrealScript function has a `.data` entry `{ "int<Class>exec<Func>", impl, 0 }`.
  `pattern_scan::find_native_function` reads it, so no aim address is hardcoded -
  all five lookups resolved at their documented RVAs on the first boot. Dumping
  the table offline (1822 entries) is now the fastest way to answer engine
  questions; M7's `AHands` natives are already visible in it.
- **Fire flow** (`ENGINE_NOTES` "Fire flow / aim"): trigger -> `Weapon.BeginFiring`
  -> `Firing` state -> anim notify -> `AttackAbility.UseAbility` -> native
  `InitiateDamage` -> `GetPerfectFireStart` -> damage factory. Attacks are
  abilities (plasmids included); the wrench damages via a Havok collision phantom
  and never traces.
- **Dead end recorded, not hidden**: the first build hooked the four aim `exec*`
  thunks and caught ZERO calls live, because native callers reach the C++
  implementation directly. The shipped seams hook implementations - weapon side
  by reading the RTTI-derived vtable slot, ability side by a prologue-checked RVA.
- **`game/bioshock1r/aim.cpp`**: per-hand rays built inside the CalcView frame
  from XR grip poses, ownership gates using the engine's own instigator check,
  value-driven out-param substitution so `ApplyAimError` still applies the
  weapon's spread on top, and self-expiring `vraim test l|r <yaw> <pitch>`
  synthetic aim for headset-free verification.
- **Investigation tooling that removes rebuild cycles**: `vraim scan <Class>
  <Func>` (any name-based native, read-only), `vraim scanimpl <rva> <stackArgs>`
  (any C++ implementation), and headless UELib decompiling via
  `tools/uscript/dump.ps1` (loads ShockGame.U in under a second).

## Verified live

- Both fire-start implementations resolve at the documented RVAs.
- `UAttackAbility::GetPerfectFireStart` fires on an Electro Bolt cast, with the
  correct `this` vtable and ownership gating.
- Hand attribution learns from the trigger the bridge itself composes ("learned
  LEFT-hand (plasmid) object" on the first cast).
- ORIGIN substitution lands (`SUB(L)` with our values); `vraim off` restores the
  engine's own numbers. No crashes or new dumps across ~6 boots of hooking
  engine internals.

## Known open (next session)

1. `GetPerfectFireStart` fills POSITIONS only - the trace DIRECTION comes from
   the damage factory (probe target: factory vtbl `+0xEC`). `APawn::GetViewDirection`
   and `AShockPlayer::GetViewPoint` were probed and ruled out.
2. The WEAPON path needs a ranged weapon to confirm end to end; the only save in
   the tree spawns with wrench + Electro Bolt, and the wrench never traces.
3. Reticle at the aim ray is not started (M6 rung 2).