### PR TITLE
M7.5: body-follows-head yaw transfer

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -360,3 +360,32 @@ runtime.
   camera. Fallback ladder if the dolly source stays unfound: (a) accept the offset with
   matched lens + exact laterals; (b) the vm_draw replay lane (render the rig ourselves at
   the controller, engine rig hidden - the user's original proposal, still on the table).
+- **2026-07-27 (session 17) - M7.5: transfer the head-look yaw into the body every frame,
+  and let the RECENTER REFERENCE absorb exactly what the body took. This OVERTURNS the
+  M6-era "rejected: writing the pawn/controller Rotation field" note above.** That
+  rejection was correct for M6's question (aim) and wrong for this one (locomotion): the
+  objection was that the rotation field "also drives movement direction and pawn facing",
+  which is precisely what M7.5 needs it to do. The user found the root cause by playing -
+  the body only turns with the right stick, so with the head turned, left-stick forward
+  walks along the old facing, the viewmodel's composition frame drifts from the hand, and
+  past ~90 deg the rig is culled. `body.cpp` writes `PC+0x1E8` (the controller's
+  `Rotation.Yaw` - located and proven in ENGINE_NOTES session 17) once per rendered frame.
+  Two design choices carry the risk. (1) **The recenter reference absorbs the transfer.**
+  The camera and both halves of the controller-to-world mapping depend only on
+  `gameYaw - recenterYaw`, so moving both by the same amount is a pure relabel - the
+  user's hard non-regression requirement (the hand must never follow the head again)
+  becomes a theorem rather than a tolerance, and the yaw path was converted to integer
+  rotator units so the cancellation is exact. `on_calcview` returns the units actually
+  COMMITTED, never the units requested, so the two can never drift apart. (2) **A probe
+  handshake replaces a watchdog**: on arm the module transfers 1.1 deg and checks the body
+  actually moved by it before scaling up, undoing itself and hard-disabling after three
+  failures. A slow rolling watchdog would have let tens of degrees of camera error
+  accumulate before tripping; this bounds the worst case to ~1.1 deg for one frame. The
+  gameplay-view guard deliberately drops the `viewActor == pc` escape hatch that aim.cpp
+  keeps for the menu attract scene - the aim ray wants the menu, a body write does not.
+  Rejected: steering the body through synthetic right-stick input (native and safe, but
+  the applied amount is unknowable per frame, so the recenter absorption lags by a frame -
+  exactly the drift the invariant forbids); writing the pawn rotation (it does not move
+  the camera, so absorbing into the recenter would counter-rotate the view every frame,
+  and the engine re-stamps it from the controller anyway - live-confirmed the pawn follows
+  our PC write for free).

--- a/docs/ENGINE_NOTES.md
+++ b/docs/ENGINE_NOTES.md
@@ -1253,6 +1253,55 @@ collision geometry yields a plausible-looking heading that is pure geometry
 on straightness <= 5% of path length and treat a failure as VOID, not as a
 result.
 
+**THE RENDER LOCK'S CORRECTION GOES FLAT UNDER HEAD-LOOK - the transfer's
+second, unplanned payoff.** Parked hand, `simhead` swept +-30 deg about a
+45 deg base, `[tlm] lock` read at every step. The predicted world NDC (`tgt`)
+and `df` came out **identical at every step in both conditions** (the hand is
+world-parked and the camera is unchanged, exactly as the invariant requires),
+and `targetYaw` held at 16500 throughout. What changed was the correction:
+
+| head delta | predicted ndcX | `lat` OFF | `lat` ON | actorYaw OFF | actorYaw ON |
+|---|---|---|---|---|---|
+| -30 | +0.088 | 1.04 | 4.50 | 16500 | 19231 |
+| -15 | -0.073 | 2.67 | 4.50 | 16500 | 21961 |
+| 0   | -0.245 | 6.12 | 4.58 | 16500 | 24692 |
+| +15 | -0.458 | 9.16 | 4.73 | 16500 | 27423 |
+| +30 | -0.779 | 11.59 | 4.96 | 16500 | 30153 |
+
+With the transfer OFF the lateral correction swings **10.5 UU** across the
+sweep (it scales with the camera-vs-actor split, which is what the lock exists
+to cancel); with it ON the correction is **flat within 0.46 UU** and actorYaw
+tracks the camera in exact 2731-unit (15 deg) steps. `depth` behaves the same
+way: a 6.1 UU swing becomes 1.0. Because the lock is applied at gain 0.9, a
+swinging correction leaves a swinging residual - the "gun drifts as you look
+around" percept - while a constant one leaves a constant, trimmable offset.
+
+**And the ON value lands on the calibrated one: `lat` 4.58 at head 45 with the
+transfer on vs 4.57 at head 0 with it off** - i.e. the transfer restores, at
+every head angle, the exact zero-split configuration that session 16
+calibrated and the user verified in the headset.
+
+**The rendered viewmodel DOES move between the two states, and that is the
+mechanism working, not a regression.** At head 45 the world region of the
+frame is pixel-identical off vs on (mean abs diff 0.048, against a 0.3
+same-condition floor) while the gun+arm region reads 23.4 - and crop-and-look
+shows the gun is not merely shifted but **viewed from a different angle**. The
+renderer orients the foreground rig by the ACTOR fields, so with the transfer
+on the rig is viewed from the camera's own orientation instead of from a
+45-deg-stale body facing. The lock corrects POSITION, never viewing angle,
+which is why it could never fully paper this over. Removing the split at its
+source is what the ENGINE_NOTES session-12 finding ("the user saw the gun move
+REVERSED... actor-frame rendering composed against the camera frame") was
+always pointing at.
+
+**Instrument that failed, recorded so it is not retried blind:** tracking the
+gun across the sweep with an NCC template - even re-localised every step and
+re-cut from the previous step's match - produced correlations of 0.56-0.79 at
+every step but the trivial self-match. The composition changes too much per
+15 deg for template chaining to survive, so every pixel number from it is
+VOID. The `[tlm] lock` telemetry above is the template-free instrument that
+answers the same question, and it should be preferred.
+
 **Nuance the flat sweep exposed - the cull is direction-dependent.** `simpose`
 parks the synthetic hand in the RECENTER frame, i.e. it models "the head turns
 but the hand stays put in the world". In that case the transfer *increases*

--- a/docs/ENGINE_NOTES.md
+++ b/docs/ENGINE_NOTES.md
@@ -1168,6 +1168,101 @@ resumes. Also noted: `xr: sr tag ring skewed (depth 8) - cleared` repeats
 while the session is VISIBLE/idle with presents at 0 - harmless in that
 state, recovers on resume.
 
+## Body facing / control rotation (M7.5 session 17, 2026-07-27)
+
+**THE PLAYERCONTROLLER'S ROTATION IS AT `PC + 0x1E4`, it is the view rotation
+the camera comes from, an ADDITIVE YAW WRITE TO IT STICKS, and it reaches
+locomotion.** Nine-step live probe on the wall save, one boot, all positive -
+the `vrbody probe` telemetry line plus the `vrbody poke <deg>` one-shot write
+(both in `body.cpp`). This closes the session-11 open question and overturns
+the ARCHITECTURE decision-log entry that rejected writing the controller
+rotation.
+
+- **It is the AActor layout, inherited.** `AController` derives from `AActor`,
+  so `kActorViewDirOffset` (0x1E4, already used on AHands and the pawn) is the
+  controller's `Rotation` too. Live: `PC.rot=(144 116 0)` vs
+  `pawn.rot=(0 116 0)` - **same yaw, and the PC carries a NON-ZERO PITCH while
+  the pawn's is 0**. That is the discriminator: session 11's inference
+  ("pawns keep pitch 0, so the pitched view rotation lives on the
+  PlayerController") was right, and this is the field. Yaw is the second
+  int32, i.e. `PC+0x1E8`.
+- **An additive write LANDS and HOLDS.** `vrbody poke 40` wrote yaw
+  116 -> 7398; the camera swung 40 deg and the value held across 11 telemetry
+  samples over 5.5 s. Nothing recomputes it from another authority.
+- **The pawn follows for free.** `pawn.yaw` tracked to 7398 on the next sample
+  (the engine's own FaceRotation propagation), so a **PC-only write is
+  sufficient** - no pawn write, and therefore no risk of desyncing a colliding
+  actor's rotation. `vrbody field pawn|both` exists but is not needed.
+- **The engine's own turn COMPOSES on our value.** A synthetic right-stick
+  turn took 7398 -> 13324, continuing from the written value rather than
+  snapping to a stick-derived absolute. The rotation update is incremental
+  (`Rotation.Yaw += delta`), which is what makes an additive transfer safe
+  alongside normal player turning.
+- **It reaches locomotion.** With the body poked to yaw 13324 (73.19 deg), a
+  synthetic left-stick-forward burst walked 780 UU along heading **72.79 deg**
+  - a 0.4 deg match to the written facing, and ~73 deg away from the original
+  one. So `PlayerWalking` composes movement against this rotation (directly or
+  through the pawn copy).
+- Pitch is deliberately never written: the engine applies a signed clamp to it
+  and the pawn is kept at pitch 0 by design. Yaw only, masked `& 0xFFFF` (the
+  engine keeps components in [0, 65535]; the live read of 55599 and 13324 are
+  both in range).
+
+**THE YAW-TRANSFER INVARIANT (why this cannot re-couple the hand).** The final
+camera and BOTH halves of the XR-controller-to-world mapping are functions of
+one composite:
+
+```
+camera yaw = gameYaw + (headYaw - recenterYaw)
+hand rot   = (gameYaw - recenterYaw) + controller yaw
+hand pos   = base + R(gameYaw - recenterYaw) * xr_to_ue(pos - recenterP) * scale
+```
+
+So adding T to the body while adding exactly T to the recenter reference
+leaves the camera and the mapping unchanged - only the body/head-look SPLIT
+relabels. Done in integer rotator units it is exact:
+`rot->yaw' = (gameYaw + T) + (residual - T) = gameYaw + residual`. That is why
+`camera.cpp` keeps the recenter yaw as `int32_t g_recenterYawUnits` (also
+wrap_rot-bounded, so it cannot accumulate into ulps larger than a rotation
+unit) and why `body::on_calcview` RETURNS the units actually committed rather
+than the units requested - the two absorbed quantities are the same integer.
+
+**Flat-measured, wall save, one boot (session 17):**
+
+- Composite `gameYaw - recenterYaw` = **1.27742 rad at every head angle**
+  (0/30/45/90/-45, transfer on and off) - five decimal places, unchanged.
+- True A/B at head 45: transfer OFF vs ON, the hand's world pose from the
+  `[tlm] xrmap` fixed-pose probe read `rot.yaw=13323` in **both** and
+  `camYaw=21516` in **both**, while gameYaw and recenterYaw each moved
+  +0.78540 rad. Position differed by 0.001 UU (float rounding; the gate was
+  0.05).
+- `[tlm] yawstep max=+0 units, nbig=0` across the arm transient and steady
+  state at ~1650 frames/s - the camera does not move at all when the transfer
+  arms, not merely "within tolerance".
+- Walk direction, transfer **OFF**: 116.49 deg and 116.67 deg at two head
+  angles **90 deg apart** - the walk tracked the body (118.19) and ignored the
+  head. That is the reported defect as a number.
+- Walk direction, transfer **ON**: at head +45, walk 163.19 / body 163.19 /
+  camera 163.19; at head -45, walk 73.20 / body 73.19 / camera 73.19. Walk ==
+  body == camera to 0.01 deg, and the pair spans 89.99 deg for a 90 deg head
+  change. Both bursts >800 UU with 0.25% straightness.
+
+**Instrument caveat recorded the hard way:** a walk burst that slides along
+collision geometry yields a plausible-looking heading that is pure geometry
+(one burst read 105.65 deg with 16% perpendicular deviation). Gate every burst
+on straightness <= 5% of path length and treat a failure as VOID, not as a
+result.
+
+**Nuance the flat sweep exposed - the cull is direction-dependent.** `simpose`
+parks the synthetic hand in the RECENTER frame, i.e. it models "the head turns
+but the hand stays put in the world". In that case the transfer *increases*
+hand-vs-body (0 -> -45 deg at head 45, measured: actor yaw 21516 vs target yaw
+13323). The reported symptom is the other case - the user physically swivels,
+so head AND hand rotate together in the world while the in-game body does not
+- and there the transfer drives hand-vs-body to ~0. Both are real; the
+residual/cull sweep is the instrument that quantifies where the boundary sits
+in each direction.
+
 ## UnrealScript findings
 
 _(Summaries only - never paste decompiled code. Tooling: UE Explorer/UELib on

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -374,9 +374,12 @@ controller, like a native VR game. Explicitly NOT wanted: bent arms, elbows, IK,
       Note the sweep also exposed that the two physical cases differ: a head-only glance with
       the hand parked in the world *increases* hand-vs-body, while the reported case (the
       user swivels, so head and hand rotate together) drives it to ~0.
-- [ ] **Done when:** the user confirms in the headset that walking forward goes where they
-      look, the gun stays aligned with the laser at any reachable aim angle, the rig never
-      vanishes in normal play - and the hand still does NOT follow the head.
+- [x] **Done when:** the user confirms in the headset. **PASSED 2026-07-27** - "this is
+      perfect... the stick was working as expected, the models didn't move when I moved my
+      head". One tuning change, now the shipped default: `vrbody deadzone` 0 -> **23 deg**,
+      which removes the last "the gun moves with the camera a bit" percept (inside the band
+      the body does not steer, so a glance leaves the viewmodel world-locked; beyond it the
+      body trails the head by exactly the band width). M7.5 DONE.
 
 ## M8 - Release quick phase + HUD usability (~1–2 sessions)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -342,26 +342,41 @@ controller, like a native VR game. Explicitly NOT wanted: bent arms, elbows, IK,
 > the user found one root cause that still degrades play - and it is a CAMERA/LOCOMOTION
 > defect, not a viewmodel one. Full spec + the invariant in STATUS "Next steps" item 1.
 
-- [ ] **Body-follows-head yaw transfer.** The body/pawn facing only rotates with the RIGHT
-      STICK, so with the head physically turned: left-stick "forward" walks along the OLD
-      facing (the user's decisive observation), weapon-laser alignment degrades as the hand
-      aims away from that facing, and past ~90 deg the rig leaves the authored bounds and is
-      CULLED (returns when the stick catches up). Fix: each frame transfer the head-look yaw
-      into the body facing while subtracting the same amount from the camera's additive yaw,
-      so the camera is unchanged and the invisible body re-aligns under the view.
-- [ ] **HARD INVARIANT - no regression of head decoupling (the user's explicit
-      requirement).** The controller-to-world mapping composes through the body yaw, so the
-      transfer must leave the final camera AND that composite mapping bit-identical (the
-      recenter reference absorbs the transferred yaw). Gate: the parked-hand simhead sweep
-      (gun glued to the world) and the full session-16 acceptance ladder pass UNCHANGED
-      before it ships; the in-headset checklist re-verifies decoupling as item 1.
-- [ ] **Residual edge alignment + the cull angle**, measured after the transfer: simpose
-      sweep at 0/30/60/80/90/100/120 deg from the facing, rendered barrel vs target angle
-      per step, exact cull-on/off angle from both directions; `vrbones lockgain` A/B if the
-      error still grows with angle.
-- [ ] **Done when:** walking forward goes where the user looks, the gun stays aligned with
-      the laser at any reachable aim angle, the rig never vanishes in normal play - and the
-      hand still does NOT follow the head.
+- [x] **Body-follows-head yaw transfer.** SHIPPED session 17, default ON, armed by VR
+      PRESET 1; `vrbody off` is the live A/B. The body facing lives at the
+      PlayerController's `Rotation.Yaw` (`PC+0x1E8`) - located and proven live: non-zero
+      pitch where the pawn's is 0, an additive write holds, the pawn follows for free, the
+      engine's own turn composes on our value, and the walk direction follows it to 0.4 deg
+      (ENGINE_NOTES session 17). `body.cpp` transfers the head-look yaw once per rendered
+      frame behind a probe handshake and a gameplay-view guard.
+- [x] **HARD INVARIANT - no regression of head decoupling.** Held exactly, not merely
+      within tolerance. The composite `gameYaw - recenterYaw` measured **1.27742 rad at
+      every head angle** (0/30/45/90/-45) in both states; at head 45 the hand's world pose
+      (`rot.yaw=13323`) and the camera (`camYaw=21516`) were **bit-identical** off vs on
+      while gameYaw and recenterYaw each moved +0.78540 rad; `[tlm] yawstep` showed
+      **max=0 units, nbig=0** through the arm transient. The yaw path was converted to
+      integer rotator units to make the cancellation exact.
+- [x] **Feature verified flat.** Walk direction with the transfer OFF: 116.49 and 116.67 deg
+      at two head angles 90 deg apart (it tracked the body and ignored the head - the defect
+      as a number). With it ON: walk == body == camera to 0.01 deg at both +45 and -45, the
+      pair spanning 89.99 deg for a 90 deg head change. Fire test 57->51 for 6 pulls, dumps
+      8->8, stereo clean, 20-step +-90 soak returned camYaw and the recenter exactly to
+      their starting values.
+- [x] **Residual sweep** (partial, and it found something better than expected): with the
+      transfer ON the render lock's lateral correction goes **flat within 0.46 UU** across a
+      +-30 deg head sweep instead of swinging 10.5 UU, landing on the same 4.57 the
+      calibrated zero-split configuration uses - so the transfer restores the
+      headset-verified session-16 regime at every head angle. Full table in ENGINE_NOTES.
+- [ ] **Still open - the exact cull angle.** The 0/30/60/80/90/100/120 deg simpose sweep and
+      the cull-on/off boundary in both directions were NOT measured: NCC template chaining
+      broke down across the composition changes (correlations 0.56-0.79, every number void -
+      recorded in ENGINE_NOTES so it is not retried blind). Needs a template-free instrument.
+      Note the sweep also exposed that the two physical cases differ: a head-only glance with
+      the hand parked in the world *increases* hand-vs-body, while the reported case (the
+      user swivels, so head and hand rotate together) drives it to ~0.
+- [ ] **Done when:** the user confirms in the headset that walking forward goes where they
+      look, the gun stays aligned with the laser at any reachable aim angle, the rig never
+      vanishes in normal play - and the hand still does NOT follow the head.
 
 ## M8 - Release quick phase + HUD usability (~1–2 sessions)
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,8 +1,89 @@
-# Project status
+﻿# Project status
 
 > Handoff file. Rewrite "Current state" and "Next steps" every session; append to the session log.
 
-## Current state (2026-07-27, session 16 part 3 - WORLDSCALE 100 BY USER CALIBRATION; VR PRESET 1 SHIPS)
+## Current state (2026-07-27, session 17 - M7.5 BODY-FOLLOWS-HEAD YAW TRANSFER SHIPS; INVARIANT HELD EXACTLY)
+
+**Branch `m7.5-body-yaw-transfer` (NOT merged - the user reviews by PR after
+their headset run). Everything below is flat-verified; the in-headset verdict
+is the only open gate.**
+
+**The root cause the user found by playing is fixed. The body facing is the
+PlayerController's `Rotation.Yaw` at `PC+0x1E8`** - found and proven live in
+one boot, nine probe steps, all positive (ENGINE_NOTES session 17): it carries
+a non-zero pitch where the pawn's is 0, an additive yaw write LANDS and HOLDS
+across samples, the pawn follows for free (so a PC-only write is enough), the
+engine's own turn COMPOSES on our value rather than snapping, and a synthetic
+walk burst followed the written facing to **0.4 deg**. That last step proved
+the whole milestone before a line of transfer code ran.
+
+**THE HARD INVARIANT HELD EXACTLY - not "within tolerance".** The camera and
+both halves of the controller-to-world mapping depend only on the composite
+`gameYaw - recenterYaw`, so the transfer adds T to the body and exactly T to
+the recenter reference. Measured: the composite read **1.27742 rad at every
+head angle** (0/30/45/90/-45) in both states; at head 45 the hand's world pose
+(`rot.yaw=13323`) and the camera (`camYaw=21516`) were **bit-identical** off vs
+on while gameYaw and recenterYaw each moved +0.78540 rad; `[tlm] yawstep`
+showed **max=0 units, nbig=0** through the arm transient at ~1650 frames/s.
+The yaw path was converted to integer rotator units so the cancellation is
+exact rather than approximate, and `body::on_calcview` returns the units
+COMMITTED (never the units requested), so the two absorbed quantities are the
+same integer and cannot drift apart.
+
+**The feature, as numbers.** Walk direction with the transfer OFF: 116.49 and
+116.67 deg at two head angles **90 deg apart** - it tracked the body (118.19)
+and ignored the head, which is the reported defect measured. With it ON: at
+head +45, walk 163.19 / body 163.19 / camera 163.19; at head -45, walk 73.20 /
+body 73.19 / camera 73.19. Walk == body == camera to 0.01 deg, the pair
+spanning 89.99 deg for a 90 deg head change.
+
+**A second payoff nobody planned: the render lock's correction goes FLAT under
+head-look.** Parked hand, +-30 deg head sweep - with the transfer off the
+lateral correction swings **10.5 UU** (it scales with the camera-vs-actor
+split); with it on it is **flat within 0.46 UU**, and it lands on `lat` 4.58
+against the 4.57 that the calibrated, headset-verified zero-split
+configuration uses. So the transfer restores the session-16 regime at *every*
+head angle instead of only at head 0. Because the lock runs at gain 0.9, a
+swinging correction leaves a swinging residual (the "gun drifts as you look
+around" percept) while a constant one leaves a constant, trimmable offset.
+
+**Be ready for this in the headset: the viewmodel WILL render differently with
+`vrbody on` vs `off`, and that is the mechanism working.** At head 45 the
+world region of the frame is pixel-identical between the two (mean abs diff
+0.048 against a 0.3 floor - the camera really is unchanged) while the gun+arm
+region reads 23.4, and looking at the crops the gun is not merely shifted but
+**viewed from a different angle**. The renderer orients the foreground rig by
+the ACTOR fields, so with the transfer on the rig is viewed from the camera's
+own orientation instead of from a 45-deg-stale body facing. The lock corrects
+position, never viewing angle - which is why it could never fully paper this
+over.
+
+**Shipped defaults: `vrbody` ON, armed by VR PRESET 1 (after the viewmodel,
+before vrstereo). `vrbody off` is the one-command live A/B against the
+session-16 build.** Knobs `vrbody rate` (0 = instant 1:1, the user's call) and
+`vrbody deadzone` (0) persist to vrpreset.ini. Safety: a probe handshake
+transfers 1.1 deg and verifies the body actually moved before scaling up,
+undoing itself and hard-disabling after three failures (worst-case visible
+error ~1.1 deg for one frame); a gameplay-view guard that deliberately drops
+aim.cpp's menu escape hatch; PC-pointer and discontinuity resets; a
+once-per-present gate.
+
+**Clean-boot acceptance (promoted build, under vrstereo):** fire test 57->51
+for 6 pulls with the transfer live, dumps 8->8, stereo heartbeat clean
+(mode=1T, presents 336/s = 2x build 168/s, guardskips 0), preset echo chain in
+order, ini round-trip, and a 20-step alternating +-90 deg soak that returned
+camYaw to its exact starting value with the recenter back to 0.0000 deg.
+
+**One thing did NOT get measured and is honestly open: the exact cull angle.**
+The 0/30/60/80/90/100/120 deg sweep needs a template-free instrument - NCC
+template chaining broke down across the composition changes (correlations
+0.56-0.79 at every step, so every pixel number from it is void; recorded in
+ENGINE_NOTES so it is not retried blind). The sweep did expose that the two
+physical cases differ in sign: a head-only glance with the hand parked in the
+world *increases* hand-vs-body, while the reported case (the user swivels, so
+head and hand rotate together) drives it to ~0.
+
+## Previous state (2026-07-27, session 16 part 3 - WORLDSCALE 100 BY USER CALIBRATION; VR PRESET 1 SHIPS)
 
 **The size problem dissolved without touching the mesh: the user found that
 worldScale 100 makes the viewmodel read PERFECT in-headset - size AND
@@ -864,61 +945,42 @@ https://github.com/mohamad-balouza/bioshock-vr. Em dashes banned repo-wide.
 
 ## Next steps
 
-0. **DONE (part 4): the user verified the part-3 build in-headset -
-   "perfect, it works perfectly."** Head-offset defaults set to 0 at their
-   request (they tune by eye + "Save preset values").
-1. **SESSION 17 FOCUS - BODY-FOLLOWS-HEAD yaw transfer (root cause found
-   by the user, part 4):** the body/pawn facing only rotates with the
-   right stick, so THREE symptoms hang off one root: left-stick "forward"
-   walks along the OLD body facing when the user physically looks away
-   (their decisive observation); the viewmodel's composition frame is the
-   body facing, so hand-vs-body angle grows with head-look and alignment
-   degrades; past ~90 deg the rig leaves the authored bounds and the
-   engine CULLS it (reappears when the stick catches up). THE FIX: each
-   frame, transfer the head-look yaw into the body facing and subtract the
-   same amount from the camera's additive yaw - the camera is unchanged
-   (seamless), the invisible body re-aligns under the view, stick-forward
-   = look direction, the viewmodel stays deep in its envelope.
-   **HARD INVARIANT - THE USER'S NON-REGRESSION REQUIREMENT: the hand must
-   NOT move with the head/camera again.** The controller->world mapping
-   composes through the body yaw (frame_context.h rotates the
-   recenter-local pose out by gameYaw), so transferring yaw into the body
-   WITHOUT rotating the recenter yaw reference by the same amount
-   re-couples the hand to the head - the exact defect sessions 12-16
-   killed. The transfer must leave the final camera AND the composite
-   controller-to-world mapping bit-identical; only the body/head-look
-   split of the yaw relabels (the recenter reference absorbs the
-   transferred amount). GATE: the parked-hand simhead sweep (gun glued to
-   the world) and the full acceptance ladder pass UNCHANGED before the
-   transfer ships - any drift there is an instant stop-and-fix, and the
-   in-headset checklist must re-verify head-decoupling explicitly.
-   Implement in the camera drive (the PC control-rotation write side of
-   the additive yaw in camera.cpp; `driveYawOffsetRad` is the amount to
-   transfer); watch for: how the game maps the left stick (control
-   rotation vs pawn rotation), recenter semantics, cutscene/vehicle guards
-   (view-actor vtable predicate), and the lock model's actor-rot inputs
-   (the transfer makes the zero-split assumption BETTER). Verify flat with
-   simhead + synthetic left-stick input (walk direction vs look
-   direction), then the angle sweep below as the before/after instrument.
-   THE RESIDUAL INVESTIGATION (after the transfer lands): holding the HAND
-   far off the gaze still reaches large hand-vs-body angles. Park simpose
-   at yaw 0/30/60/80/90/100/120 from the facing, measure rendered-barrel
-   vs target per step, find the exact cull angle both directions. If the
-   error grows ~linearly, A/B lockgain 0.9 vs 1.0 at the worst angle.
-   THE QUEUE AFTER SESSION 17 (user's calls, part 4): the M8 QUICK PHASE,
-   whose first two items are RELEASE BLOCKERS because they hit every user -
-   (a) the flat-screen mirror (the window alternates L/R under stereo, so
-   the mod cannot be streamed/recorded/shown) and (b) the
-   headset-disconnect stall (<1 fps flat while the headset idles). THEN
-   the first GitHub release (zip + install/use README) and the grip-switch
-   wrong-controller bug (spec in ROADMAP M8). Then M8's HUD usability
-   (health/EVE visible, keybind audit). If session 17 finishes early,
-   starting the two blockers is the right use of the remaining time.
-2. **The retired scale hunt**: worldScale 100 solved the size percept; the
+0. **THE OPEN GATE: the user's in-headset run on branch
+   `m7.5-body-yaw-transfer`** (checklist below, head-decoupling re-verification
+   is item 1). If it passes, open the PR and merge to main. Do NOT merge first.
+1. **THE M8 QUICK PHASE - both items are RELEASE BLOCKERS by the user's call,
+   and neither was started in session 17** (the session went entirely on M7.5
+   and its verification):
+   (a) **headset-disconnect stall** - the flat window drops under 1 fps while
+   the headset idles (presents=0/s, session VISIBLE in the log; the per-present
+   xrWaitFrame pacing keeps waiting). Skip or time out the pacing when the XR
+   session leaves FOCUSED; must recover cleanly on reconnect.
+   (b) **flat-screen mirror** - the desktop window alternates L/R eyes under
+   SequentialReentry, so the mod cannot be streamed, recorded, or shown. Re-blit
+   the held left-eye image on right-eye presents at Present-tail WITHOUT
+   touching the eye capture the compositor feeds on. Verify: consecutive window
+   captures phase-consistent (the img-diff floor, not the eye-offset value).
+   *Note from session 17: all 12 acceptance shots came out the SAME eye phase,
+   so the alternation is not uniform - worth understanding while fixing it.*
+   Then the first GitHub release (tagged build, zip with both DLLs,
+   README/INSTALL covering the xinput1_3 proxy, the itsloopyo conflict, Virtual
+   Desktop/VDXR setup, and use: VR PRESET 1, the sliders, `vrpreset save`), and
+   the grip-switch wrong-controller bug (spec in ROADMAP M8; cheap first check
+   is whether it self-corrects after one trigger pull). Then M8's HUD usability.
+2. **The M7.5 leftover: the exact cull angle.** Park `vrhands simpose <yaw> 0 0
+   120000` at 0/30/60/80/90/100/120 from the facing and find the cull-on/off
+   boundary from both directions - but NOT with NCC template chaining, which
+   failed outright in session 17 (correlations 0.56-0.79; every number void).
+   Use a template-free instrument: the `[tlm] lock tgt=` NDC is ground truth for
+   where the anchor should land, and a dark-pixel disc-width profile or a
+   `vrhands off` reference-frame difference detects presence/absence without a
+   template. Only worth doing if the user still sees the rig vanish in the
+   headset with the transfer on - the mechanism that caused it is now removed.
+3. **The retired scale hunt**: worldScale 100 solved the size percept; the
    engine-lever negatives stay documented (ENGINE_NOTES session 16 part 2)
    and the world/viewmodel scale SPLIT design is parked in M9. Do NOT
    reopen unless the user wants the world scale moved independently.
-3. **If the headset run reports depth slightly off**: `vrbones lockdgain`
+4. **If the headset run reports depth slightly off**: `vrbones lockdgain`
    is the live A/B (it scales the applied pull too - the 12.8 knob assumes
    0.9); if the resting spot reads wrong, `vrbones lock diff`. If the rig
    BLANKS when the hand comes near the face: expected inside ~23 cm (the
@@ -926,35 +988,94 @@ https://github.com/mohamad-balouza/bioshock-vr. Em dashes banned repo-wide.
    a soft clamp on the applied pull near the face is the queued fix.
    (Weapon-laser fine alignment: the existing pos/trim sliders + "Save
    offsets" - after the scale lands.)
-4. **Sway kill at source (UpdateHandValues bob params)**: possibly less urgent
+5. **Sway kill at source (UpdateHandValues bob params)**: possibly less urgent
    now - with lock ABS the flat shot series sat pixel-frozen (the per-frame
    re-pin may be absorbing the lateral sway); ask the user whether any
    breathing still shows before building this.
-5. **Polish knobs the headset run may ask for**: per-hand anchor trims (the
+6. **Polish knobs the headset run may ask for**: per-hand anchor trims (the
    left wrist anchor may want a palm offset), collapse scope (clavicle in or
    out), and a smoothing option if raw controller jitter reads on the model.
-6. Carried over, unchanged: a true dot at the IMPACT point (needs a per-frame
+7. Carried over, unchanged: a true dot at the IMPACT point (needs a per-frame
    engine line-check - start at the damage factory, factory fetched by 0x231E70
    in `UAttackAbility::InitiateDamage` 0x1BBD80, virtual at factory vtbl
    `+0xEC`); verify a PROJECTILE plasmid (Incinerate); hide the head-centred
    crosshair; per-weapon offset profiles keyed by weapon class name; and the
    20-second load-crossing check the user still owes.
-7. **Dropped from M7 by the user's call**: dual-wield (BioShock 1 equips one
+8. **Dropped from M7 by the user's call**: dual-wield (BioShock 1 equips one
    hand at a time - it moves to the M10 BioShock 2 adapter, which supports it
    natively), elbow IK, arm bending, two-handed grips.
-8. M5 rung 2 - menu mode (quad + controller laser -> virtual mouse, DR-6).
+9. M5 rung 2 - menu mode (quad + controller laser -> virtual mouse, DR-6).
    Controller polish (deadzone/curve/menu timing) and rebinds stay parked in M9.
-9. Still open from M3: cutscene cameras are head-driven. The aim path already
+10. Still open from M3: cutscene cameras are head-driven. The aim path already
    guards on the view actor's vtable (AShockPlayer) - reuse that predicate for
    the camera when it is addressed.
-10. If the init-crash flake (bioshockvr.dll+0x30BE5, one occurrence pre-SEH
+11. If the init-crash flake (bioshockvr.dll+0x30BE5, one occurrence pre-SEH
     guards) recurs: the crash log prints module+RVA - symbolize against the PDB.
-11. DR-7 borderless/windowed stability; DR-6 menu input path; optional Steam
+12. DR-7 borderless/windowed stability; DR-6 menu input path; optional Steam
     Link / SteamVR cross-check any time.
-12. **Parked in M9** (user's call 2026-07-24): IPD slider verification, small
+13. **Parked in M9** (user's call 2026-07-24): IPD slider verification, small
     head-motion bobbing, the vrstereo off/re-arm state bug, HUD-in-both-eyes.
 
-### IN-HEADSET CHECKLIST - M7-v2 matched-lens run (session 16 build)
+### IN-HEADSET CHECKLIST - M7.5 body-follows-head (session 17 build, branch `m7.5-body-yaw-transfer`)
+
+Setup: Quest 3 + Virtual Desktop, launch from Steam, load the newest save,
+press **VR PRESET 1** (it now arms the yaw transfer too, after the viewmodel
+and before stereo). What changed: the invisible body/pawn facing now follows
+your head every frame, so **forward is where you look**. The camera is
+mathematically unchanged by this - you should not feel the transfer happen at
+all, only its effects. `vrbody off` reverts to the session-16 behaviour live,
+`vrbody on` brings it back: that is the A/B for every question below.
+
+1. **HEAD DECOUPLING - the non-regression check, please do this FIRST.** Park
+   your hand pointing at something and look around with your head, yaw AND
+   pitch, through a wide range. **The gun must hold its world spot and must
+   NOT follow your head.** This is the defect that took sessions 12-16 to kill
+   and the one thing we cannot regress. Flat it is bit-identical (the hand's
+   world pose and the camera came out byte-for-byte the same with the transfer
+   on and off), but your eyes are the gate. If anything drags with your head,
+   say so and stop - `vrbody off` is the immediate revert.
+2. **The headline: walk where you look.** Physically turn your head, then push
+   the left stick forward without touching the right stick. You should walk in
+   the direction you are looking. Then A/B it: `vrbody off`, same test - you
+   should get the old behaviour (walking along the stale facing). Does the new
+   one feel right, or does it need smoothing? (`vrbody rate 3` eases the body
+   in over ~1/3 s instead of snapping; `vrbody deadzone 20` makes small
+   glances not steer. Both default 0 = instant, which is what you asked for -
+   these are here in case instant feels twitchy in practice.)
+3. **The disappearing rig.** This is the symptom that should be gone. Turn
+   past 90 deg in both directions, aim off to the sides, do the things that
+   used to make the whole rig vanish. Does it still vanish anywhere? If yes,
+   roughly what angle and which direction - and does `vrbody off` make it
+   worse? (Flat note: the mechanism that caused it is removed, but the exact
+   cull boundary was NOT measured this session - the template instrument
+   failed and I did not want to report numbers I could not trust.)
+4. **Weapon-laser alignment at angle.** The complaint was that alignment
+   degraded as the hand aimed away from the body facing. Aim well off to the
+   side and check the barrel against the laser. Flat, the render lock's
+   correction went from swinging 10.5 UU across a +-30 deg head sweep to flat
+   within 0.5 UU, which should read as "the gun stops drifting as you look
+   around" - does it?
+5. **Expect the viewmodel to LOOK different between `vrbody on` and `off`.**
+   Not a bug: the renderer views the rig from the actor's orientation, so with
+   the transfer on it is viewed from your camera's orientation instead of a
+   stale body facing. Flat, the world is pixel-identical between the two while
+   the gun sits differently. Which one looks right to you?
+6. **Turning still works normally.** Right stick turns camera and body
+   together as before; it composes with the transfer rather than fighting it
+   (flat-proven). Any stutter, fight, or drift while turning is signal.
+7. **Fire + plasmid parity**: two right-trigger pulls at a wall, then left
+   trigger Electro Bolt - electricity on the driven hand. (Flat: 6 pulls,
+   ammo 57->51, no crash dumps.)
+8. **Load crossing (20 seconds)**: Esc -> LOAD -> newest save -> YES, then
+   fire both hands. The transfer resets its state machine on the new
+   PlayerController and re-probes; you should not notice.
+9. **Cutscene / bathysphere**: if you hit one, confirm the view behaves
+   normally. The transfer is gated off whenever the view actor is not your
+   pawn, but it has not been tested against a real cutscene.
+10. **Anything that feels off, `vrbody off` first** - if that fixes it, it is
+    mine; if not, it predates this session.
+
+### PREVIOUS CHECKLIST - M7-v2 matched-lens run (session 16 build)
 
 Setup unchanged: Quest 3 + Virtual Desktop, launch from Steam, load the newest
 save, tick **VR stereo**, then **"Viewmodel follows the controller"**. What
@@ -1015,11 +1136,69 @@ and it resumes.
   line, still dead) and key-bound commands are inert. The mod issues engine
   commands via the console-command seam (`exec` -> engine Exec dispatchers).
 - Adapter VRAM logs as "3072 MB" - DXGI_ADAPTER_DESC.DedicatedVideoMemory is a 32-bit SIZE_T in
-  our process, so values ≥4 GB truncate. Cosmetic; ignore.
+  our process, so values â‰¥4 GB truncate. Cosmetic; ignore.
 - itsloopyo's headtracking mod also installs as `xinput1_3.dll` - mutually exclusive with ours
   (install.ps1 backs theirs up automatically).
 
 ## Session log (newest first)
+
+### 2026-07-27 - Session 17 (M7.5: the body-follows-head yaw transfer ships, invariant exact)
+
+- Work done on branch **`m7.5-body-yaw-transfer`** at the user's request, to
+  keep the verified session-16 behaviour on main until they sign off in the
+  headset. Two commits; PR after their run.
+- **The body facing was found in one boot: `PC+0x1E8`** (the
+  PlayerController's `Rotation.Yaw` - AActor layout inherited by AController,
+  same +0x1E4 offset the mod already read on AHands and the pawn). A
+  read-only `vrbody probe` line plus a `vrbody poke <deg>` one-shot write
+  answered all nine probe steps positively: non-zero pitch where the pawn's is
+  0, the write lands and holds across 11 samples, the pawn follows for free,
+  the engine's turn composes on our value, and a synthetic walk burst followed
+  the written facing to 0.4 deg. The milestone was proven before any transfer
+  code ran. This overturns the M6-era ARCHITECTURE note rejecting a
+  pawn/controller rotation write.
+- **The hard invariant held exactly.** Composite `gameYaw - recenterYaw` read
+  1.27742 rad at every head angle in both states; at head 45 the hand's world
+  pose and the camera were bit-identical off vs on; `[tlm] yawstep` max=0
+  units / nbig=0 through the arm transient. The yaw path was converted to
+  integer rotator units to make the cancellation exact, and `on_calcview`
+  returns the units COMMITTED so the two absorbed quantities are one integer.
+- **The feature measured**: transfer OFF, the walk heading changed 0.18 deg
+  for a 90 deg head change; ON, walk == body == camera to 0.01 deg at +45 and
+  -45, spanning 89.99 deg.
+- **Unplanned second payoff**: with the transfer on, the render lock's lateral
+  correction goes flat within 0.46 UU across a +-30 deg head sweep instead of
+  swinging 10.5 UU, landing on the same 4.57 the calibrated zero-split
+  configuration uses. The transfer restores the headset-verified session-16
+  regime at every head angle rather than only at head 0.
+- **A trap that would have faked a regression, caught before it did**:
+  `hands.cpp` forced the simpose lane's recenter yaw to 0, making the parked
+  synthetic hand body-locked while a real controller is recenter-locked - the
+  gate would have shown the parked gun swinging a full 45 deg and read as the
+  sessions-12-16 defect. Fixed; it was a no-op before the transfer existed.
+- **Two honest negatives, both recorded in ENGINE_NOTES so they are not
+  retried blind**: (1) NCC template chaining across the sweep failed outright
+  (correlations 0.56-0.79 at every step) because the composition changes too
+  much per 15 deg - every pixel number from it is void, and the exact cull
+  angle is therefore still unmeasured. The `[tlm] lock` telemetry is the
+  template-free instrument that answers the same question. (2) The cull is
+  direction-dependent: a head-only glance with the hand parked in the world
+  *increases* hand-vs-body, while the reported case (the user swivels, so head
+  and hand move together) drives it to ~0. Both are real.
+- Also learned: a walk burst that slides along collision geometry yields a
+  plausible-looking heading that is pure geometry (one read 105.65 deg at 16%
+  perpendicular deviation). Every burst is now gated on straightness <= 5% and
+  a failure is VOID, not a result.
+- Promoted to default ON and into VR PRESET 1 (after the viewmodel, before
+  vrstereo); `vrbody off` is the live A/B. `bodyRate`/`bodyDeadzoneDeg` persist
+  to vrpreset.ini, both 0 = instant 1:1 by the user's call.
+- Clean-boot acceptance on the promoted build: fire test 57->51 for 6 pulls,
+  dumps 8->8 throughout the whole session, stereo clean (mode=1T, presents =
+  2x builds, guardskips 0), preset echo chain + ini round-trip, and a 20-step
+  +-90 deg soak returning camYaw and the recenter to their exact start values.
+- **Not started, and they are the next session's job**: the two M8 release
+  blockers (headset-disconnect stall, flat-screen mirror). The session went
+  entirely on M7.5 and its verification.
 
 ### 2026-07-27 - Session 16 part 4 (preset verified in-headset; the ROOT CAUSE of the edge desync found by the user)
 
@@ -2119,15 +2298,15 @@ THEN arm 1t):**
 - Researched game installation (32-bit DX11 Vengeance/UE2.5, no DRM, gameswf Flash UI), engine
   family (BS2R same engine; Infinite UE3-6829), modding ecosystem, prior VR art (vorpX G3D works;
   itsloopyo headtracking hook proven; REFramework MIT reference), and the VR injection stack
-  (OpenXR-first for VDXR+SteamVR). Full findings → RESEARCH.md.
-- Decided architecture (C++20/x86, xinput proxy → bioshockvr.dll, core+adapter split, stereo
-  ladder with SequentialReentry as primary bet) → ARCHITECTURE.md decision log.
+  (OpenXR-first for VDXR+SteamVR). Full findings â†’ RESEARCH.md.
+- Decided architecture (C++20/x86, xinput proxy â†’ bioshockvr.dll, core+adapter split, stereo
+  ladder with SequentialReentry as primary bet) â†’ ARCHITECTURE.md decision log.
 - Built: repo + docs suite, CMake (VS2022 `-A Win32`, submodules minhook/imgui/OpenXR-SDK pinned),
   xinput proxy (ordinals verified against the real SysWOW64 DLL with dumpbin - game imports @2/@3),
   mod DLL (deferred init, logger, minidump handler, MinHook, kiero-style Present/ResizeBuffers
   hooks, ImGui overlay), tools scripts.
 - **In-game smoke test passed** on first run (full init chain + D3D11 device info in log).
-  Found + fixed: logger file locking (fopen_s denies sharing → switched to `_wfsopen` with
+  Found + fixed: logger file locking (fopen_s denies sharing â†’ switched to `_wfsopen` with
   `_SH_DENYNO`), non-ASCII mojibake in log lines, missing `-Install` passthrough in build.ps1.
 - Verified: LAA=YES; D3D11 confirmed at runtime; user ini path confirmed after first launch.
 - Repo created and pushed: https://github.com/mohamad-balouza/bioshock-vr (public, MIT).

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,11 +2,35 @@
 
 > Handoff file. Rewrite "Current state" and "Next steps" every session; append to the session log.
 
-## Current state (2026-07-27, session 17 - M7.5 BODY-FOLLOWS-HEAD YAW TRANSFER SHIPS; INVARIANT HELD EXACTLY)
+## Current state (2026-07-27, session 17 - M7.5 SHIPS AND IS IN-HEADSET VERIFIED; DEADZONE 23 DEG BY USER CALIBRATION)
 
-**Branch `m7.5-body-yaw-transfer` (NOT merged - the user reviews by PR after
-their headset run). Everything below is flat-verified; the in-headset verdict
-is the only open gate.**
+**IN-HEADSET VERDICT (same day): "This is perfect... the stick was working as
+expected, the models didn't move when I moved my head... so just needed that
+deadzone change and it was perfect."** The user tuned `vrbody deadzone` to
+**23 deg** live and asked for it as the default; it now ships that way. All
+three reported symptoms are addressed and the hard invariant survived the
+headset: the models do not move with the head.
+
+**Why the deadzone was the last piece.** The user's one remaining note was
+"the gun moves with the camera a bit". Inside the 23 deg band the body does
+not steer at all, so an ordinary glance leaves the viewmodel completely
+world-locked; only a deliberate turn past the band carries the body along. And
+because the transfer takes `residual - band`, beyond the band the body trails
+the head by exactly 23 deg, so head and body never diverge further than that
+no matter how far you turn. Flat-confirmed on the shipping default: `resid`
+settles at exactly 23.00 deg, and the invariant is untouched by the band -
+gameYaw and recenterYaw each moved 0.38398 rad (22 deg = 45 - 23) while
+`camYaw` stayed 8308 and the hand's world yaw stayed 116, both bit-identical.
+
+**Branch `m7.5-body-yaw-transfer`, ready to merge.** Everything below is
+flat-verified and now headset-verified.
+
+**Harness note worth keeping: a `vrpreset.ini` written by a smoke test will
+silently OVERRIDE a later code default.** The session-16-era ini on this box
+pinned `bodyDeadzoneDeg=0.0` and would have cancelled the new 23 deg default
+on the next preset press. It contained nothing but shipped defaults, so it was
+deleted and code owns the values again. Any future default change needs the
+same check.
 
 **The root cause the user found by playing is fixed. The body facing is the
 PlayerController's `Rotation.Yaw` at `PC+0x1E8`** - found and proven live in
@@ -945,9 +969,9 @@ https://github.com/mohamad-balouza/bioshock-vr. Em dashes banned repo-wide.
 
 ## Next steps
 
-0. **THE OPEN GATE: the user's in-headset run on branch
-   `m7.5-body-yaw-transfer`** (checklist below, head-decoupling re-verification
-   is item 1). If it passes, open the PR and merge to main. Do NOT merge first.
+0. **DONE: the user verified M7.5 in-headset - "this is perfect".** Deadzone
+   defaulted to their tuned 23 deg. Branch `m7.5-body-yaw-transfer` is ready to
+   merge to main by PR.
 1. **THE M8 QUICK PHASE - both items are RELEASE BLOCKERS by the user's call,
    and neither was started in session 17** (the session went entirely on M7.5
    and its verification):
@@ -1016,7 +1040,13 @@ https://github.com/mohamad-balouza/bioshock-vr. Em dashes banned repo-wide.
 13. **Parked in M9** (user's call 2026-07-24): IPD slider verification, small
     head-motion bobbing, the vrstereo off/re-arm state bug, HUD-in-both-eyes.
 
-### IN-HEADSET CHECKLIST - M7.5 body-follows-head (session 17 build, branch `m7.5-body-yaw-transfer`)
+### IN-HEADSET CHECKLIST - M7.5 body-follows-head (session 17) - PASSED
+
+**Result: passed on the first run.** Head decoupling held ("the models didn't
+move when I moved my head"), the stick worked as expected, and looking to a
+specific spot left or right at a decent angle behaved. The only change asked
+for was `vrbody deadzone` 0 -> **23 deg**, which is now the shipped default -
+so the "Deadzone (deg)" slider below reads 23, not 0, on any later run.
 
 Setup: Quest 3 + Virtual Desktop, launch from Steam, load the newest save,
 press **VR PRESET 1** (it now arms the yaw transfer too, after the viewmodel
@@ -1141,6 +1171,30 @@ and it resumes.
   (install.ps1 backs theirs up automatically).
 
 ## Session log (newest first)
+
+### 2026-07-27 - Session 17 part 2 (IN-HEADSET: PASSED; deadzone 23 deg becomes the default)
+
+- The user tested the session-17 build: **"This is perfect... the stick was
+  working as expected, the models didn't move when I moved my head while
+  looking forward and around that section, when I looked at a specific part to
+  the right or left that needed a decent angle also worked as expected."** The
+  hard invariant survived the headset - that is the gate M7.5 existed to pass.
+- One tuning change, made live by the user and now the shipped default:
+  **`vrbody deadzone` 0 -> 23 deg**. Their remaining note before it was "the
+  gun moves with the camera a bit"; inside the band the body does not steer at
+  all, so a glance leaves the viewmodel world-locked, and beyond the band the
+  body trails the head by exactly the band width (head and body never diverge
+  more than 23 deg).
+- Flat re-verified on the shipping default: `resid` settles at exactly
+  23.00 deg; gameYaw and recenterYaw each moved 0.38398 rad (45 - 23 = 22 deg)
+  while camYaw stayed 8308 and the hand's world yaw stayed 116 - both
+  bit-identical, so the deadzone does not weaken the invariant. Fire smoke
+  under stereo clean, dumps 8->8, guardskips 0.
+- **Trap found while shipping the default: a `vrpreset.ini` left by a smoke
+  test silently OVERRIDES a later code default.** The ini on this box pinned
+  `bodyDeadzoneDeg=0.0` and would have cancelled the new default on the next
+  preset press. It held nothing but shipped defaults, so it was deleted. Check
+  this whenever a default changes.
 
 ### 2026-07-27 - Session 17 (M7.5: the body-follows-head yaw transfer ships, invariant exact)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,8 @@ add_library(bioshockvr SHARED
     game/bioshock1r/aim.h
     game/bioshock1r/bioshock1r_adapter.cpp
     game/bioshock1r/bioshock1r_adapter.h
+    game/bioshock1r/body.cpp
+    game/bioshock1r/body.h
     game/bioshock1r/bones.cpp
     game/bioshock1r/bones.h
     game/bioshock1r/camera.cpp

--- a/src/game/bioshock1r/bioshock1r_adapter.cpp
+++ b/src/game/bioshock1r/bioshock1r_adapter.cpp
@@ -2,6 +2,7 @@
 
 #include "core/util/log.h"
 #include "game/bioshock1r/aim.h"
+#include "game/bioshock1r/body.h"
 #include "game/bioshock1r/bones.h"
 #include "game/bioshock1r/camera.h"
 #include "game/bioshock1r/hands.h"
@@ -26,6 +27,7 @@ bool Bioshock1RAdapter::init(const bvr::pattern_scan::ProcessImage& image) {
     aim::init(image, symbols); // same: M6 seam hooks are command-gated
     hands::init(image);        // M7 viewmodel; the actor is located lazily
     bones::init(image);        // M7-v2 skeleton drive; located lazily off the actor
+    body::init(image);         // M7.5 body yaw transfer; default off, probe-gated
     BVR_LOG("[b1r] adapter ready, capabilities 0x%X", capabilities());
     return true;
 }
@@ -38,6 +40,7 @@ void Bioshock1RAdapter::drawDebugUi() {
     camera::draw_debug_ui();
     aim::draw_debug_ui();
     hands::draw_debug_ui();
+    body::draw_debug_ui();
     input_drive::draw_debug_ui();
     scenedraw::draw_debug_ui();
 }

--- a/src/game/bioshock1r/body.cpp
+++ b/src/game/bioshock1r/body.cpp
@@ -1,0 +1,491 @@
+#include "game/bioshock1r/body.h"
+
+#include "core/hooks/d3d11_hook.h"
+#include "core/util/log.h"
+#include "game/bioshock1r/patterns.h"
+#include "game/bioshock1r/ue_math.h"
+
+#include <windows.h>
+
+#include <imgui.h>
+
+#include <atomic>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+
+namespace bvr::b1r::body {
+namespace {
+
+const uint8_t* g_imageBase = nullptr;
+
+// ---- knobs (overlay thread writes, game thread reads) ----------------------
+
+// Default OFF for the flat acceptance gate: with this off the build must
+// reproduce the session-16 numbers exactly, which is how the integer-yaw
+// refactor gets its own regression test. Promoted to default ON (and into the
+// VR preset) once the gate passes.
+std::atomic<bool>  g_armed{false};
+// 0 = instant 1:1 (the user's call, session 17): the body snaps to the head
+// yaw every frame, so stick-forward is ALWAYS exactly the look direction and
+// the camera-vs-body split stays ~0 - the best case for both the viewmodel
+// alignment and the bounds cull. Non-zero = exponential follow at that rate.
+std::atomic<float> g_ratePerSec{0.0f};
+std::atomic<float> g_deadzoneDeg{0.0f};
+std::atomic<float> g_maxDegPerSec{180.0f};  // safety slew cap, not feel
+std::atomic<int>   g_field{0};              // 0 pc, 1 pawn, 2 both
+std::atomic<bool>  g_probeLog{false};
+// One-shot raw write test (`vrbody poke <deg>`), applied on the next frame.
+std::atomic<int32_t> g_pokeUnits{0};
+
+// ---- telemetry (game thread writes, overlay reads) -------------------------
+
+std::atomic<int>     g_stateTlm{0};
+std::atomic<float>   g_residDegTlm{0.0f};
+std::atomic<int32_t> g_committedPerSec{0};
+std::atomic<uint32_t> g_skipView{0}, g_skipWrite{0}, g_resets{0};
+
+// ---- game-thread-only state ------------------------------------------------
+
+enum State { kOff, kProbe, kRun, kDisabled };
+State g_state = kOff;
+
+void*    g_lastPc = nullptr;
+uint32_t g_lastPresent = 0;
+bool     g_havePrev = false;
+int32_t  g_prevGameYaw = 0;
+int32_t  g_expect = 0;      // units commanded last frame (0 = nothing)
+int      g_probeTries = 0;
+int      g_quietFrames = 0;
+LARGE_INTEGER g_qpcFreq{};
+LARGE_INTEGER g_lastQpc{};
+uint64_t g_lastProbeLogMs = 0;
+uint64_t g_secWindowMs = 0;
+int32_t  g_secAccum = 0;
+// RUN-state health: over a rolling window, commanded vs observed.
+int      g_runFrames = 0;
+int32_t  g_runCommanded = 0, g_runObserved = 0;
+char     g_disableReason[64] = {};
+
+// A single frame's transfer never exceeds this. Purely a blast radius limit:
+// the probe handshake below is what actually decides whether the write works.
+constexpr int32_t kMaxStepUnits = 4096;      // 22.5 deg
+constexpr int32_t kProbeUnits = 200;         // 1.1 deg - invisible if it fails
+constexpr int32_t kProbeTolerance = 64;
+constexpr int32_t kQuietUnits = 32;          // "the player is not turning"
+constexpr int32_t kDiscontinuityUnits = 4096; // teleport / load / scripted slew
+
+// ---- guarded memory helpers (no C++ objects in an SEH frame) ---------------
+
+bool read_rot(const void* obj, uint32_t off, int32_t out[3]) {
+    __try {
+        memcpy(out, static_cast<const uint8_t*>(obj) + off, 12);
+        return true;
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        return false;
+    }
+}
+
+// Yaw is the SECOND int32 of an FRotator {pitch, yaw, roll} - see ue_math.h.
+// Pitch is deliberately never touched: the engine's own rotation update
+// applies a signed clamp to it, and the pawn keeps pitch 0 by design.
+bool write_yaw(void* obj, uint32_t rotOff, int32_t yaw) {
+    __try {
+        *reinterpret_cast<int32_t*>(static_cast<uint8_t*>(obj) + rotOff + 4) = yaw;
+        return true;
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        return false;
+    }
+}
+
+bool read_ptr(const void* src, void** out) {
+    __try {
+        *out = *static_cast<void* const*>(src);
+        return true;
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        return false;
+    }
+}
+
+uint32_t to_rva(const void* p) {
+    if (!p || !g_imageBase) return 0;
+    return static_cast<uint32_t>(static_cast<const uint8_t*>(p) - g_imageBase);
+}
+
+// The cutscene/vehicle guard, same predicate aim.cpp and hands.cpp use - but
+// WITHOUT their `viewActor == pc` escape hatch. That hatch exists so the aim
+// ray still works in the main-menu attract scene; a write to the body facing
+// emphatically must not fire there.
+bool is_gameplay_view(void* viewActor) {
+    if (!viewActor) return false;
+    void* vtbl = nullptr;
+    if (!read_ptr(viewActor, &vtbl)) return false;
+    return to_rva(vtbl) == patterns::kShockPlayerVtableRva;
+}
+
+const char* state_name(State s) {
+    switch (s) {
+        case kOff: return "off";
+        case kProbe: return "PROBE";
+        case kRun: return "RUN";
+        default: return "DISABLED";
+    }
+}
+
+void set_state(State s) {
+    g_state = s;
+    g_stateTlm.store(static_cast<int>(s), std::memory_order_relaxed);
+}
+
+void disable(const char* why) {
+    _snprintf_s(g_disableReason, sizeof g_disableReason, _TRUNCATE, "%s", why);
+    set_state(kDisabled);
+    BVR_LOG("[vrbody] DISABLED: %s - the body write does not stick on this "
+            "build. Camera and hand mapping are untouched (the probe undid "
+            "itself); `vrbody status` for details.",
+            why);
+}
+
+// Commit `units` to the body facing. Returns what actually landed (0 on a
+// failed write), which is the ONLY thing the caller may absorb.
+int32_t commit(void* pc, void* pawn, int32_t units) {
+    if (units == 0) return 0;
+    int field = g_field.load(std::memory_order_relaxed);
+    bool wantPc = (field == 0 || field == 2);
+    bool wantPawn = (field == 1 || field == 2);
+    bool ok = false;
+
+    if (wantPc && pc) {
+        int32_t rot[3];
+        if (read_rot(pc, patterns::kActorViewDirOffset, rot) &&
+            write_yaw(pc, patterns::kActorViewDirOffset, (rot[1] + units) & 0xFFFF))
+            ok = true;
+    }
+    if (wantPawn && pawn) {
+        int32_t rot[3];
+        if (read_rot(pawn, patterns::kActorViewDirOffset, rot) &&
+            write_yaw(pawn, patterns::kActorViewDirOffset, (rot[1] + units) & 0xFFFF))
+            ok = true;
+    }
+    if (!ok) {
+        g_skipWrite.fetch_add(1, std::memory_order_relaxed);
+        return 0;
+    }
+    return units;
+}
+
+// How much of the residual to take this frame, before any clamping.
+int32_t wanted_step(int32_t residualUnits, float dt) {
+    float dz = g_deadzoneDeg.load(std::memory_order_relaxed) * kRotUnitsPerDegree;
+    float r = static_cast<float>(residualUnits);
+    if (dz > 0.0f) {
+        if (fabsf(r) <= dz) return 0;
+        r -= (r > 0.0f ? dz : -dz); // no jump at the band edge
+    }
+    float rate = g_ratePerSec.load(std::memory_order_relaxed);
+    if (rate > 0.0f) r *= (1.0f - expf(-rate * dt));
+
+    float cap = g_maxDegPerSec.load(std::memory_order_relaxed) * kRotUnitsPerDegree * dt;
+    if (cap > 0.0f) {
+        if (r > cap) r = cap;
+        if (r < -cap) r = -cap;
+    }
+    int32_t u = static_cast<int32_t>(lroundf(r));
+    if (u > kMaxStepUnits) u = kMaxStepUnits;
+    if (u < -kMaxStepUnits) u = -kMaxStepUnits;
+    return u;
+}
+
+} // namespace
+
+void init(const bvr::pattern_scan::ProcessImage& image) {
+    g_imageBase = image.base;
+    QueryPerformanceFrequency(&g_qpcFreq);
+}
+
+void on_reset(const char* why) {
+    g_havePrev = false;
+    g_expect = 0;
+    g_probeTries = 0;
+    g_quietFrames = 0;
+    g_runFrames = 0;
+    g_runCommanded = g_runObserved = 0;
+    if (g_state != kDisabled) set_state(g_armed.load(std::memory_order_relaxed) ? kProbe : kOff);
+    g_resets.fetch_add(1, std::memory_order_relaxed);
+    if (why) BVR_LOG("[vrbody] state reset (%s) -> %s", why, state_name(g_state));
+}
+
+int32_t on_calcview(void* pc, void* viewActor, int32_t gameYawUnits,
+                    int32_t residualUnits, bool vrDriving) {
+    // Once per rendered frame. CalcView fires far above frame rate (~7800/s at
+    // the menu), and an ADDITIVE body write must not be applied several times
+    // for one frame's worth of head motion. Same gate input_drive uses.
+    uint32_t present = static_cast<uint32_t>(bvr::d3d11_hook::present_count());
+    if (present == g_lastPresent) return 0;
+    g_lastPresent = present;
+
+    uint64_t nowMs = GetTickCount64();
+
+    if (pc != g_lastPc) {
+        g_lastPc = pc;
+        on_reset("player controller changed");
+    }
+
+    // Read both candidate rotation fields once - the probe telemetry and the
+    // transfer share them.
+    int32_t pcRot[3] = {0, 0, 0}, pawnRot[3] = {0, 0, 0};
+    bool havePc = pc && read_rot(pc, patterns::kActorViewDirOffset, pcRot);
+    bool havePawn = viewActor && read_rot(viewActor, patterns::kActorViewDirOffset, pawnRot);
+
+    int32_t dG = g_havePrev ? wrap_rot(gameYawUnits - g_prevGameYaw) : 0;
+
+    if (g_probeLog.load(std::memory_order_relaxed) && nowMs - g_lastProbeLogMs >= 500) {
+        g_lastProbeLogMs = nowMs;
+        BVR_LOG("[vrbody] pc=%p G=%d (dG=%+d, expect %+d) | PC.rot=(%d %d %d)%s | "
+                "pawn=%p rot=(%d %d %d)%s | resid=%+d (%.2f deg) | %s view=%s",
+                pc, gameYawUnits, dG, g_expect, pcRot[0], pcRot[1], pcRot[2],
+                havePc ? "" : " UNREADABLE", viewActor, pawnRot[0], pawnRot[1], pawnRot[2],
+                havePawn ? "" : " UNREADABLE", residualUnits,
+                residualUnits / kRotUnitsPerDegree, state_name(g_state),
+                is_gameplay_view(viewActor) ? "gameplay" : "OTHER");
+    }
+
+    g_residDegTlm.store(residualUnits / kRotUnitsPerDegree, std::memory_order_relaxed);
+
+    // `vrbody poke <deg>`: one raw additive write through the transfer's own
+    // path, deliberately NOT absorbed into the recenter. If the camera swings
+    // and STAYS swung, the field is the authority and the engine's rotation
+    // update composes on our value - which is the whole precondition for the
+    // transfer. If it snaps back, this field is a slave and we go hunting.
+    int32_t poke = g_pokeUnits.exchange(0, std::memory_order_relaxed);
+    if (poke != 0) {
+        int32_t landed = commit(pc, viewActor, poke);
+        BVR_LOG("[vrbody] poke %+d units: %s (G was %d, PC.yaw was %d, pawn.yaw was %d) "
+                "- watch the next few [vrbody] lines: G should hold at %d",
+                poke, landed ? "written" : "WRITE FAILED", gameYawUnits, pcRot[1],
+                pawnRot[1], wrap_rot(gameYawUnits + poke) & 0xFFFF);
+        g_havePrev = true;
+        g_prevGameYaw = gameYawUnits;
+        return 0; // never absorbed - the camera swing IS the signal
+    }
+
+    // 1 Hz "units committed" telemetry.
+    if (nowMs - g_secWindowMs >= 1000) {
+        g_secWindowMs = nowMs;
+        g_committedPerSec.store(g_secAccum, std::memory_order_relaxed);
+        g_secAccum = 0;
+    }
+
+    // A discontinuity we did not command (teleport, load, scripted camera
+    // slew) must not be read as "our write failed".
+    if (g_havePrev && g_expect == 0 && abs(dG) > kDiscontinuityUnits) {
+        g_prevGameYaw = gameYawUnits;
+        on_reset("yaw discontinuity");
+        return 0;
+    }
+
+    bool armed = g_armed.load(std::memory_order_relaxed);
+    if (!armed) {
+        if (g_state != kDisabled && g_state != kOff) set_state(kOff);
+        g_havePrev = true;
+        g_prevGameYaw = gameYawUnits;
+        g_expect = 0;
+        return 0;
+    }
+    if (g_state == kOff) on_reset("armed");
+    if (g_state == kDisabled) {
+        g_havePrev = true;
+        g_prevGameYaw = gameYawUnits;
+        return 0;
+    }
+
+    if (!vrDriving) {
+        g_havePrev = true;
+        g_prevGameYaw = gameYawUnits;
+        g_expect = 0;
+        return 0;
+    }
+    if (!is_gameplay_view(viewActor)) {
+        g_skipView.fetch_add(1, std::memory_order_relaxed);
+        g_havePrev = true;
+        g_prevGameYaw = gameYawUnits;
+        g_expect = 0;
+        return 0;
+    }
+
+    float dt = 0.016f;
+    LARGE_INTEGER qpc{};
+    QueryPerformanceCounter(&qpc);
+    if (g_lastQpc.QuadPart && g_qpcFreq.QuadPart)
+        dt = static_cast<float>(qpc.QuadPart - g_lastQpc.QuadPart) /
+             static_cast<float>(g_qpcFreq.QuadPart);
+    g_lastQpc = qpc;
+    if (dt < 0.001f) dt = 0.001f;
+    if (dt > 0.1f) dt = 0.1f;
+
+    int32_t committed = 0;
+
+    if (g_state == kProbe) {
+        if (g_expect != 0) {
+            // Verdict frame: did last frame's 1.1 deg actually move the body?
+            if (abs(dG - g_expect) <= kProbeTolerance) {
+                set_state(kRun);
+                g_probeTries = 0;
+                BVR_LOG("[vrbody] probe CONFIRMED (asked %+d units, body moved %+d) - "
+                        "the write is the authority and composes incrementally. "
+                        "Transfer live.",
+                        g_expect, dG);
+            } else if (++g_probeTries >= 3) {
+                // Undo: hand back exactly what we took, so a failed probe
+                // leaves the shipped behaviour bit-identical.
+                committed = -g_expect;
+                g_expect = 0;
+                g_havePrev = true;
+                g_prevGameYaw = gameYawUnits;
+                g_secAccum += committed;
+                disable("body yaw write did not stick (3 probes)");
+                return committed;
+            } else {
+                committed = -g_expect; // undo this attempt, retry after quiet
+                BVR_LOG("[vrbody] probe %d/3 failed (asked %+d, body moved %+d) - retrying",
+                        g_probeTries, g_expect, dG);
+                g_quietFrames = 0;
+            }
+            g_expect = 0;
+        } else {
+            // Wait for the player to stop turning, so the engine's own turn
+            // delta cannot be mistaken for our probe landing.
+            if (abs(dG) < kQuietUnits) ++g_quietFrames; else g_quietFrames = 0;
+            if (g_quietFrames >= 2 && abs(residualUnits) > kProbeUnits) {
+                int32_t step = residualUnits > 0 ? kProbeUnits : -kProbeUnits;
+                committed = commit(pc, viewActor, step);
+                g_expect = committed;
+            }
+        }
+    } else if (g_state == kRun) {
+        int32_t step = wanted_step(residualUnits, dt);
+        committed = commit(pc, viewActor, step);
+        g_expect = committed;
+
+        // Rolling health check: if we keep asking and the body keeps not
+        // moving, something else took ownership - drop back to PROBE rather
+        // than silently transferring into a void.
+        g_runCommanded += abs(g_expect);
+        g_runObserved += abs(dG);
+        if (++g_runFrames >= 30) {
+            if (g_runCommanded > 500 && g_runObserved * 4 < g_runCommanded) {
+                BVR_LOG("[vrbody] commanded %d units over 30 frames but the body moved "
+                        "%d - re-probing",
+                        g_runCommanded, g_runObserved);
+                on_reset("body stopped responding");
+            }
+            g_runFrames = 0;
+            g_runCommanded = g_runObserved = 0;
+        }
+    }
+
+    g_havePrev = true;
+    g_prevGameYaw = gameYawUnits;
+    g_secAccum += committed;
+    return committed;
+}
+
+bool enabled() { return g_armed.load(std::memory_order_relaxed); }
+
+void handle_command(const char* args) {
+    float v = 0.0f;
+    char word[16] = {};
+
+    if (strncmp(args, "status", 6) == 0) {
+        BVR_LOG("[vrbody] %s%s | rate=%.2f/s (%s) deadzone=%.1f deg max=%.0f deg/s | "
+                "field=%s | resid=%.2f deg | committed=%d units/s | "
+                "skips: view=%u write=%u resets=%u",
+                state_name(g_state),
+                g_state == kDisabled ? g_disableReason : "",
+                g_ratePerSec.load(std::memory_order_relaxed),
+                g_ratePerSec.load(std::memory_order_relaxed) <= 0.0f ? "instant 1:1"
+                                                                    : "smoothed",
+                g_deadzoneDeg.load(std::memory_order_relaxed),
+                g_maxDegPerSec.load(std::memory_order_relaxed),
+                g_field.load(std::memory_order_relaxed) == 0   ? "pc"
+                : g_field.load(std::memory_order_relaxed) == 1 ? "pawn"
+                                                              : "both",
+                g_residDegTlm.load(std::memory_order_relaxed),
+                g_committedPerSec.load(std::memory_order_relaxed),
+                g_skipView.load(std::memory_order_relaxed),
+                g_skipWrite.load(std::memory_order_relaxed),
+                g_resets.load(std::memory_order_relaxed));
+    } else if (strncmp(args, "probe", 5) == 0) {
+        bool on = strstr(args, "off") == nullptr;
+        g_probeLog.store(on, std::memory_order_relaxed);
+        BVR_LOG("[vrbody] probe telemetry %s", on ? "ON (2 Hz)" : "off");
+    } else if (strncmp(args, "rate", 4) == 0) {
+        if (sscanf_s(args + 4, "%f", &v) == 1) {
+            if (v < 0.0f) v = 0.0f;
+            g_ratePerSec.store(v, std::memory_order_relaxed);
+            BVR_LOG("[vrbody] rate %.2f/s (%s)", v, v <= 0.0f ? "instant 1:1" : "smoothed");
+        }
+    } else if (strncmp(args, "deadzone", 8) == 0) {
+        if (sscanf_s(args + 8, "%f", &v) == 1) {
+            if (v < 0.0f) v = 0.0f;
+            g_deadzoneDeg.store(v, std::memory_order_relaxed);
+            BVR_LOG("[vrbody] deadzone %.1f deg", v);
+        }
+    } else if (strncmp(args, "max", 3) == 0) {
+        if (sscanf_s(args + 3, "%f", &v) == 1) {
+            if (v < 1.0f) v = 1.0f;
+            g_maxDegPerSec.store(v, std::memory_order_relaxed);
+            BVR_LOG("[vrbody] slew cap %.0f deg/s", v);
+        }
+    } else if (strncmp(args, "field", 5) == 0) {
+        if (sscanf_s(args + 5, "%15s", word, static_cast<unsigned>(sizeof word)) == 1) {
+            int f = strcmp(word, "pawn") == 0 ? 1 : (strcmp(word, "both") == 0 ? 2 : 0);
+            g_field.store(f, std::memory_order_relaxed);
+            on_reset("field changed");
+            BVR_LOG("[vrbody] write field = %s", f == 0 ? "pc" : (f == 1 ? "pawn" : "both"));
+        }
+    } else if (strncmp(args, "poke", 4) == 0) {
+        // One-shot additive body-yaw write through the SAME path the transfer
+        // uses - the discriminator that answers "does an additive write to
+        // this field survive the engine's own per-tick rotation update?"
+        // without hand-computing a hex address. Does NOT touch the recenter
+        // reference, so the camera WILL swing by this amount: that is the
+        // point of the test.
+        if (sscanf_s(args + 4, "%f", &v) == 1) {
+            BVR_LOG("[vrbody] poke %+.1f deg queued (camera WILL swing - this is the "
+                    "raw write test, the recenter is deliberately not advanced)",
+                    v);
+            g_pokeUnits.store(static_cast<int32_t>(lroundf(v * kRotUnitsPerDegree)),
+                              std::memory_order_relaxed);
+        }
+    } else {
+        bool on = strncmp(args, "off", 3) != 0;
+        g_armed.store(on, std::memory_order_relaxed);
+        on_reset(on ? "armed" : "disarmed");
+        BVR_LOG("[vrbody] body-follows-head yaw transfer %s", on ? "ON" : "off");
+    }
+}
+
+void draw_debug_ui() {
+    if (!ImGui::CollapsingHeader("Body / locomotion (M7.5)")) return;
+
+    bool on = g_armed.load(std::memory_order_relaxed);
+    if (ImGui::Checkbox("Body follows head (stick-forward = look direction)", &on)) {
+        g_armed.store(on, std::memory_order_relaxed);
+        handle_command(on ? "on" : "off");
+    }
+
+    float rate = g_ratePerSec.load(std::memory_order_relaxed);
+    if (ImGui::SliderFloat("Follow rate (/s, 0 = instant)", &rate, 0.0f, 10.0f, "%.2f"))
+        g_ratePerSec.store(rate, std::memory_order_relaxed);
+    float dz = g_deadzoneDeg.load(std::memory_order_relaxed);
+    if (ImGui::SliderFloat("Deadzone (deg)", &dz, 0.0f, 60.0f, "%.1f"))
+        g_deadzoneDeg.store(dz, std::memory_order_relaxed);
+
+    ImGui::Text("state %s   residual %.1f deg   %d units/s",
+                state_name(static_cast<State>(g_stateTlm.load(std::memory_order_relaxed))),
+                g_residDegTlm.load(std::memory_order_relaxed),
+                g_committedPerSec.load(std::memory_order_relaxed));
+}
+
+} // namespace bvr::b1r::body

--- a/src/game/bioshock1r/body.cpp
+++ b/src/game/bioshock1r/body.cpp
@@ -34,7 +34,14 @@ std::atomic<bool>  g_armed{true};
 // the camera-vs-body split stays ~0 - the best case for both the viewmodel
 // alignment and the bounds cull. Non-zero = exponential follow at that rate.
 std::atomic<float> g_ratePerSec{0.0f};
-std::atomic<float> g_deadzoneDeg{0.0f};
+// 23 deg by the user's in-headset calibration (session 17): "just needed that
+// deadzone change and it was perfect". Inside the band the body does not steer
+// at all, so ordinary glances leave the viewmodel completely world-locked -
+// which is what removes the last of the "the gun moves with the camera a bit"
+// percept - and only a deliberate turn past the band carries the body along.
+// Beyond it the body trails the head by exactly the band width, so head and
+// body never diverge by more than 23 deg no matter how far you turn.
+std::atomic<float> g_deadzoneDeg{23.0f};
 std::atomic<float> g_maxDegPerSec{180.0f};  // safety slew cap, not feel
 std::atomic<int>   g_field{0};              // 0 pc, 1 pawn, 2 both
 std::atomic<bool>  g_probeLog{false};

--- a/src/game/bioshock1r/body.cpp
+++ b/src/game/bioshock1r/body.cpp
@@ -21,11 +21,14 @@ const uint8_t* g_imageBase = nullptr;
 
 // ---- knobs (overlay thread writes, game thread reads) ----------------------
 
-// Default OFF for the flat acceptance gate: with this off the build must
-// reproduce the session-16 numbers exactly, which is how the integer-yaw
-// refactor gets its own regression test. Promoted to default ON (and into the
-// VR preset) once the gate passes.
-std::atomic<bool>  g_armed{false};
+// Default ON since session 17: the flat gate passed with it off (reproducing
+// the session-16 numbers, which is how the integer-yaw refactor got its own
+// regression test) and then passed again with it on - the hand's world pose
+// and the camera came out bit-identical, and the render lock's correction went
+// from swinging 10.5 UU across a +-30 deg head sweep to flat within 0.5 UU,
+// landing on the same 4.57 the calibrated zero-split configuration uses.
+// `vrbody off` is the live in-headset A/B against the session-16 build.
+std::atomic<bool>  g_armed{true};
 // 0 = instant 1:1 (the user's call, session 17): the body snaps to the head
 // yaw every frame, so stick-forward is ALWAYS exactly the look direction and
 // the camera-vs-body split stays ~0 - the best case for both the viewmodel
@@ -391,6 +394,14 @@ int32_t on_calcview(void* pc, void* viewActor, int32_t gameYawUnits,
 }
 
 bool enabled() { return g_armed.load(std::memory_order_relaxed); }
+
+float rate_per_sec() { return g_ratePerSec.load(std::memory_order_relaxed); }
+float deadzone_deg() { return g_deadzoneDeg.load(std::memory_order_relaxed); }
+
+void set_tuning(float ratePerSec, float deadzoneDeg) {
+    g_ratePerSec.store(ratePerSec < 0.0f ? 0.0f : ratePerSec, std::memory_order_relaxed);
+    g_deadzoneDeg.store(deadzoneDeg < 0.0f ? 0.0f : deadzoneDeg, std::memory_order_relaxed);
+}
 
 void handle_command(const char* args) {
     float v = 0.0f;

--- a/src/game/bioshock1r/body.h
+++ b/src/game/bioshock1r/body.h
@@ -1,0 +1,73 @@
+#pragma once
+// M7.5 body-follows-head yaw transfer: rotate the invisible body/pawn facing
+// under an UNCHANGED camera, so "forward" is where the player looks.
+//
+// THE DEFECT (user, session 16 part 4): the body facing only rotates with the
+// right stick. With the head physically turned, left-stick "forward" walks
+// along the OLD facing. One root, three symptoms - the movement mapping, the
+// weapon-laser desync that grows with hand-vs-facing angle, and the rig being
+// CULLED past ~90 deg (its composition frame is the body facing).
+//
+// THE INVARIANT THIS MODULE EXISTS TO PRESERVE - read before touching it.
+// The camera and BOTH halves of the XR-controller-to-world mapping
+// (frame_context.h) are functions of the same composite:
+//
+//     camera yaw = gameYaw + (headYaw - recenterYaw)
+//     hand rot   = (gameYaw - recenterYaw) + controller yaw
+//     hand pos   = base + R(gameYaw - recenterYaw) * xr_offset * worldScale
+//
+// So transferring T into the body (gameYaw += T) while advancing the recenter
+// reference by exactly the same T leaves the final camera AND the composite
+// mapping bit-identical - only the body/head-look SPLIT of the yaw relabels.
+// In integer rotator units that is a theorem, not a tolerance:
+//
+//     rot->yaw' = (gameYaw + T) + (residual - T) = gameYaw + residual
+//
+// The hand following the head again is the defect sessions 12-16 killed; the
+// user's explicit non-regression requirement is that it never comes back. That
+// is why on_calcview RETURNS the amount actually committed and camera.cpp adds
+// exactly that to the recenter reference - the two can never drift apart
+// because they are the same integer.
+//
+// What DOES legitimately change: the AHands actor's own rotation (the
+// renderer's composition frame), because the engine places the rig from the
+// view rotation. That is the point - it is what un-culls the rig past 90 deg
+// and shrinks the camera-vs-actor split the bones render lock corrects for.
+
+#include "core/hooks/pattern_scan.h"
+
+#include <cstdint>
+
+namespace bvr::b1r::body {
+
+void init(const bvr::pattern_scan::ProcessImage& image);
+
+// Called ONCE per rendered frame from the very end of the CalcView detour -
+// after the FrameContext publish, so this frame's aim/hands consumers see the
+// (driveYawOffset, recenterYaw) pair that describes the body the engine
+// actually has right now. The write is state for the NEXT frame.
+//
+//   pc             the PlayerController the hook fired on
+//   viewActor      *view_actor out-param (gameplay/cutscene guard)
+//   gameYawUnits   the engine's own body yaw this frame (rot->yaw pre-drive)
+//   residualUnits  head-look yaw not yet absorbed, wrapped to (-32768, 32767]
+//   vrDriving      an HMD (or simhead) pose drove the camera this frame
+//
+// Returns the yaw units COMMITTED to the body. The caller must add exactly
+// this to its recenter reference - no more, no less.
+int32_t on_calcview(void* pc, void* viewActor, int32_t gameYawUnits,
+                    int32_t residualUnits, bool vrDriving);
+
+// Reset the transfer state machine (PC pointer change, world change, recenter).
+void on_reset(const char* why);
+
+// Seam commands: on | off | status | rate <perSec> | deadzone <deg> |
+// max <degPerSec> | field pc|pawn|both | probe on|off | poke <deg>
+void handle_command(const char* args);
+
+// Overlay section (render thread only).
+void draw_debug_ui();
+
+bool enabled();
+
+} // namespace bvr::b1r::body

--- a/src/game/bioshock1r/body.h
+++ b/src/game/bioshock1r/body.h
@@ -70,4 +70,9 @@ void draw_debug_ui();
 
 bool enabled();
 
+// Tuned values the VR preset persists to vrpreset.ini.
+float rate_per_sec();
+float deadzone_deg();
+void set_tuning(float ratePerSec, float deadzoneDeg);
+
 } // namespace bvr::b1r::body

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -431,6 +431,8 @@ void save_vr_preset() {
     fprintf(f, "aimTrimLYaw=%.1f\n", aim::trim_yaw_deg(0));
     fprintf(f, "aimTrimRPitch=%.1f\n", aim::trim_pitch_deg(1));
     fprintf(f, "aimTrimRYaw=%.1f\n", aim::trim_yaw_deg(1));
+    fprintf(f, "bodyRate=%.2f\n", body::rate_per_sec());
+    fprintf(f, "bodyDeadzoneDeg=%.1f\n", body::deadzone_deg());
     fclose(f);
     BVR_LOG("[b1r] VR preset values saved to vrpreset.ini");
 }
@@ -444,6 +446,7 @@ void load_vr_preset_values() {
     int n = 0;
     float lp = aim::trim_pitch_deg(0), ly = aim::trim_yaw_deg(0);
     float rp = aim::trim_pitch_deg(1), ry = aim::trim_yaw_deg(1);
+    float bodyRate = body::rate_per_sec(), bodyDz = body::deadzone_deg();
     while (fgets(line, sizeof line, f)) {
         char key[48] = {};
         float v = 0.0f;
@@ -459,11 +462,14 @@ void load_vr_preset_values() {
         else if (strcmp(key, "aimTrimLYaw") == 0) ly = v;
         else if (strcmp(key, "aimTrimRPitch") == 0) rp = v;
         else if (strcmp(key, "aimTrimRYaw") == 0) ry = v;
+        else if (strcmp(key, "bodyRate") == 0) bodyRate = v;
+        else if (strcmp(key, "bodyDeadzoneDeg") == 0) bodyDz = v;
         else --n;
     }
     fclose(f);
     aim::set_trim(0, lp, ly);
     aim::set_trim(1, rp, ry);
+    body::set_tuning(bodyRate, bodyDz);
     if (n) BVR_LOG("[b1r] VR preset: %d value(s) loaded from vrpreset.ini", n);
 }
 
@@ -480,6 +486,7 @@ void apply_vr_preset() {
     aim::handle_command("laser on");
     hands::handle_command("on");       // viewmodel follows the controller
     hands::handle_command("pose aim"); // align to the AIM ray
+    body::handle_command("on");        // M7.5: stick-forward = look direction
     load_vr_preset_values();           // tuned sliders (ini) over defaults
     scenedraw::handle_command("vrstereo on"); // last: 1t + stereo, sticky
     BVR_LOG("[b1r] VR PRESET 1 armed (unwind: vrstereo off + overlay checkboxes)");

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -9,6 +9,7 @@
 #include "core/input/xinput_bridge.h"
 #include "core/util/log.h"
 #include "game/bioshock1r/aim.h"
+#include "game/bioshock1r/body.h"
 #include "game/bioshock1r/bones.h"
 #include "game/bioshock1r/console_exec.h"
 #include "core/vr/openxr_runtime.h"
@@ -131,7 +132,17 @@ uint64_t g_lastHeartbeatMs = 0;
 uint32_t g_heartbeatBaseCount = 0;
 bool g_haveRecenter = false;
 bvr::vr::HeadPose g_recenterPose{};
-float g_recenterYawRad = 0.0f;
+// The seated frame's yaw zero, in ROTATOR UNITS (65536/turn), not radians.
+// Integer because the M7.5 body yaw transfer moves it: the camera and the
+// whole controller-to-world mapping are functions of (gameYaw - recenterYaw),
+// so the transfer adds T to the body and exactly T to this - and in integers
+// that cancellation is exact rather than merely close (body.h has the proof).
+// It also cannot accumulate: wrap_rot keeps it in (-180, +180] deg, where a
+// bare float would have drifted into ulps larger than a rotation unit after a
+// few minutes of spinning.
+int32_t g_recenterYawUnits = 0;
+// Float mirror, for the FrameContext and the telemetry only.
+float recenter_yaw_rad() { return g_recenterYawUnits / kRotUnitsPerRadian; }
 
 // Synthetic HMD lane (session 12 part 4): `simhead <yaw> <pitch> <roll>
 // [holdMs]` feeds a scripted head pose through the REAL camera drive -
@@ -373,6 +384,8 @@ void apply_command(const char* cmd, const char* args) {
         hands::handle_command(args); // M7 viewmodel; logs its own echoes
     } else if (strcmp(cmd, "vrbones") == 0) {
         bones::handle_command(args); // M7-v2 skeleton probes; logs its own echoes
+    } else if (strcmp(cmd, "vrbody") == 0) {
+        body::handle_command(args); // M7.5 yaw transfer; logs its own echoes
     } else if (strcmp(cmd, "exec") == 0) {
         console_exec::run_viewport(args); // engine console command, viewport chain
     } else if (strcmp(cmd, "execc") == 0) {
@@ -603,6 +616,9 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
     // the pre-head-offset camera loc and the yaw the drive added.
     FVector baseLoc = loc ? *loc : FVector{};
     float driveYawOffsetRad = 0.0f;
+    // The same quantity in rotator units - what M7.5 transfers to the body.
+    int32_t residualUnits = 0;
+    int32_t gameYawUnitsRaw = rot ? rot->yaw : 0; // the engine's own body yaw
     bvr::vr::HeadPose hp{};
     bool simHead = now < g_simHead.deadline;
     if (simHead) {
@@ -623,18 +639,23 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
         UeAngles a = hmd_angles(hp);
         if (g_recenterRequested.exchange(false, std::memory_order_relaxed) || !g_haveRecenter) {
             g_recenterPose = hp;
-            g_recenterYawRad = a.yawRad;
+            g_recenterYawUnits = static_cast<int32_t>(lroundf(a.yawRad * kRotUnitsPerRadian));
             g_haveRecenter = true;
+            body::on_reset("recentered");
             BVR_LOG("[b1r] vr camera recentered (yaw %.1f deg)", a.yawRad * 57.29578f);
         }
 
+        // Integer all the way through: the head-look residual is the ONLY
+        // thing added to the game's own yaw, and the M7.5 transfer subtracts
+        // from it by exactly the units it hands to the body.
         int32_t gameYawUnits = rot->yaw;
+        int32_t headYawUnits = static_cast<int32_t>(lroundf(a.yawRad * kRotUnitsPerRadian));
+        residualUnits = wrap_rot(headYawUnits - g_recenterYawUnits);
         float gameYawRad = static_cast<float>(gameYawUnits) / kRotUnitsPerRadian;
         rot->pitch = static_cast<int32_t>(a.pitchRad * kRotUnitsPerRadian);
         rot->roll = static_cast<int32_t>(a.rollRad * kRotUnitsPerRadian);
-        driveYawOffsetRad = a.yawRad - g_recenterYawRad;
-        rot->yaw = gameYawUnits +
-                   static_cast<int32_t>((a.yawRad - g_recenterYawRad) * kRotUnitsPerRadian);
+        driveYawOffsetRad = static_cast<float>(residualUnits) / kRotUnitsPerRadian;
+        rot->yaw = gameYawUnits + residualUnits;
 
         float dxr[3] = {hp.px - g_recenterPose.px, hp.py - g_recenterPose.py,
                         hp.pz - g_recenterPose.pz};
@@ -643,7 +664,8 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
         float scale = g_worldScale.load(std::memory_order_relaxed);
         // Into the recenter-local frame, then out by the game yaw (which is
         // where recenter-forward points now, since our yaw is purely additive).
-        float c = cosf(-g_recenterYawRad), s = sinf(-g_recenterYawRad);
+        float recenterYawRad = recenter_yaw_rad();
+        float c = cosf(-recenterYawRad), s = sinf(-recenterYawRad);
         float lx = d[0] * c - d[1] * s;
         float ly = d[0] * s + d[1] * c;
         float cg = cosf(gameYawRad), sg = sinf(gameYawRad);
@@ -697,7 +719,7 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
                 BVR_LOG("[tlm] head xr p=(%.3f %.3f %.3f) yaw=%.1f pitch=%.1f roll=%.1f | "
                         "recenter yaw=%.1f p=(%.3f %.3f %.3f) | headOff=(%.1f %.1f %.1f)",
                         hp.px, hp.py, hp.pz, a.yawRad * 57.29578f, a.pitchRad * 57.29578f,
-                        a.rollRad * 57.29578f, g_recenterYawRad * 57.29578f, g_recenterPose.px,
+                        a.rollRad * 57.29578f, recenter_yaw_rad() * 57.29578f, g_recenterPose.px,
                         g_recenterPose.py, g_recenterPose.pz, ox, oy, oz);
             }
         }
@@ -768,7 +790,7 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
             fc.camRoll = rot->roll;
         }
         fc.driveYawOffsetRad = driveYawOffsetRad;
-        fc.recenterYawRad = g_recenterYawRad;
+        fc.recenterYawRad = recenter_yaw_rad();
         fc.recenterPx = g_recenterPose.px;
         fc.recenterPy = g_recenterPose.py;
         fc.recenterPz = g_recenterPose.pz;
@@ -776,6 +798,31 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
         fc.viewActor = viewActor ? *viewActor : nullptr;
         fc.pc = self;
         g_lastViewActor.store(fc.viewActor, std::memory_order_relaxed);
+
+        // THE HARD-INVARIANT INSTRUMENT (session 17). Run a FIXED XR pose
+        // through the unmodified context and log where it lands. This is the
+        // exact function the aim ray and the viewmodel both call, with the
+        // real recenter values, independent of any synthetic lane - so with a
+        // static scene, any change in this line between `vrbody on` and
+        // `vrbody off` IS the hand-follows-the-head defect. gameYaw and
+        // recenterYaw must move together (that is the relabel); loc and rot
+        // must not move at all.
+        if (bones::telemetry_on()) {
+            static uint64_t lastXrmap = 0;
+            if (now - lastXrmap >= 200) {
+                lastXrmap = now;
+                const float probePos[3] = {0.15f, -0.20f, -0.35f};
+                const float probeQuat[4] = {0.0f, 0.0f, 0.0f, 1.0f};
+                GamePose gp = xr_pose_to_game(fc, probePos, probeQuat);
+                BVR_LOG("[tlm] xrmap loc=(%.3f %.3f %.3f) rot=(%d %d %d) "
+                        "gameYaw=%.5f recenterYaw=%.5f camYaw=%d dyaw=%.5f",
+                        gp.loc.x, gp.loc.y, gp.loc.z, gp.rot.pitch, gp.rot.yaw, gp.rot.roll,
+                        static_cast<double>(fc.camYaw) / kRotUnitsPerRadian -
+                            fc.driveYawOffsetRad,
+                        fc.recenterYawRad, fc.camYaw, fc.driveYawOffsetRad);
+            }
+        }
+
         aim::on_calcview(fc);
         // The viewmodel write goes LAST in the frame: the engine placed the
         // hands during its own tick, so ours has to be the one that survives.
@@ -831,6 +878,58 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
     } else if (g_wasOverridingFov) {
         *fov_ptr(self) = g_savedFov; // one-shot restore
         g_wasOverridingFov = false;
+    }
+
+    // M7.5 body-follows-head yaw transfer, LAST in the frame and for a
+    // load-bearing reason: aim::on_calcview and hands::on_calcview above
+    // consumed the (driveYawOffset, recenterYaw) pair, and that pair must
+    // describe the body facing the engine actually has RIGHT NOW. The write
+    // below is state for the NEXT frame - by then the engine's own rot->yaw
+    // carries the transferred amount and the residual has shrunk by exactly
+    // the same integer, so the camera and the hand mapping are unchanged.
+    // Transfer first and the hand would be off by T for one frame, every
+    // frame: the very defect the hard invariant forbids.
+    // Camera continuity, sampled EVERY frame (a 5 Hz line cannot see a
+    // single-frame jump). The transfer's whole safety story is "the camera is
+    // unchanged", so this tracks the largest per-frame step in the final
+    // camera yaw and counts the frames that exceed a couple of rotation units.
+    // Arming the transfer must not move either number: if the recenter fails
+    // to absorb what the body took, camYaw jumps ~8192 units and then runs
+    // away, and this line shows it inside one second.
+    if (rot && bones::telemetry_on()) {
+        static bool haveYs = false;
+        static int32_t prevYs = 0;
+        static int32_t maxStep = 0;
+        static uint32_t nbig = 0, frames = 0;
+        static uint64_t lastYs = 0;
+        if (haveYs) {
+            int32_t step = wrap_rot(rot->yaw - prevYs);
+            if (abs(step) > abs(maxStep)) maxStep = step;
+            if (abs(step) > 2) ++nbig;
+        }
+        prevYs = rot->yaw;
+        haveYs = true;
+        ++frames;
+        if (now - lastYs >= 1000) {
+            lastYs = now;
+            BVR_LOG("[tlm] yawstep max=%+d units (%.4f deg) nbig=%u frames=%u | "
+                    "camYaw=%d gameYaw=%d resid=%+d recenter=%.4f deg",
+                    maxStep, maxStep / kRotUnitsPerDegree, nbig, frames, rot->yaw,
+                    gameYawUnitsRaw, residualUnits,
+                    g_recenterYawUnits / kRotUnitsPerDegree);
+            maxStep = 0;
+            nbig = 0;
+            frames = 0;
+        }
+    }
+
+    {
+        int32_t moved = body::on_calcview(self, viewActor ? *viewActor : nullptr,
+                                          gameYawUnitsRaw, residualUnits, vrDrove);
+        // Absorb EXACTLY what the body took - never the amount we asked for.
+        // These two are the same integer, which is what makes the invariant a
+        // theorem instead of a tolerance.
+        if (moved) g_recenterYawUnits = wrap_rot(g_recenterYawUnits + moved);
     }
 }
 

--- a/src/game/bioshock1r/hands.cpp
+++ b/src/game/bioshock1r/hands.cpp
@@ -473,13 +473,20 @@ void on_calcview(const FrameContext& ctx) {
         FrameContext mapCtx = ctx;
         if (now < g_sim.deadline) {
             // Synthetic XR pose through the REAL mapping path: a fixed spot a
-            // hand would occupy, oriented by the sim angles, recenter identity.
+            // hand would occupy, oriented by the sim angles.
             pos[0] = 0.15f;  // meters right of the recenter origin
             pos[1] = -0.20f; // below it
             pos[2] = -0.35f; // in front (XR forward is -Z)
             xr_local_trim_quat(g_sim.pitchDeg / kRadToDeg, g_sim.yawDeg / kRadToDeg,
                                g_sim.rollDeg / kRadToDeg, quat);
-            mapCtx.recenterYawRad = 0.0f;
+            // POSITION zero only. The recenter YAW is deliberately left alone
+            // (session 17): forcing it to 0 here made the parked synthetic hand
+            // BODY-locked while a real controller is RECENTER-locked, so with
+            // the M7.5 yaw transfer armed the parked gun swung by the full head
+            // angle - indistinguishable by eye from the sessions-12-16
+            // head-coupling defect, but a pure artifact of this line. It was a
+            // no-op before the transfer existed: every flat baseline arms
+            // `simhead 0 0 0` first, which sets the recenter yaw to exactly 0.
             mapCtx.recenterPx = mapCtx.recenterPy = mapCtx.recenterPz = 0.0f;
         } else {
             bvr::vr::HeadPose hp{};

--- a/src/game/bioshock1r/ue_math.h
+++ b/src/game/bioshock1r/ue_math.h
@@ -22,6 +22,16 @@ constexpr float kRotUnitsPerDegree = 65536.0f / 360.0f;
 constexpr float kRotUnitsPerRadian = 65536.0f / (2.0f * kPi);
 constexpr float kRadToDeg = 57.29578f;
 
+// Shortest-way-round rotator delta, wrapped to (-32768, 32767] - i.e. to
+// (-180, +180] degrees. Rotator components are consumed modulo 65536 by this
+// engine, so this is the ONLY correct way to subtract two of them: a raw
+// subtraction of yaw 100 from yaw 65500 reads as -65400 rather than +136.
+// The M7.5 yaw transfer's exactness rests on this being integer arithmetic -
+// see body.h.
+inline int32_t wrap_rot(int32_t delta) {
+    return static_cast<int16_t>(delta & 0xFFFF);
+}
+
 inline void quat_rotate(float qx, float qy, float qz, float qw, const float v[3],
                         float out[3]) {
     float t[3] = {2.0f * (qy * v[2] - qz * v[1]), 2.0f * (qz * v[0] - qx * v[2]),


### PR DESCRIPTION
## What this fixes

The body/pawn facing only rotated with the right stick. With the head physically turned, left-stick "forward" walked along the old facing - one root cause behind three symptoms: the movement mapping, the weapon-laser desync growing with hand-vs-body angle, and the rig being culled past ~90 deg (its composition frame is the body facing).

Each frame the head-look yaw is transferred into the PlayerController's `Rotation.Yaw` and **exactly the same amount** is added to the recenter reference.

## Why the hand cannot follow the head again

The camera and both halves of the XR-controller-to-world mapping depend only on `gameYaw - recenterYaw`:

```
camera yaw = gameYaw + (headYaw - recenterYaw)
hand rot   = (gameYaw - recenterYaw) + controller yaw
hand pos   = base + R(gameYaw - recenterYaw) * xr_to_ue(pos - recenterP) * scale
```

So moving both by T is a pure relabel. In integer rotator units it is exact: `rot->yaw' = (gameYaw + T) + (residual - T) = gameYaw + residual`. The yaw path was converted to integers for that reason, and `body::on_calcview` returns the units **committed** rather than requested, so the two absorbed quantities are the same integer and cannot drift apart.

Measured, not asserted:

| check | result |
|---|---|
| composite `gameYaw - recenterYaw`, head 0/30/45/90/-45, both states | **1.27742 rad**, unchanged to 5 decimals |
| hand world pose + camera at head 45, off vs on | `rot.yaw=13323` / `camYaw=21516` - **bit-identical** |
| `[tlm] yawstep` through the arm transient | **max=0 units, nbig=0** |

## The engine finding

`PC+0x1E8` is the body facing - proven live in one boot, nine probe steps: non-zero pitch where the pawn's is 0, an additive write lands and holds, the pawn follows for free, the engine's own turn composes on our value, and a synthetic walk burst followed the written facing to **0.4 deg**. This overturns the M6-era decision-log note rejecting a controller-rotation write (correct for aim, wrong for locomotion). Full derivation in `docs/ENGINE_NOTES.md`.

## The feature, as numbers

- Transfer **off**: walk heading moved 0.18 deg for a **90 deg** head change - it tracked the body and ignored the head.
- Transfer **on**: walk == body == camera to 0.01 deg at both +45 and -45, the pair spanning 89.99 deg.

## Unplanned second payoff

The render lock's lateral correction goes from swinging **10.5 UU** across a +-30 deg head sweep to **flat within 0.46 UU**, landing on the same 4.57 the calibrated zero-split configuration uses - so the transfer restores the headset-verified session-16 regime at every head angle, not just at head 0.

## In-headset verdict

Passed on the first run: *"this is perfect... the stick was working as expected, the models didn't move when I moved my head"*. One tuning change, now the default: `vrbody deadzone` 0 -> **23 deg**. Inside the band the body does not steer, so a glance leaves the viewmodel world-locked; beyond it the body trails the head by exactly the band width.

## Safety

Probe handshake (1.1 deg test transfer, self-undoing, hard-disable after 3 failures) instead of a slow watchdog; gameplay-view guard without aim.cpp's menu escape hatch; PC-pointer and discontinuity resets; once-per-present gate; yaw written masked, pitch never touched.

Default on, armed by VR PRESET 1. `vrbody off` is the live A/B.

## Known open

The exact cull angle was **not** measured - NCC template chaining broke down across the composition changes (correlations 0.56-0.79, every pixel number void). Recorded in ENGINE_NOTES so it is not retried blind. The mechanism that caused the culling is removed, and the user reported no vanishing in the headset run.

## Acceptance

Fire test 57->51 for 6 pulls, dumps 8->8 across the whole session, stereo clean (mode=1T, presents = 2x builds, guardskips 0), preset echo chain + ini round-trip, and a 20-step +-90 deg soak returning camYaw and the recenter to their exact starting values.