### PR TITLE
M8 release quick phase: blockers fixed, per-hand tuning, crosshair, stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,15 @@ Tuning (all in the overlay, all persisted by **"Save preset values"** / `vrprese
 
 - **World scale / IPD / game FOV** - comfort and scale calibration
 - **Head anchor offsets** - if the camera sits wrong in the body
-- **Per-hand aim trim** - laser/bullet alignment per hand
+- **Per-hand aim trim** - laser/bullet direction alignment per hand
+- **Per-hand ray offsets** - the "Ray offset hand: L / R" selector + three sliders move the
+  laser (and the bullets with it - they are one ray) to line up with the controller and model
 - **Per-hand model offsets** - the "Tuning hand: L / R" selector picks which hand the six
   position/rotation sliders edit, so the pistol and the plasmid hand are tuned independently
 - **`vrbody off`** - live A/B for the body-follows-head transfer (deadzone defaults 23 deg)
+
+The flat-screen crosshair is hidden by default (the laser replaces it); the "Flat-screen
+crosshair" checkbox or `vrxhair on` brings it back.
 
 The desktop window mirrors the **left eye** while stereo runs (`vrmirror off` restores the raw
 alternating view), and the game keeps running at full speed on the monitor when you take the

--- a/README.md
+++ b/README.md
@@ -8,35 +8,68 @@ The mod is a DLL injected into the game's process. It hooks the game's DirectX 1
 the Vengeance engine (Unreal Engine 2.5 lineage) camera path, and drives them from an OpenXR
 session. No game files are modified and no game assets are distributed.
 
-> **Status:** early development - project scaffolding and injection skeleton.
-> See [docs/STATUS.md](docs/STATUS.md) for the current state and [docs/ROADMAP.md](docs/ROADMAP.md)
-> for the milestone plan (stereo rendering, motion controls, hands, selection wheels, VR menus,
-> BioShock 2 support).
+> **Status:** first playable release. Working today: full-rate stereo rendering, 6DOF head
+> tracking, motion-controller aim with a laser (right hand = weapons, left hand = plasmids),
+> the visible viewmodel following the controller, body-follows-head movement ("walk where you
+> look"), a single-eye desktop mirror, and in-headset tuning sliders that persist. See
+> [docs/STATUS.md](docs/STATUS.md) for the current state and [docs/ROADMAP.md](docs/ROADMAP.md)
+> for what is next (HUD readability in VR is the known big gap).
 
 ## Requirements
 
 - BioShock Remastered on Steam (`steamapps\common\BioShock Remastered`)
-- A PCVR-capable headset. Primary target: Meta Quest 3 with Virtual Desktop (VDXR) or Steam Link (SteamVR)
-- To build: Visual Studio 2022 Build Tools with the **x86** MSVC toolset (the game is 32-bit), git
+- A PCVR-capable headset. Primary target: Meta Quest 3 with Virtual Desktop (VDXR) or Steam
+  Link (SteamVR); any OpenXR runtime with a 32-bit loader should work
 
-## Build
+## Install (release zip)
+
+1. Download the release zip and copy **both DLLs** (`xinput1_3.dll`, `bioshockvr.dll`) into the
+   game's binary folder:
+   `...\steamapps\common\BioShock Remastered\Build\Final\`
+2. If you use **itsloopyo's head-tracking mod**, remove or back up its `xinput1_3.dll` first -
+   the two mods use the same injection vector and cannot coexist.
+3. Headset side (Quest 3 + Virtual Desktop): in Virtual Desktop's Streaming tab set the OpenXR
+   runtime to **VDXR**, connect, then launch the game from Steam inside Virtual Desktop.
+   (Steam Link / SteamVR works too - the mod talks to whatever OpenXR runtime is active.)
+4. Launch the game through Steam. The mod logs to `%LOCALAPPDATA%\BioshockVR\bioshockvr.log`.
+
+To uninstall, delete the two DLLs (restore itsloopyo's backup if you made one).
+
+## Playing in VR
+
+1. Load into the game flat first (menus are still flat-screen for now).
+2. Press **F10** to open the mod overlay and click **VR PRESET 1** - one press arms
+   everything in the right order: VR pacing, 6DOF camera, motion controllers, controller aim +
+   laser, the viewmodel drive, body-follows-head, and stereo last.
+3. Quest 3 Touch: right controller aims and fires weapons, left controller aims and casts
+   plasmids, grips switch hands, sticks move and turn.
+
+Tuning (all in the overlay, all persisted by **"Save preset values"** / `vrpreset save`):
+
+- **World scale / IPD / game FOV** - comfort and scale calibration
+- **Head anchor offsets** - if the camera sits wrong in the body
+- **Per-hand aim trim** - laser/bullet alignment per hand
+- **Per-hand model offsets** - the "Tuning hand: L / R" selector picks which hand the six
+  position/rotation sliders edit, so the pistol and the plasmid hand are tuned independently
+- **`vrbody off`** - live A/B for the body-follows-head transfer (deadzone defaults 23 deg)
+
+The desktop window mirrors the **left eye** while stereo runs (`vrmirror off` restores the raw
+alternating view), and the game keeps running at full speed on the monitor when you take the
+headset off (`vrpace off` restores the old blocking behavior).
+
+## Build from source
 
 ```powershell
 git clone --recursive https://github.com/mohamad-balouza/bioshock-vr
 cd bioshock-vr
 .\tools\build.ps1            # Debug build (finds the VS-bundled CMake automatically)
 .\tools\build.ps1 -Release   # Release build
-```
-
-## Install / uninstall
-
-```powershell
 .\tools\install.ps1          # copies the mod DLLs into the game's Build\Final folder
 .\tools\uninstall.ps1        # removes them (restores anything it backed up)
 ```
 
-Then launch the game normally through Steam. The mod writes a log to
-`%LOCALAPPDATA%\BioshockVR\bioshockvr.log` (`.\tools\tail-log.ps1` follows it live).
+Building needs Visual Studio 2022 Build Tools with the **x86** MSVC toolset (the game is
+32-bit) and git. `.\tools\tail-log.ps1` follows the log live.
 
 ## Legal
 

--- a/docs/ENGINE_NOTES.md
+++ b/docs/ENGINE_NOTES.md
@@ -1312,6 +1312,60 @@ so head AND hand rotate together in the world while the in-game body does not
 residual/cull sweep is the instrument that quantifies where the boundary sits
 in each direction.
 
+## Desktop present / mirror + hand attribution (M8 session 18, 2026-07-27)
+
+**Why the session-17 screenshots were all the same eye phase - the desktop
+present duty cycle is heavily skewed, not 50/50.** Under SequentialReentry
+with pair pacing, the two presents of one stereo pair are separated only by
+the time the game takes to BUILD the right-eye frame (~1-3 ms), while the
+right-eye image then stays on the window through the whole next pair's
+blocking xrWaitFrame (~8+ ms at 90 Hz, or the full inter-pair gap flat). A
+DWM-sourced capture (PrintWindow/screenshot) samples the composed surface and
+therefore lands on the SECOND eye of the pair with high probability - 12/12
+same-phase shots is expected behavior, not evidence that alternation is gone.
+The alternation is real (a 60 Hz recorder catches left-eye slices as flicker);
+it is just not uniform. Session-8-era captures caught both phases because
+pair pacing did not exist yet - the pair was split by a blocking wait.
+
+**The mirror fix (M8b)** rides the same sr eye tags the capture uses: left
+presents snapshot the backbuffer into a held texture (read-only), right
+presents copy it back over the backbuffer AFTER the right eye's XR capture,
+so the real Present always displays the left eye and the compositor feed is
+untouched. It also runs on presents with no open XR frame (pace-guard skip,
+session gone) since the game keeps presenting alternating eyes there. Flat
+acceptance 2026-07-27: within-condition consecutive-shot img-diff 0.31-0.73
+(the floor) for mirror on AND off - both phase-locked, as the duty cycle
+predicts - while the cross-diff mirror-on vs mirror-off is 13.6-13.9 (the
+full near-field eye offset at worldScale 100): the pin flips WHICH eye the
+window shows. Counters: holds == blits exactly, one per pair.
+
+**Grip-switch wrong-controller bug: root cause is attribution, not the game.**
+The grips compose to the BUMPERS (LB/RB) in the M5 mapping, and a bumper
+press switches the raised hand (LB -> plasmid, RB -> weapon) WITHOUT any
+trigger event. `hands::active_hand()`'s auto latch learned only from the
+composed triggers, so a grip switch left the latch (and with it the bone
+drive and the laser) on the stale controller until the next trigger pull -
+which also explains the reported self-correction after one shot. Fix: the
+latch now learns from the composed bumpers too (bumpers checked first,
+triggers second so a same-frame fire wins). Flat-proven on a clean boot:
+after two right pulls the status reads auto(R); a single LB press flips it
+to auto(L) with no trigger; RB flips it back. The fire-direction was never
+wrong: the aim seams attribute weapon-vs-plasmid structurally (which C++
+seam fired), so only the model/laser lagged.
+
+**xrWaitFrame under an idle headset (VDXR observation, M8a).** When the
+headset idles the session drops FOCUSED -> VISIBLE and per-present
+xrWaitFrame starts blocking for seconds (flat window <1 fps, presents=0/s).
+The pace guard skips the blocking wait once a session that HAS been FOCUSED
+leaves that state; bring-up is exempt (SYNCHRONIZED -> VISIBLE -> FOCUSED
+requires submitted frames to advance, so a naive not-FOCUSED gate would
+deadlock session start), and a 5 s keepalive still paces one real frame in
+case the runtime wants frames before re-granting FOCUSED. The keepalive's
+block trips the reentry watchdog's detect-only log line - expected noise.
+`xrWaitFrame` block durations now log when >1 s, so the first real headset
+idle will tell us how VDXR actually behaves (event-driven recovery vs
+keepalive-dependent).
+
 ## UnrealScript findings
 
 _(Summaries only - never paste decompiled code. Tooling: UE Explorer/UELib on

--- a/docs/ENGINE_NOTES.md
+++ b/docs/ENGINE_NOTES.md
@@ -1366,6 +1366,52 @@ block trips the reentry watchdog's detect-only log line - expected noise.
 idle will tell us how VDXR actually behaves (event-driven recovery vs
 keepalive-dependent).
 
+## Reticle + the engine SET seam (M8 session 18 part 2, 2026-07-27)
+
+**The flat crosshair has a first-class engine off-switch: `ShockPlayer.
+bReticleDisabled`.** ShockHUD.RenderReticle's FIRST branch checks
+`ShouldHideReticle()` and pushes the type string "NoReticle" to the flash HUD
+movie (`CallMethodString("SetReticleInfo", ...)`) - the game itself then
+hides the reticle every frame. `DisableReticle`/`EnableReticle`/
+`ShouldHideReticle` are three-line script functions around that one bool
+(read straight from the SOURCE TEXT embedded in ShockGame.U - see below);
+nothing else in ShockGame calls them, so nothing fights a write. Verified
+live both ways: set true -> the ornate ring at screen center vanishes
+(19 -> 0 bright pixels in an 80x80 center crop), set false -> it returns.
+
+**The bigger find: the engine's console `SET <class> <prop> <value>` handler
+WORKS through the exec seam** - `exece set shockplayer breticledisabled true`
+returned HANDLED and took effect. That means ANY script property is now
+writable BY NAME with no offset, no bitmask, no reflection walking: the
+engine resolves the property itself. SET also writes the class default, so
+newly spawned instances (load crossings) inherit the value. This closes the
+gap session 9 left ("script-command path needs the player-object Exec
+signature") for the entire SET/GET family. Caveats: it writes ALL instances
+of the class plus the default (fine for player-singleton classes); property
+GETs still need `get` (untested).
+
+**Package source-text extraction, the method.** UELib fails to deserialize
+~40% of UFunctions on this licensee build (the reticle trio included), but
+the packages embed the full UnrealScript SOURCE as UTF-16 TextBuffer objects.
+Byte-scan the .u for UTF-16 identifiers - CHECK BOTH ALIGNMENTS (a name at an
+odd byte offset is invisible to an even-aligned decode; the reticle
+functions sat at odd phase) - then read the surrounding text. Faster and
+more complete than decompiling when it works; `tools/uscript/` stays the
+workspace, findings summarized here, never the source itself.
+
+**Aim-ray origin offsets (session 18 part 2, user request).** The model
+offsets move the MESH about its pivot, so a tuned model can sit visually
+right while the aim ray no longer runs along the barrel. New per-hand
+`vraim pos [l|r] <fwd> <right> <up>` (cm) moves the RAY: applied once at ray
+build in aim.cpp along the FINAL (trimmed) ray's zero-roll basis, so the
+laser, the fire-origin substitution, and every other g_ray consumer move
+together by construction (the laser applies the same cm offset XR-side,
+meters, same basis convention: right = ray x world-up). Flat-proven exact:
+`pos r 0 60 0` moved the R ray origin (-0.7, +60.0, 0.0) UU (the 0.64 deg
+yaw cosine leak on X), `pos l 0 0 45` moved L by +45.0 UU up, each hand
+isolated, 2 fire-seam substitutions carried the offset ray, vrpreset
+round-trip (save -> zero -> apply restores).
+
 ## UnrealScript findings
 
 _(Summaries only - never paste decompiled code. Tooling: UE Explorer/UELib on

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -425,6 +425,16 @@ fixed or the release waits:**
       over the six sliders, per-hand hands.ini keys with legacy fallback, and `vrpreset
       save` now persists them too. Flat-proven: each hand's offsets apply only while that
       hand drives (0.01 UU exact), ini round-trips both formats.
+- [x] **Aim-ray origin offsets (user ask 2026-07-27, session 18 part 2)**: per-hand
+      `vraim pos [l|r] <fwd> <right> <up>` cm + "Ray offset hand" selector sliders,
+      applied once at ray build so laser + bullets + substitution move as one while the
+      tuned model stays put; vrpreset.ini persistence. Flat-exact (+-60/45 UU, per-hand
+      isolated, subs carried, round-trip).
+- [x] **Crosshair hidden by default (user ask 2026-07-27, session 18 part 2)**: the
+      engine-native lever `ShockPlayer.bReticleDisabled` written via the engine console
+      SET handler through the exec seam (the reusable name-based property-write find);
+      `vrxhair on|off` + overlay checkbox, 15 s re-assert, persisted. Flat: 19 -> 0
+      bright center pixels on a clean boot, toggle exact both ways.
 
 **HUD usability:**
 - [ ] See health + EVE clearly in VR: gameswf HUD draws redirected to offscreen RT → a

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -390,29 +390,41 @@ controller, like a native VR game. Explicitly NOT wanted: bent arms, elbows, IK,
 **Quick phase (immediately after session 17). The two defects below are RELEASE BLOCKERS
 by the user's call 2026-07-27 - they hit every user, not just this desk, so they ship
 fixed or the release waits:**
-- [ ] **Flat-screen mirror under stereo (RELEASE BLOCKER)**: the desktop window alternates
-      L/R eyes under SequentialReentry, so the mod cannot be streamed, recorded, or shown
-      to anyone on a monitor. Mirror ONE eye only (e.g. re-blit the held left-eye image on
-      right-eye presents at Present-tail) WITHOUT disturbing the eye capture the compositor
-      feeds on. Verify: consecutive window captures are phase-consistent (the img-diff
-      floor, not the ~2.0 eye-offset value) while the headset view stays correct.
-- [ ] **Headset-disconnect stall (RELEASE BLOCKER)**: taking the headset off mid-game drops
-      the flat window under 1 fps until reconnect - the per-present xrWaitFrame pacing keeps
-      waiting while the session idles (log: presents=0/s, session VISIBLE). Skip or timeout
-      the pacing when the session leaves FOCUSED; must recover cleanly on reconnect (the
-      quiet-retry path already exists).
-- [ ] **First GitHub release**: tagged build + release zip (the two DLLs) + README/INSTALL
-      section covering how to install (xinput1_3.dll proxy into `Build\Final`, the
-      itsloopyo-mod conflict note, Virtual Desktop/VDXR setup) and how to use (VR PRESET 1
-      button, the tuning sliders, vrpreset save). Ships AFTER the two blockers above.
-- [ ] **Hand-switch wrong-controller bug (user report 2026-07-27)**: switching hands via
-      GRIP instead of trigger loads the incoming hand's model on the WRONG controller
-      (e.g. the in-game right hand rides the left controller). Likely cause: the hand map
-      learns object-to-hand attribution ONLY from the trigger-keyed fire seams ("learned
-      RIGHT-hand object"); a grip-initiated switch never crosses those seams, so the drive
-      keeps the stale attribution. Cheap first check: does one trigger pull correct it?
-      Fix direction: learn from the switch path too, or read the engine's own
-      which-hand-is-raised state instead of inferring from triggers.
+- [x] **Flat-screen mirror under stereo (RELEASE BLOCKER)** - DONE flat 2026-07-27
+      (session 18): the window is pinned to the LEFT eye (left presents snapshot the
+      backbuffer, right presents re-blit it after the right eye's XR capture; also active
+      with no open XR frame). `vrmirror off` = the old alternation. Flat acceptance:
+      within-condition shot diffs at the 0.3-0.7 floor, mirror-on vs mirror-off cross-diff
+      13.6-13.9 (the near-field eye offset) - the pin flips the displayed eye; holds ==
+      blits exactly. Headset-side confirmation (stereo still correct in the HMD) is on the
+      session-18 checklist. ENGINE_NOTES session 18 explains why single screenshots always
+      looked same-phase (present duty cycle, not absence of alternation).
+- [x] **Headset-disconnect stall (RELEASE BLOCKER)** - DONE flat 2026-07-27 (session 18):
+      the pace guard skips per-present xrWaitFrame once a previously-FOCUSED session
+      leaves FOCUSED (bring-up exempt; 5 s keepalive as recovery insurance; `vrpace off`
+      = old behavior). Flat, with a simulated idle (`vrpace simidle on`, 1 s block per
+      paced frame): guard ON holds 378-396 presents/s, guard OFF collapses to 1/s, guard
+      re-on recovers to 416/s within seconds. Real-headset idle/reconnect is on the
+      session-18 checklist (the >1 s wait logging will show how VDXR behaves).
+- [ ] **First GitHub release**: README rewritten with install (proxy DLLs, itsloopyo
+      conflict, VDXR setup) and VR usage (PRESET 1, sliders, vrpreset save, per-hand
+      offsets); release zip built (both RelWithDebInfo DLLs + README.txt). REMAINING:
+      the user's in-headset verification, then tag + publish (user gate - nothing public
+      without their go).
+- [x] **Hand-switch wrong-controller bug (user report 2026-07-27)** - root-caused and
+      FIXED flat 2026-07-27 (session 18): grips compose to the bumpers, and the auto-hand
+      latch learned only from triggers, so a grip switch left the model+laser on the stale
+      controller until the next pull (hence the predicted self-correction). The latch now
+      learns from the composed bumpers too (LB -> left/plasmid, RB -> right/weapon;
+      triggers still win same-frame). Flat: status auto(R) -> LB alone -> auto(L) -> RB
+      alone -> auto(R), no trigger events. Headset confirmation on the checklist.
+
+- [x] **Per-hand model offsets (user ask 2026-07-27, session 18)**: the viewmodel's
+      position/rotation offsets are per hand (L plasmid / R weapon) - `vrhands pos|rot
+      [l|r] ...` (no side = both, harness-compatible), a "Tuning hand: L / R" selector
+      over the six sliders, per-hand hands.ini keys with legacy fallback, and `vrpreset
+      save` now persists them too. Flat-proven: each hand's offsets apply only while that
+      hand drives (0.01 UU exact), ini round-trips both formats.
 
 **HUD usability:**
 - [ ] See health + EVE clearly in VR: gameswf HUD draws redirected to offscreen RT → a

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1361,15 +1361,20 @@ and it resumes.
   0.2/17.7, aimPosL 0.2/-0.5/-0.7 - "make them in the preset" done; NOT
   baked as code defaults (per-weapon differences pending). The inis on this
   box are now LIVE USER DATA - do not delete them in cleanup anymore.
-- **Test loadout**: the cheat path is closed - `giveall` (ShockCheatManager
-  has GiveAll/FillPlasmids) fell off the client+engine exec chains and
-  FAULTED the viewport chain (SEH caught; relaunched). The Tab console is
-  compiled out (known). Route chosen: the Nexus NG+ save (nexusmods.com
-  /bioshock/mods/77 - end-of-game at the Fontaine fight, all weapons with
-  mods, almost all plasmids, filename per the Steam guide; installs into
-  Documents\BioshockHD\Bioshock\SaveGames) - needs the user's Nexus login,
-  so they download, we install/verify. Per-weapon aim variance is the open
-  design question after that (per-weapon profiles keyed by class name need
+- **Test loadout: DONE.** The cheat path is closed - `giveall`
+  (ShockCheatManager has GiveAll/FillPlasmids) fell off the client+engine
+  exec chains and FAULTED the viewport chain (SEH caught; relaunched). The
+  Tab console is compiled out (known). The Nexus NG+ save (nexusmods.com
+  /bioshock/mods/77) was downloaded by the user, installed as
+  `7_21_2024_21_54_13.bsb` (13.6 MB, mtime touched to newest) into
+  Documents\BioshockHD\BioShock\SaveGames, and USER-VERIFIED: it loads at
+  the Fontaine fight with ALL weapons and plasmids in the LB/RB wheels.
+  Boot note: CONTINUE loaded the wall save anyway (it tracks last-played,
+  not newest mtime) - pick the NG+ save via LOAD explicitly; the flat
+  harness is unaffected. Two observations for the headset run: the shotgun
+  (and likely others) is a TWO-HANDED hold mesh - a new composition class
+  for the one-controller bone drive - and per-weapon aim variance is the
+  open design question (per-weapon profiles keyed by class name would need
   the FName resolution work).
 - Dumps 8->8 across part 3.
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -83,6 +83,39 @@ firing pulls with an LB/RB plasmid round-trip in between, fresh decal, dumps
 guardskips 0). Test-artifact inis (hands.ini with zeros, vrpreset.ini with
 defaults) deleted after the run per the session-17 trap - code owns defaults.
 
+### Session 18 part 2 (same day): aim-ray origin offsets + the crosshair kill
+
+**6. Aim-ray ORIGIN offsets (user ask: "the aim is the thing that is
+misaligned, not the model").** New per-hand `vraim pos [l|r] <fwd> <right>
+<up>` in cm (no side = both), an overlay "Ray offset hand: L / R" selector
+with three sliders under the existing trim sliders, persisted in vrpreset.ini
+(aimPosL*/aimPosR*). Applied ONCE at ray build (aim.cpp) along the FINAL
+(trimmed) ray's zero-roll basis, so the laser, the fire-origin substitution,
+and everything else reading the ray move together by construction - the
+model deliberately does NOT take them (its own sliders stay, and the two are
+tuned against each other). The laser applies the identical cm offset XR-side
+in meters with the same basis convention. Flat-proven exact under vrstereo:
+`pos r 0 60 0` moved the R ray origin by (-0.7, +60.0, 0.0) UU with the L ray
+bit-identical; `pos l 0 0 45` moved L +45.0 UU up; two fire-seam
+substitutions carried the offset ray (subs=2); save -> zero -> preset apply
+restored both hands' values from the ini.
+
+**7. The flat crosshair is GONE by default (user ask), and the lever is a
+one-line engine property.** `ShockPlayer.bReticleDisabled` makes the game's
+own RenderReticle push "NoReticle" to the flash HUD every frame - found by
+reading the SCRIPT SOURCE embedded in ShockGame.U (the reticle functions are
+in the 40% UELib cannot decompile; the source text can, ENGINE_NOTES session
+18 part 2). It is written through **the engine's own console SET handler via
+the exec seam** - `set ShockPlayer bReticleDisabled True` -> HANDLED - which
+is the session's biggest reusable find: ANY script property is now writable
+by name, no offsets, no reflection (SET also writes the class default, so
+load-crossing pawns inherit it). Shipped as `vrxhair on|off|status` +
+overlay checkbox ("Flat-screen crosshair", VR camera section), DEFAULT
+HIDDEN, re-asserted every 15 s, `crosshairVisible` persisted in vrpreset.ini.
+Flat: clean boot hides it automatically (19 -> 0 bright pixels in the center
+crop, screenshot-verified), `vrxhair on` restores those exact pixels, off
+kills them again, dumps 8->8.
+
 ## Previous state (2026-07-27, session 17 - M7.5 SHIPS AND IS IN-HEADSET VERIFIED; DEADZONE 23 DEG BY USER CALIBRATION)
 
 **IN-HEADSET VERDICT (same day): "This is perfect... the stick was working as
@@ -1157,11 +1190,25 @@ first.
    within a few seconds. Then check `vrpace status` in the log and tell me
    the skips/keepalives numbers and any "xrWaitFrame blocked N ms" lines -
    they tell us whether VDXR needed the keepalive.
-6. **Expected noise, not bugs**: during headset-off idle the log prints a
+6. **THE RAY OFFSET SLIDERS (part 2, your ask).** In the aim section, "Ray
+   offset hand: L / R" + three sliders (forward/right/up, cm). Tune the
+   LASER onto the barrel of the tuned model: the beam and the bullets move
+   together (one ray by construction), the model does not move. Check a shot
+   actually lands on the laser after tuning - that is the invariant that
+   matters. Then "Save preset values" and confirm it comes back after a
+   reload + PRESET 1.
+7. **THE CROSSHAIR (part 2, your ask).** The flat head-centred crosshair
+   should simply be GONE from the moment the game is up - no preset needed,
+   hidden is the default. The overlay checkbox "Flat-screen crosshair" (VR
+   camera section) or `vrxhair on` brings it back live if you ever want it.
+   Check it STAYS gone across a save load and a level transition.
+8. **Expected noise, not bugs**: during headset-off idle the log prints a
    watchdog "deadlock state detected (log only)" line every ~5 s (the
    keepalive block trips it); the VD menu overlay still parks the model
-   dead-center (VISIBLE state, poses stop - known since session 16).
-7. **Anything off: `vrmirror off` / `vrpace off` first.** If the symptom
+   dead-center (VISIBLE state, poses stop - known since session 16); and the
+   log prints one `engine exec 'set ShockPlayer bReticleDisabled True' ->
+   HANDLED` line every 15 s (the crosshair re-assert).
+9. **Anything off: `vrmirror off` / `vrpace off` first.** If the symptom
    survives both, it predates this session.
 
 ### PREVIOUS CHECKLIST - M7.5 body-follows-head (session 17) - PASSED
@@ -1295,6 +1342,32 @@ and it resumes.
   (install.ps1 backs theirs up automatically).
 
 ## Session log (newest first)
+
+### 2026-07-27 - Session 18 part 2 (aim-ray origin offsets + the crosshair kill via the engine SET seam)
+
+- Two user asks, both flat-green same day:
+- **Aim-ray origin offsets**: per-hand `vraim pos [l|r] <f> <r> <u>` cm,
+  "Ray offset hand" selector + 3 sliders, vrpreset persistence. Applied once
+  at ray build along the trimmed ray's zero-roll basis; the laser applies the
+  identical offset XR-side (same basis convention: right = ray x world-up),
+  so beam + bullet + substitution move as one and the model stays put. Flat:
+  +60.0 UU right / +45.0 UU up exact, per-hand isolated, subs=2 carried the
+  offset, ini round-trip via save -> zero -> apply.
+- **Crosshair hidden by default**: the lever is `ShockPlayer.bReticleDisabled`
+  (game-side RenderReticle then pushes "NoReticle" to the flash HUD per
+  frame), found by reading the script SOURCE TEXT embedded in ShockGame.U
+  after UELib failed to decompile the reticle functions. Written via **the
+  engine's console SET handler through the exec seam** (`exece set
+  shockplayer breticledisabled true` -> HANDLED) - the reusable find: any
+  script property is now settable BY NAME with no offset/bitmask, and SET
+  writes the class default so it survives load crossings. Shipped
+  `vrxhair on|off` + checkbox, default hidden, 15 s re-assert,
+  `crosshairVisible` in vrpreset.ini. Flat: clean boot 0 bright center
+  pixels (was 19), toggle restores/kills them exactly, dumps 8->8.
+- Method note: package source-text extraction needs BOTH UTF-16 alignments
+  (odd-phase strings are invisible to an even-aligned decode), and char
+  indices in a decoded string are half the byte offset - one extraction ran
+  at the wrong offset before the arithmetic was fixed.
 
 ### 2026-07-27 - Session 18 (M8 quick phase: both blockers + per-hand offsets + grip fix, all flat-green; release staged)
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,7 +2,88 @@
 
 > Handoff file. Rewrite "Current state" and "Next steps" every session; append to the session log.
 
-## Current state (2026-07-27, session 17 - M7.5 SHIPS AND IS IN-HEADSET VERIFIED; DEADZONE 23 DEG BY USER CALIBRATION)
+## Current state (2026-07-27, session 18 - M8 QUICK PHASE CODE-COMPLETE FLAT: both release blockers fixed, per-hand offsets, grip-switch fix, release zip staged)
+
+**Branch `m8-release-quick-phase` (from main at PR #2's merge). Everything below
+is flat-verified on clean boots with numeric acceptance; the in-headset run is
+the open gate, and the GitHub release publishes only after it + the user's
+explicit go.**
+
+**1. Per-hand model offsets (the user's ask, shipped first).** The viewmodel's
+six position/rotation offsets are now PER HAND (0 = left/plasmid, 1 =
+right/weapon, same convention as `vraim cal`): `vrhands pos [l|r] <f> <r> <u>`
+and `vrhands rot [l|r] <p> <y> <r>` - no side = BOTH hands, so the harness and
+old scripts are untouched; the overlay grew a "Tuning hand: L / R" selector
+above the existing six sliders (not twelve sliders); hands.ini persists
+per-hand keys (`posFwdCmL/R`, ...) with the legacy suffix-less key loading to
+both; and **`vrpreset save` now also writes hands.ini**, so the one in-headset
+save button covers the model sliders. Flat proof, all exact: with the right
+hand driving, `pos r 40 0 0` moved the written loc +40.0 UU along fwd, a LEFT
+offset left it bit-identical at baseline; with `hand l` the left offset
+engaged (+40.0); `rot r 0 30 0` moved the written yaw by exactly 5461 units;
+both ini formats round-trip. The M7.5 invariant is untouched by construction -
+the change only swaps WHICH atomic feeds the existing trim/offset math,
+nothing in the camera/recenter path was edited.
+
+**2. Headset-disconnect stall (M8 blocker a) - FIXED flat.** When the headset
+idles, the session leaves FOCUSED and per-present xrWaitFrame blocks for
+seconds (<1 fps flat). The new pace guard (openxr_runtime.cpp) skips the
+blocking pacing once a session that HAS been FOCUSED leaves that state.
+Bring-up is exempt - SYNCHRONIZED -> VISIBLE -> FOCUSED needs submitted frames
+to advance, a naive not-FOCUSED gate would deadlock session start - and a 5 s
+keepalive still paces one real frame in case VDXR wants frames before
+re-granting FOCUSED (event recovery is primary: pump_events runs every present
+regardless). `vrpace on|off|simidle on|off|status`; wait durations >1 s now
+log with the session state. Flat acceptance via the simulated idle (state
+forced VISIBLE, 1 s sleep in place of the blocked wait): guard ON held
+378-396 presents/s with one keepalive hitch per 5 s; guard OFF reproduced the
+field stall exactly (presents=1/s); re-enabling recovered to 416/s. Known
+cosmetic: each keepalive block trips the reentry watchdog's detect-only line.
+
+**3. Flat-screen mirror (M8 blocker b) - FIXED flat, and the session-17 clue
+is EXPLAINED.** The window now always displays the LEFT eye: left-tagged
+presents snapshot the backbuffer (read-only), right-tagged presents re-blit
+the held image AFTER the right eye's XR capture, so the compositor feed is
+untouched; the pin also runs on presents with no open XR frame (pace-guard
+skips / no session - the game still presents alternating eyes there).
+`vrmirror on|off|status`. Why all 12 session-17 shots were one phase: the
+pair's presents have wildly unequal display time (L visible only while the R
+frame builds, ~1-3 ms; R through the next blocking wait, ~8+ ms), so
+DWM-sourced captures land on R with high probability - duty-cycle skew, not
+absent alternation (ENGINE_NOTES session 18). Acceptance matches that model:
+within-condition consecutive shots sit at the 0.31-0.73 floor for BOTH mirror
+on and off, while the on-vs-off cross-diff is 13.6-13.9 (the near-field eye
+offset at worldScale 100) - the pin flips which eye the window shows. Holds ==
+blits exactly (74774 each); stereo heartbeat unaffected (presents = 2x builds,
+guardskips 0).
+
+**4. Grip-switch wrong-controller bug - ROOT-CAUSED AND FIXED flat (the
+ROADMAP theory was right).** Grips compose to the bumpers, a bumper press
+switches the raised hand with no trigger event, and `active_hand()`'s auto
+latch learned only from triggers - so the model+laser stayed on the stale
+controller until the next pull (= the predicted self-correction). The latch
+now learns from the composed bumpers too (LB -> left/plasmid, RB ->
+right/weapon; triggers checked second so a same-frame fire wins). Live flat
+repro then fix-proof on a clean boot: two right pulls -> status `auto(R)`; LB
+alone raised Electro Bolt and (pre-fix) left the latch RIGHT; post-fix LB
+alone flips to `auto(L)`, RB back to `auto(R)`, no triggers. Fire direction
+was never affected (seam attribution is structural). Status now prints the
+latched hand: `hand=auto(L|R)`.
+
+**5. Release prep (task 4) - staged, NOT published.** README rewritten
+(install incl. itsloopyo conflict + VDXR setup, VR PRESET 1 flow, tuning incl.
+per-hand offsets, mirror/pace defaults; overlay key verified F10). Release zip
+built from the RelWithDebInfo build (both DLLs + README.txt) at the session-18
+scratchpad as `bioshock-vr-v0.1.0.zip`. Tag + GitHub release wait for the
+in-headset verdict and the user's explicit go.
+
+**Promoted-build clean-boot smoke (grip-fix build):** fire test 59->53 for 6
+firing pulls with an LB/RB plasmid round-trip in between, fresh decal, dumps
+8->8 all session, vrstereo heartbeat clean (mode=1T, presents = 2x builds,
+guardskips 0). Test-artifact inis (hands.ini with zeros, vrpreset.ini with
+defaults) deleted after the run per the session-17 trap - code owns defaults.
+
+## Previous state (2026-07-27, session 17 - M7.5 SHIPS AND IS IN-HEADSET VERIFIED; DEADZONE 23 DEG BY USER CALIBRATION)
 
 **IN-HEADSET VERDICT (same day): "This is perfect... the stick was working as
 expected, the models didn't move when I moved my head... so just needed that
@@ -969,28 +1050,25 @@ https://github.com/mohamad-balouza/bioshock-vr. Em dashes banned repo-wide.
 
 ## Next steps
 
-0. **DONE: the user verified M7.5 in-headset - "this is perfect".** Deadzone
-   defaulted to their tuned 23 deg. Branch `m7.5-body-yaw-transfer` is ready to
-   merge to main by PR.
-1. **THE M8 QUICK PHASE - both items are RELEASE BLOCKERS by the user's call,
-   and neither was started in session 17** (the session went entirely on M7.5
-   and its verification):
-   (a) **headset-disconnect stall** - the flat window drops under 1 fps while
-   the headset idles (presents=0/s, session VISIBLE in the log; the per-present
-   xrWaitFrame pacing keeps waiting). Skip or time out the pacing when the XR
-   session leaves FOCUSED; must recover cleanly on reconnect.
-   (b) **flat-screen mirror** - the desktop window alternates L/R eyes under
-   SequentialReentry, so the mod cannot be streamed, recorded, or shown. Re-blit
-   the held left-eye image on right-eye presents at Present-tail WITHOUT
-   touching the eye capture the compositor feeds on. Verify: consecutive window
-   captures phase-consistent (the img-diff floor, not the eye-offset value).
-   *Note from session 17: all 12 acceptance shots came out the SAME eye phase,
-   so the alternation is not uniform - worth understanding while fixing it.*
-   Then the first GitHub release (tagged build, zip with both DLLs,
-   README/INSTALL covering the xinput1_3 proxy, the itsloopyo conflict, Virtual
-   Desktop/VDXR setup, and use: VR PRESET 1, the sliders, `vrpreset save`), and
-   the grip-switch wrong-controller bug (spec in ROADMAP M8; cheap first check
-   is whether it self-corrects after one trigger pull). Then M8's HUD usability.
+0. **THE IN-HEADSET RUN for session 18's four changes** - the checklist below.
+   Everything is flat-green; the headset decides. If it passes, open the PR
+   for `m8-release-quick-phase`.
+1. **Publish the first GitHub release AFTER the user's explicit go** (their
+   rule: nothing public-facing without asking): tag (proposed v0.1.0) on the
+   merged main, upload the zip (rebuild from the tagged commit: `build.ps1
+   -Release`, then zip the two RelWithDebInfo DLLs + README.txt), release
+   notes from the README's status blurb.
+2. **Watch the pace-guard telemetry on the first real headset idle**: the >1 s
+   xrWaitFrame log lines + `vrpace status` skips/keepalives show whether VDXR
+   recovers via events alone (then the 5 s keepalive can lengthen) or needs
+   the keepalive. If the headset-off window still stalls in the field, the
+   fallback design is an async wait thread - not built because the sync gate
+   passed flat.
+3. **Then M8's HUD usability** (health/EVE on a floating quad during stereo
+   gameplay + the Quest 3 keybind audit) - the remaining M8 items.
+
+Carried-over backlog (numbering kept from session 17):
+
 2. **The M7.5 leftover: the exact cull angle.** Park `vrhands simpose <yaw> 0 0
    120000` at 0/30/60/80/90/100/120 from the facing and find the cull-on/off
    boundary from both directions - but NOT with NCC template chaining, which
@@ -1040,7 +1118,53 @@ https://github.com/mohamad-balouza/bioshock-vr. Em dashes banned repo-wide.
 13. **Parked in M9** (user's call 2026-07-24): IPD slider verification, small
     head-motion bobbing, the vrstereo off/re-arm state bug, HUD-in-both-eyes.
 
-### IN-HEADSET CHECKLIST - M7.5 body-follows-head (session 17) - PASSED
+### IN-HEADSET CHECKLIST - M8 quick phase (session 18)
+
+Setup as always: Quest 3 + Virtual Desktop (VDXR), launch from Steam, load the
+newest save, press **VR PRESET 1**. Four changes to judge; `vrmirror off`,
+`vrpace off`, and the L/R forms are the live A/Bs. Nothing in the camera or
+recenter path changed, so head decoupling and body-follow should feel
+IDENTICAL to session 17 - anything different there is a regression, say so
+first.
+
+1. **Non-regression sweep (do this first, 60 seconds).** Park the hand, look
+   around wide - the model must hold its world spot exactly like session 17.
+   Stick-walk where you look, turn past 90 both ways, two right-trigger pulls
+   + an Electro Bolt. Any drag, drift, or stutter that session 17 did not
+   have: stop and report.
+2. **THE GRIP-SWITCH FIX (the bug you reported).** Switch hands with the GRIP
+   several times, in both directions, WITHOUT pulling triggers in between.
+   The incoming hand's model must appear on the CORRECT controller
+   immediately - no wrong-controller model, no needing a trigger pull to fix
+   it. Then mix in trigger switching to confirm nothing regressed there.
+3. **PER-HAND MODEL OFFSETS (your ask).** Overlay -> "Hands + weapon (M7)":
+   above the six sliders there is now "Tuning hand: L (plasmid) / R (weapon)".
+   With the pistol up, tune R sliders - the plasmid hand must NOT move when
+   you later raise it. Switch the selector to L, tune the plasmid hand - the
+   pistol must stay where you put it. Press **"Save preset values"** (one
+   button now saves these too), quit to menu, reload, PRESET 1 - both hands'
+   tuning must come back.
+4. **THE DESKTOP MIRROR (blocker b).** While playing in stereo, glance at the
+   monitor (or better: have the phone record it / stream it). The window must
+   show ONE steady eye - no L/R flicker, no shimmer. In the HEADSET nothing
+   may change: stereo depth still correct both eyes (this is the one thing
+   flat cannot verify - the re-blit must not have touched the compositor
+   feed). `vrmirror off` = the old flickering window for comparison.
+5. **THE DISCONNECT STALL (blocker a).** Mid-game, take the headset off and
+   let it sleep (or close Virtual Desktop streaming). The flat window must
+   KEEP RUNNING at full speed (the old behavior was <1 fps). Put the headset
+   back on / reconnect VD: the game must come back into the headset cleanly
+   within a few seconds. Then check `vrpace status` in the log and tell me
+   the skips/keepalives numbers and any "xrWaitFrame blocked N ms" lines -
+   they tell us whether VDXR needed the keepalive.
+6. **Expected noise, not bugs**: during headset-off idle the log prints a
+   watchdog "deadlock state detected (log only)" line every ~5 s (the
+   keepalive block trips it); the VD menu overlay still parks the model
+   dead-center (VISIBLE state, poses stop - known since session 16).
+7. **Anything off: `vrmirror off` / `vrpace off` first.** If the symptom
+   survives both, it predates this session.
+
+### PREVIOUS CHECKLIST - M7.5 body-follows-head (session 17) - PASSED
 
 **Result: passed on the first run.** Head decoupling held ("the models didn't
 move when I moved my head"), the stick worked as expected, and looking to a
@@ -1171,6 +1295,53 @@ and it resumes.
   (install.ps1 backs theirs up automatically).
 
 ## Session log (newest first)
+
+### 2026-07-27 - Session 18 (M8 quick phase: both blockers + per-hand offsets + grip fix, all flat-green; release staged)
+
+- Branch `m8-release-quick-phase` off main (post-PR-#2). Five commits: per-hand
+  offsets, pace guard, mirror pin, grip-switch latch fix, docs/release.
+- **Per-hand model offsets** (user ask): `vrhands pos|rot [l|r]` (no side =
+  both), overlay "Tuning hand" selector, per-hand hands.ini keys + legacy
+  fallback, `vrpreset save` also writes hands.ini now. Flat: each hand's
+  offsets apply only while that hand drives - +40.0 UU exact when driving,
+  baseline bit-identical when not; rot trim +5461 units exact for 30 deg;
+  both ini formats round-trip.
+- **Pace guard (blocker a)**: skip per-present xrWaitFrame once a
+  previously-FOCUSED session leaves FOCUSED; bring-up exempt (the state
+  machine needs frames to REACH focused); 5 s keepalive as recovery
+  insurance; >1 s waits now logged with state. Flat via `vrpace simidle on`
+  (state forced VISIBLE + 1 s sleep standing in for the blocked wait):
+  guard ON 378-396 presents/s, guard OFF 1/s (the field stall reproduced),
+  re-on recovers 416/s. 21345 skips / 15 keepalives across the sim, clean.
+- **Mirror pin (blocker b)**: window always shows the LEFT eye - left
+  presents snapshot the backbuffer, right presents re-blit AFTER the right
+  eye's XR capture; also active with no open XR frame (that path is exactly
+  the headset-off case). Flat: within-condition shots at the 0.31-0.73
+  floor for BOTH mirror on and off; on-vs-off cross-diff 13.6-13.9 = the
+  pin flips the displayed eye; holds == blits (74774 each); stereo
+  heartbeat unchanged.
+- **The session-17 same-phase clue EXPLAINED** (ENGINE_NOTES session 18):
+  under pair pacing the L image is displayed only while the R frame builds
+  (~1-3 ms) but R persists through the next blocking wait (~8+ ms), so
+  DWM-sourced captures land on R with high probability. Duty-cycle skew,
+  not absent alternation - the naive 50/50 bimodal model was wrong, and
+  the acceptance numbers match the corrected model exactly.
+- **Grip-switch bug root-caused and fixed** (ROADMAP theory confirmed):
+  grips compose to bumpers; a bumper press switches the raised hand with no
+  trigger event; the auto latch learned only from triggers. Live flat repro
+  (LB raised Electro Bolt, latch stayed RIGHT), then fix (latch learns from
+  composed bumpers, triggers win same-frame), then flat proof on a clean
+  boot: auto(R) -> LB alone -> auto(L) -> RB alone -> auto(R). Status now
+  prints the latch (`hand=auto(L|R)`).
+- Promoted-build smoke: fire 59->53 for 6 firing pulls with an LB/RB
+  round-trip between, dumps 8->8 all session, stereo clean throughout.
+- Release staged, NOT published (user gate): README rewritten (install,
+  itsloopyo conflict, VDXR setup, PRESET 1, tuning, mirror/pace), zip with
+  both RelWithDebInfo DLLs at the session-18 scratchpad. Proposed tag
+  v0.1.0 after the in-headset run.
+- Harness notes: `2>&1` on a native exe in PowerShell 5.1 still wraps
+  stderr as errors (cost one build re-run); test-artifact inis deleted
+  after the run per the session-17 vrpreset trap.
 
 ### 2026-07-27 - Session 17 part 2 (IN-HEADSET: PASSED; deadzone 23 deg becomes the default)
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1343,6 +1343,36 @@ and it resumes.
 
 ## Session log (newest first)
 
+### 2026-07-27 - Session 18 part 3 (trim decoupling + the user's tuning captured; loadout via Nexus save pending)
+
+- **In-headset feedback from the user's first part-2 run**: the ray offsets
+  work (they tuned R right-7.9/up+7.5 cm live), BUT re-trimming the aim
+  rotation dragged the tuned MODEL with it - the session-11 "barrel follows
+  the ray by construction" coupling, now wrong because the model has its own
+  per-hand trim. FIXED: the aim calibration trim is no longer applied to the
+  model (model = raw aim pose + model trim; ray = raw aim pose + aim trim +
+  origin offset). `vrhands aligntrim on` restores the old coupling. Flat:
+  with `cal r 0 20` armed the model rot stayed bit-identical (0 116 0);
+  aligntrim on moved it exactly +20 deg (3756). NOTE for the headset: the
+  user's L trim (17.7 deg yaw) was tuned WITH the coupling live - the left
+  hand may need a re-tune under the fix.
+- **The user's live tuning was captured to the inis** (they had not pressed
+  save): vrpreset.ini now holds aimPosR right-7.9/up+7.5, aimTrimL
+  0.2/17.7, aimPosL 0.2/-0.5/-0.7 - "make them in the preset" done; NOT
+  baked as code defaults (per-weapon differences pending). The inis on this
+  box are now LIVE USER DATA - do not delete them in cleanup anymore.
+- **Test loadout**: the cheat path is closed - `giveall` (ShockCheatManager
+  has GiveAll/FillPlasmids) fell off the client+engine exec chains and
+  FAULTED the viewport chain (SEH caught; relaunched). The Tab console is
+  compiled out (known). Route chosen: the Nexus NG+ save (nexusmods.com
+  /bioshock/mods/77 - end-of-game at the Fontaine fight, all weapons with
+  mods, almost all plasmids, filename per the Steam guide; installs into
+  Documents\BioshockHD\Bioshock\SaveGames) - needs the user's Nexus login,
+  so they download, we install/verify. Per-weapon aim variance is the open
+  design question after that (per-weapon profiles keyed by class name need
+  the FName resolution work).
+- Dumps 8->8 across part 3.
+
 ### 2026-07-27 - Session 18 part 2 (aim-ray origin offsets + the crosshair kill via the engine SET seam)
 
 - Two user asks, both flat-green same day:

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1083,9 +1083,68 @@ https://github.com/mohamad-balouza/bioshock-vr. Em dashes banned repo-wide.
 
 ## Next steps
 
-0. **THE IN-HEADSET RUN for session 18's four changes** - the checklist below.
-   Everything is flat-green; the headset decides. If it passes, open the PR
-   for `m8-release-quick-phase`.
+0. **SESSION 19 PLAN - the user's four reports from the all-weapons run
+   (investigated 2026-07-27 session 18 part 4, code untouched; work them in
+   this order):**
+
+   (a) **Model/laser sync - the ROOT CAUSE is two different trim algebras,
+   so one tuning only holds at ONE controller orientation.** The ray's trim
+   is rotator ADDS in game space (yaw about world-up, pitch about horizon -
+   aim.cpp ray build and the laser's XR-side math, deliberately identical);
+   the model's trim is a QUATERNION COMPOSED IN THE CONTROLLER'S LOCAL FRAME
+   (hands.cpp, the session-11 fix for the "pivot breaks everything" bug).
+   Those agree at the tuning pose and DIVERGE as the controller rotates -
+   the divergence grows with both the trim size and the rotation from the
+   tuning pose. It did NOT regress: before part 3 the coupling HID it
+   (the model inherited the ray's trim on top of its own); decoupling made
+   it visible. FIX: convert the aim trim (ray + laser, both sides) to the
+   SAME local-frame quaternion compose the model uses; after that one
+   tuning holds at every orientation. Numeric gate BEFORE any headset ask:
+   a `synccheck` self-test that sweeps ~20 simpose orientations and prints
+   the angle between the model's driven rot and the ray rot - max
+   divergence should collapse to ~0 after the algebra unification (it will
+   NOT be 0 before). The render lock is position-only (gain 0.9) and can
+   still shift the model a few UU relative to the beam - measure it in the
+   same sweep, list it separately.
+
+   (b) **Auto-derive the barrel per weapon (the user's ask) - feasible via
+   the weapon's OWN skeleton, and the FName resolution unlocks it.** The
+   equipped weapon is a skeletal mesh (reload anims) attached to hand bone
+   43; muzzle-flash FX anchor somewhere on it, so a muzzle bone/socket very
+   likely exists. Probe: read the weapon ACTOR's SkeletonInstance (try the
+   AHands offset +0x3FC first - same engine actor layout), dump its bone
+   array per weapon, find the muzzle bone (tip-most along the barrel axis;
+   names make it trivial). Then aim ray := muzzle bone's world transform
+   mapped through the existing chain - laser and bullets follow the
+   RENDERED barrel exactly, zero manual tuning, per-weapon automatic, and
+   the whole per-weapon-profile question dissolves. PREREQUISITE that pays
+   twice: FName index -> string resolution (parked since session 11; also
+   the key for per-weapon ini profiles as the fallback if no muzzle bone
+   exists). Fallback if skeleton probing fails: per-weapon manual profiles
+   keyed by class name.
+
+   (c) **Right-stick pitch must die under VR.** The composed pad's right
+   stick Y feeds the game's pitch: the PC/pawn ViewRotation pitches, and
+   the renderer orients the rig by the ACTOR fields, so the MODEL rides the
+   stick (the user's report) - and the wrench's Havok melee phantom swings
+   where the BODY pitch points, not the hand (the melee-hitbox half of the
+   report). Fix step 1 (surgical): zero the right-stick Y in the composed
+   pad while the VR camera drives (gameplay only - menus keep it). Fix
+   step 2 (evaluate after 1): drive the body PITCH from the HMD the way
+   M7.5 drives yaw, so melee/interactions follow the head; the M7.5
+   probe/commit machinery is the template. Step 1 alone likely kills both
+   symptoms - measure melee aim before building step 2.
+
+   (d) **Hide the inactive hand.** The mechanism already exists: the sleeve
+   collapse (bones.cpp `g_collapse`, zero-scale). Extend it to the whole
+   INACTIVE hand cluster - left wrist 6 + fingers 7-21 when the weapon is
+   up; right wrist 27 + fingers 28-42 + weapon bone 43 when the plasmid is
+   up. `vrhands hideinactive on|off`, default ON. Watch: FX anchored to
+   collapsed bones (Electro Bolt shell on a hidden left hand) - verify the
+   plasmid FX parity test still passes with the collapse live.
+
+1. **THE IN-HEADSET RUN for session 18's changes** - the checklist below.
+   If it passes, open the PR for `m8-release-quick-phase`.
 1. **Publish the first GitHub release AFTER the user's explicit go** (their
    rule: nothing public-facing without asking): tag (proposed v0.1.0) on the
    merged main, upload the zip (rebuild from the tagged commit: `build.ps1

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1402,6 +1402,28 @@ and it resumes.
 
 ## Session log (newest first)
 
+### 2026-07-27 - Session 18 part 4 (the 2 GB scan wall: level transition lost the viewmodel)
+
+- **User report from the long NG+ play session: after a level transition the
+  model stopped following, re-enabling did nothing, and the game froze
+  briefly on a cycle. Root cause: `scan_for_vtable_object` walked only to
+  0x7FFF0000 - the game is Large-Address-Aware, and after enough streaming
+  the new level's AHands actor was allocated ABOVE 2 GB.** The log showed
+  the smoking gun: "2 vtable match(es), chosen=00000000" every 32 s (the
+  part-3 backoff working as designed - each futile scan cost ~4 s, the
+  periodic freeze) while the rig visibly rendered engine-placed. Fixed:
+  both heap walkers (patterns.cpp + value_scan.cpp) now walk to 0xFFFE0000
+  (VirtualQuery simply fails past the top on non-LAA processes). Verified
+  on the user's new all-weapons Medical Pavilion save: chosen=5A1862C0,
+  bones 47, drive writing, fire smoke clean, dumps 8->8. NOTE: a fresh
+  boot cannot reproduce the >2 GB heap state - the mechanism evidence is
+  the log + the constant; the user's next long session is the field test.
+- The user made THE all-weapons save (NG+ at the Medical Pavilion, full
+  arsenal + plasmids + ammo types restored by NG+ at that story point) -
+  the permanent test anchor going forward. CONTINUE loads it.
+- boot.ps1's success detector is wall-save-specific and prints FAIL on any
+  other save - cosmetic, fix next session.
+
 ### 2026-07-27 - Session 18 part 3 (trim decoupling + the user's tuning captured; loadout via Nexus save pending)
 
 - **In-headset feedback from the user's first part-2 run**: the ray offsets

--- a/src/core/debug/value_scan.cpp
+++ b/src/core/debug/value_scan.cpp
@@ -71,7 +71,9 @@ void for_each_writable_region(Fn&& fn) {
 
     uintptr_t p = 0x10000;
     MEMORY_BASIC_INFORMATION mbi{};
-    while (p < 0x7FFF0000u &&
+    // Full 4 GB walk - the game is LAA and allocates above 2 GB in long
+    // sessions (same fix as patterns.cpp scan_for_vtable_object).
+    while (p < 0xFFFE0000u &&
            VirtualQuery(reinterpret_cast<void*>(p), &mbi, sizeof(mbi)) == sizeof(mbi)) {
         uintptr_t base = reinterpret_cast<uintptr_t>(mbi.BaseAddress);
         uintptr_t end = base + mbi.RegionSize;

--- a/src/core/input/xinput_bridge.cpp
+++ b/src/core/input/xinput_bridge.cpp
@@ -52,6 +52,7 @@ Gamepad g_lastComposed{};
 // an atomic rather than a peek at g_lastComposed so a hooked engine native on
 // the game thread never has to take g_mutex.
 std::atomic<uint16_t> g_lastTriggers{0};
+std::atomic<uint16_t> g_lastButtons{0}; // composed button bits, same contract
 uint32_t g_packet = 0;            // bridge-owned monotonic dwPacketNumber
 bool g_packetBump = false;        // forced bump on enable/disable edges
 
@@ -158,10 +159,14 @@ void compose_over(DWORD userIndex, XINPUT_STATE* xs, DWORD* result) {
         // tell weapon fire from plasmid fire, and that has to work for a player
         // on a physical pad too.
         uint16_t t = 0;
-        if (*result == ERROR_SUCCESS)
+        uint16_t b = 0;
+        if (*result == ERROR_SUCCESS) {
             t = static_cast<uint16_t>(xs->Gamepad.bLeftTrigger) |
                 static_cast<uint16_t>(static_cast<uint16_t>(xs->Gamepad.bRightTrigger) << 8);
+            b = xs->Gamepad.wButtons;
+        }
         g_lastTriggers.store(t, std::memory_order_relaxed);
+        g_lastButtons.store(b, std::memory_order_relaxed);
         return;
     }
 
@@ -187,6 +192,7 @@ void compose_over(DWORD userIndex, XINPUT_STATE* xs, DWORD* result) {
     g_lastTriggers.store(static_cast<uint16_t>(out.lt) |
                              static_cast<uint16_t>(static_cast<uint16_t>(out.rt) << 8),
                          std::memory_order_relaxed);
+    g_lastButtons.store(out.buttons, std::memory_order_relaxed);
 
     if (!g_loggedFirstCompose.exchange(true, std::memory_order_relaxed))
         BVR_LOG("input: first synthetic compose served (packet %u)", g_packet);
@@ -468,6 +474,12 @@ void last_composed_triggers(uint8_t* lt, uint8_t* rt) {
     uint16_t t = g_lastTriggers.load(std::memory_order_relaxed);
     if (lt) *lt = static_cast<uint8_t>(t & 0xFF);
     if (rt) *rt = static_cast<uint8_t>(t >> 8);
+}
+
+void last_composed_bumpers(bool* lb, bool* rb) {
+    uint16_t b = g_lastButtons.load(std::memory_order_relaxed);
+    if (lb) *lb = (b & XINPUT_GAMEPAD_LEFT_SHOULDER) != 0;
+    if (rb) *rb = (b & XINPUT_GAMEPAD_RIGHT_SHOULDER) != 0;
 }
 
 void handle_command(const char* args) {

--- a/src/core/input/xinput_bridge.h
+++ b/src/core/input/xinput_bridge.h
@@ -40,6 +40,12 @@ float stick_deadzone();
 // trigger is the player pulling" is information the mod already owns.
 void last_composed_triggers(uint8_t* lt, uint8_t* rt);
 
+// Last composed bumper pair. The grips compose to the bumpers, and in this
+// game a bumper press SWITCHES the raised hand (LB -> plasmid = left hand,
+// RB -> weapon = right hand) without any trigger event - the M8 grip-switch
+// fix latches hand attribution from these too.
+void last_composed_bumpers(bool* lb, bool* rb);
+
 // Install the bridge's composing XInputGetState wrapper into an import slot
 // (e.g. the game module's IAT entry for xinput1_3 ordinal 2). The slot's
 // previous target becomes the passthrough, so a hook chain already wrapping

--- a/src/core/vr/openxr_runtime.cpp
+++ b/src/core/vr/openxr_runtime.cpp
@@ -150,6 +150,28 @@ bool g_srPairOpen = false; // present thread only
 std::atomic<uint32_t> g_srPairs{0}, g_srPairAborts{0};
 std::atomic<bool> g_loggedFirstPair{false};
 
+// M8 release blocker (a): the headset-disconnect stall guard. When the
+// headset idles, the runtime drops the session out of FOCUSED and xrWaitFrame
+// starts blocking for seconds per call, dragging the flat window under 1 fps
+// (log signature: presents=0/s, `xr: session state VISIBLE`). Once a session
+// has been FOCUSED, losing FOCUSED switches pacing to SKIP: presents stop
+// calling the blocking wait entirely and the game runs free, while
+// pump_events keeps running every present so the return to FOCUSED is acted
+// on immediately. A low-cadence keepalive still runs one real paced frame in
+// case the runtime wants to see frames before re-granting FOCUSED -
+// event-driven recovery is the primary path, the keepalive is insurance.
+// The guard NEVER engages before the first FOCUSED: during bring-up
+// (SYNCHRONIZED -> VISIBLE -> FOCUSED) the runtime needs submitted frames to
+// advance its own state machine, so a naive "skip whenever not FOCUSED"
+// would deadlock session start.
+constexpr uint64_t kPaceKeepaliveMs = 5000;
+std::atomic<bool> g_paceGuard{true};      // A/B knob (`vrpace off` = old behavior)
+std::atomic<bool> g_everFocused{false};   // written on the present thread
+uint64_t g_nextKeepaliveMs = 0;           // present thread only
+std::atomic<uint32_t> g_paceSkips{0}, g_paceKeepalives{0};
+std::atomic<uint32_t> g_lastWaitMs{0}; // last xrWaitFrame block, telemetry
+std::atomic<bool> g_simIdle{false};    // flat stand-in (`vrpace simidle on`)
+
 // Pop one tag; 0 = none pending (mono/AER frame).
 int sr_pop_eye() {
     uint32_t tail = g_srTail.load(std::memory_order_relaxed);
@@ -189,6 +211,25 @@ const char* state_str(XrSessionState s) {
         case XR_SESSION_STATE_EXITING: return "EXITING";
         default: return "UNKNOWN";
     }
+}
+
+// The stall-guard decision for one present, shared verbatim by the real pace
+// path and the flat simulation (which forces state/everFocused). True = this
+// present must NOT run the blocking pacing. Present thread only.
+bool pace_should_skip(XrSessionState state, bool everFocused, uint64_t now) {
+    if (!g_paceGuard.load(std::memory_order_relaxed)) return false;
+    if (state == XR_SESSION_STATE_FOCUSED) return false;
+    if (!everFocused) return false; // bring-up: frames are how we REACH focused
+    if (now >= g_nextKeepaliveMs) {
+        g_nextKeepaliveMs = now + kPaceKeepaliveMs;
+        g_paceKeepalives.fetch_add(1, std::memory_order_relaxed);
+        BVR_LOG("xr: pace keepalive while %s (one paced frame so the runtime can "
+                "re-grant FOCUSED; skips so far %u)",
+                state_str(state), g_paceSkips.load(std::memory_order_relaxed));
+        return false;
+    }
+    g_paceSkips.fetch_add(1, std::memory_order_relaxed);
+    return true;
 }
 
 void reset_aer() {
@@ -244,6 +285,8 @@ void teardown_session(const char* why) {
     g_srPairOpen = false;
     g_system = XR_NULL_SYSTEM_ID;
     g_state = XR_SESSION_STATE_UNKNOWN;
+    g_everFocused = false;
+    g_nextKeepaliveMs = 0;
     g_framesSubmitted = 0;
     g_nextRetryMs = GetTickCount64() + 5000; // cooldown before the next attempt
 }
@@ -490,10 +533,23 @@ void pump_events() {
                     }
                     break;
                 }
+                case XR_SESSION_STATE_FOCUSED:
+                    if (g_everFocused &&
+                        g_paceSkips.load(std::memory_order_relaxed) > 0)
+                        BVR_LOG("xr: FOCUSED again - full pacing resumes (guard "
+                                "skipped %u presents, %u keepalives)",
+                                g_paceSkips.load(std::memory_order_relaxed),
+                                g_paceKeepalives.load(std::memory_order_relaxed));
+                    g_everFocused = true;
+                    g_nextKeepaliveMs = 0;
+                    break;
                 case XR_SESSION_STATE_STOPPING:
                     if (g_sessionBegun) {
                         xrEndSession(g_session);
                         g_sessionBegun = false;
+                        // The next bring-up must pace freely again (bring-up
+                        // needs frames), so the focus latch resets with it.
+                        g_everFocused = false;
                         BVR_LOG("xr: session stopped (headset idle?) - waiting for READY again");
                     }
                     break;
@@ -558,6 +614,19 @@ void init_instance() {
 }
 
 void on_present_begin(IDXGISwapChain* swapchain) {
+    // Flat stand-in for the headset-idle stall (flat has no XR session, so the
+    // real path below never runs): the SAME guard decision runs with the state
+    // forced VISIBLE and the focus latch forced, and a 1 s sleep stands in for
+    // the runtime's blocked xrWaitFrame on frames the guard lets through.
+    // Acceptance: `vrpace simidle on` with the guard ON holds presents/s near
+    // the free-running rate (one 1 s keepalive hitch per 5 s); with the guard
+    // OFF it collapses under 1/s - the stall being fixed, reproduced.
+    if (g_simIdle.load(std::memory_order_relaxed)) {
+        if (!pace_should_skip(XR_SESSION_STATE_VISIBLE, true, GetTickCount64()))
+            Sleep(1000);
+        return;
+    }
+
     if (g_instance == XR_NULL_HANDLE) return;
 
     if (!g_enabled.load(std::memory_order_relaxed)) {
@@ -579,6 +648,11 @@ void on_present_begin(IDXGISwapChain* swapchain) {
     pump_events();
     if (g_session == XR_NULL_HANDLE || !g_sessionBegun) return;
 
+    // M8 (a): headset idle (session left FOCUSED after having held it) - skip
+    // the blocking pacing so the flat window keeps running. Events were
+    // already pumped above, so recovery needs no paced frame to be seen.
+    if (pace_should_skip(g_state, g_everFocused, GetTickCount64())) return;
+
     // A mid-session ResizeBuffers destroys the swapchains; recreate them at
     // the new backbuffer size (and recompute the fov, which depends on aspect).
     if (g_swapchains[0] == XR_NULL_HANDLE) {
@@ -591,7 +665,21 @@ void on_present_begin(IDXGISwapChain* swapchain) {
 
     XrFrameWaitInfo fwi{XR_TYPE_FRAME_WAIT_INFO};
     g_frameState = {XR_TYPE_FRAME_STATE};
+    uint64_t waitStart = GetTickCount64();
     XrResult r = xrWaitFrame(g_session, &fwi, &g_frameState);
+    uint32_t waitMs = static_cast<uint32_t>(GetTickCount64() - waitStart);
+    g_lastWaitMs.store(waitMs, std::memory_order_relaxed);
+    // Telemetry for the disconnect stall: a healthy wait is one display
+    // period. Long blocks with their session state tell us how THIS runtime
+    // behaves when the headset idles (rate-limited: keepalives are expected
+    // to block while unfocused).
+    if (waitMs > 1000) {
+        static uint64_t lastStallLogMs = 0;
+        if (waitStart - lastStallLogMs > 5000) {
+            lastStallLogMs = waitStart;
+            BVR_LOG("xr: xrWaitFrame blocked %u ms (state %s)", waitMs, state_str(g_state));
+        }
+    }
     if (XR_FAILED(r)) {
         BVR_LOG("xr: xrWaitFrame failed: %s", res_str(r));
         teardown_session("waitframe failed");
@@ -1124,6 +1212,11 @@ void draw_debug_ui() {
     if (camMode && !g_projectionReady.load(std::memory_order_relaxed))
         ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f),
                            "projection NOT ready - drive is held off (see log)");
+    uint32_t paceSkips = g_paceSkips.load(std::memory_order_relaxed);
+    if (paceSkips)
+        ImGui::Text("pace guard: skipped %u waits, %u keepalives, last wait %u ms",
+                    paceSkips, g_paceKeepalives.load(std::memory_order_relaxed),
+                    g_lastWaitMs.load(std::memory_order_relaxed));
 
     input_draw_debug_ui(); // M5 action-layer status line
 
@@ -1172,6 +1265,41 @@ void set_enabled(bool on) {
 
 void set_sr_pair_pacing(bool on) {
     g_srPairPacing.store(on, std::memory_order_relaxed);
+}
+
+void handle_pace_command(const char* args) {
+    char verb[16] = {};
+    int consumed = 0;
+    if (sscanf_s(args, "%15s%n", verb, static_cast<unsigned>(sizeof verb), &consumed) != 1)
+        verb[0] = '\0';
+    const char* rest = args + consumed;
+    while (*rest == ' ' || *rest == '\t') ++rest;
+
+    if (strcmp(verb, "on") == 0) {
+        g_paceGuard.store(true, std::memory_order_relaxed);
+        BVR_LOG("xr: pace guard ON (unfocused session skips the blocking wait)");
+    } else if (strcmp(verb, "off") == 0) {
+        g_paceGuard.store(false, std::memory_order_relaxed);
+        BVR_LOG("xr: pace guard OFF (pre-M8 behavior: every present waits, the "
+                "flat window stalls when the headset idles)");
+    } else if (strcmp(verb, "simidle") == 0) {
+        bool on = strncmp(rest, "on", 2) == 0;
+        g_simIdle.store(on, std::memory_order_relaxed);
+        BVR_LOG("xr: simulated idle %s%s", on ? "ON" : "off",
+                on ? " (flat stand-in: state VISIBLE, 1 s block per paced frame; "
+                     "with the guard off, commands crawl at ~1/s until it lands)"
+                   : "");
+    } else {
+        BVR_LOG("xr: pace guard %s | session %s everFocused=%d | skips %u "
+                "keepalives %u lastWait %u ms | simidle %s "
+                "(vrpace on|off|simidle on|off|status)",
+                g_paceGuard.load(std::memory_order_relaxed) ? "ON" : "off",
+                state_str(g_state), g_everFocused.load(std::memory_order_relaxed) ? 1 : 0,
+                g_paceSkips.load(std::memory_order_relaxed),
+                g_paceKeepalives.load(std::memory_order_relaxed),
+                g_lastWaitMs.load(std::memory_order_relaxed),
+                g_simIdle.load(std::memory_order_relaxed) ? "ON" : "off");
+    }
 }
 
 float suggested_hfov_deg() {
@@ -1230,6 +1358,7 @@ bool vr_camera_mode() { return false; }
 void set_camera_mode(bool) {}
 void set_enabled(bool) {}
 void set_sr_pair_pacing(bool) {}
+void handle_pace_command(const char*) {}
 float suggested_hfov_deg() { return 0.0f; }
 void set_rendered_hfov(float) {}
 int current_eye_sign() { return 0; }

--- a/src/core/vr/openxr_runtime.cpp
+++ b/src/core/vr/openxr_runtime.cpp
@@ -172,6 +172,29 @@ std::atomic<uint32_t> g_paceSkips{0}, g_paceKeepalives{0};
 std::atomic<uint32_t> g_lastWaitMs{0}; // last xrWaitFrame block, telemetry
 std::atomic<bool> g_simIdle{false};    // flat stand-in (`vrpace simidle on`)
 
+// M8 release blocker (b): the desktop mirror. Under SequentialReentry every
+// Present alternates the backbuffer between the two eyes, so the flat window
+// cannot be streamed, recorded, or shown. Fix: LEFT-eye presents snapshot the
+// backbuffer (read-only - the compositor's eye capture is untouched); on
+// RIGHT-eye presents, AFTER the right eye has been captured into its XR
+// swapchain, the held left image is copied back over the backbuffer, so the
+// real Present always displays the LEFT eye. Runs off the same sr eye tags
+// the capture uses, and also on presents with no open XR frame (pace-guard
+// skips, session gone) - the game keeps presenting alternating eyes there
+// and the window still needs the pin.
+// (Session-17 screenshot clue, explained: the pair's two presents have very
+// unequal display time - L is visible only while the game builds the R frame,
+// R through the whole next blocking xrWaitFrame - so DWM-sourced captures
+// land on R with high probability. Same phase 12/12 was duty-cycle skew, not
+// absence of alternation; a 60 Hz recorder still catches L slices.)
+std::atomic<bool> g_mirror{true};        // `vrmirror off` = old alternation
+ID3D11Texture2D* g_mirrorTex = nullptr;  // held left-eye image, present thread
+uint32_t g_mirrorW = 0, g_mirrorH = 0;
+DXGI_FORMAT g_mirrorFmt = DXGI_FORMAT_UNKNOWN;
+bool g_mirrorHeld = false;               // a left image has been snapshotted
+std::atomic<uint32_t> g_mirrorHolds{0}, g_mirrorBlits{0};
+std::atomic<bool> g_loggedFirstMirror{false};
+
 // Pop one tag; 0 = none pending (mono/AER frame).
 int sr_pop_eye() {
     uint32_t tail = g_srTail.load(std::memory_order_relaxed);
@@ -230,6 +253,68 @@ bool pace_should_skip(XrSessionState state, bool everFocused, uint64_t now) {
     }
     g_paceSkips.fetch_add(1, std::memory_order_relaxed);
     return true;
+}
+
+void release_mirror() {
+    if (g_mirrorTex) {
+        g_mirrorTex->Release();
+        g_mirrorTex = nullptr;
+    }
+    g_mirrorHeld = false;
+    g_mirrorW = g_mirrorH = 0;
+    g_mirrorFmt = DXGI_FORMAT_UNKNOWN;
+}
+
+// The eye pin for one present (see the block comment at the globals). Uses
+// the game device straight off the backbuffer, so it works with or without a
+// live XR session. eyeSign: -1 = this backbuffer is the LEFT eye (snapshot),
+// +1 = RIGHT eye (re-blit the held left over it - call only AFTER the right
+// eye's XR capture), 0 = mono (nothing to pin).
+void mirror_present(IDXGISwapChain* swapchain, int eyeSign) {
+    if (eyeSign == 0 || !g_mirror.load(std::memory_order_relaxed)) return;
+    ID3D11Texture2D* backbuffer = nullptr;
+    if (FAILED(swapchain->GetBuffer(0, IID_PPV_ARGS(&backbuffer))) || !backbuffer) return;
+    D3D11_TEXTURE2D_DESC bd{};
+    backbuffer->GetDesc(&bd);
+    ID3D11Device* dev = nullptr;
+    ID3D11DeviceContext* ctx = nullptr;
+    backbuffer->GetDevice(&dev);
+    if (dev) dev->GetImmediateContext(&ctx);
+    if (ctx) {
+        if (g_mirrorTex &&
+            (g_mirrorW != bd.Width || g_mirrorH != bd.Height || g_mirrorFmt != bd.Format))
+            release_mirror();
+        if (!g_mirrorTex && eyeSign < 0) {
+            D3D11_TEXTURE2D_DESC td = bd;
+            td.Usage = D3D11_USAGE_DEFAULT;
+            td.BindFlags = 0;
+            td.CPUAccessFlags = 0;
+            td.MiscFlags = 0;
+            if (SUCCEEDED(dev->CreateTexture2D(&td, nullptr, &g_mirrorTex))) {
+                g_mirrorW = bd.Width;
+                g_mirrorH = bd.Height;
+                g_mirrorFmt = bd.Format;
+            } else {
+                g_mirrorTex = nullptr; // failed create: mirror silently off
+            }
+        }
+        if (g_mirrorTex) {
+            if (eyeSign < 0) {
+                ctx->CopyResource(g_mirrorTex, backbuffer);
+                g_mirrorHeld = true;
+                g_mirrorHolds.fetch_add(1, std::memory_order_relaxed);
+            } else if (g_mirrorHeld) {
+                ctx->CopyResource(backbuffer, g_mirrorTex);
+                g_mirrorBlits.fetch_add(1, std::memory_order_relaxed);
+                if (!g_loggedFirstMirror.exchange(true))
+                    BVR_LOG("xr: desktop mirror pinned to the LEFT eye "
+                            "(right-eye presents re-show the held left image)");
+            }
+        }
+        ctx->Release();
+    }
+    if (dev) dev->Release();
+    backbuffer->Release();
 }
 
 void reset_aer() {
@@ -929,7 +1014,13 @@ uint32_t build_laser_layers(XrCompositionLayerQuad* quads) {
 }
 
 void on_present_end(IDXGISwapChain* swapchain) {
-    if (!g_frameOpen) return;
+    if (!g_frameOpen) {
+        // No XR frame this present (session gone, or the pace guard skipped
+        // it). The game may still be presenting alternating stereo eyes -
+        // keep draining the tag ring and keep the window pinned to one eye.
+        mirror_present(swapchain, sr_pop_eye());
+        return;
+    }
     bool pairSecond = g_srPairOpen; // this present completes an open pair
     g_srPairOpen = false;
     g_frameOpen = false; // the pair-hold path below re-arms both
@@ -961,6 +1052,11 @@ void on_present_end(IDXGISwapChain* swapchain) {
     // convention AER validated in-headset (depth not inverted).
     int srSign = sr_pop_eye();
     bool srFrame = projectionMode && srSign != 0;
+
+    // Mirror, left half: snapshot the LEFT eye before anything else runs
+    // (read-only - the XR eye capture below is unaffected). The right half
+    // runs after the capture block, once the right eye is safely captured.
+    if (srSign < 0) mirror_present(swapchain, srSign);
 
     // Pair-pacing bookkeeping and the hold decision. A LEFT-tagged present
     // holds the frame open for its RIGHT sibling; anything unexpected on the
@@ -1097,6 +1193,11 @@ void on_present_end(IDXGISwapChain* swapchain) {
         }
     }
 
+    // Mirror, right half: the right eye's XR capture is done (or was skipped
+    // this present) - pin the backbuffer to the held left image before the
+    // real Present displays it.
+    if (srSign > 0) mirror_present(swapchain, srSign);
+
     // Aim laser on top of the game frame - projection mode only, since in quad
     // ("cinema screen") mode there is no world for it to point into.
     if (layerCount && projectionMode) {
@@ -1136,6 +1237,7 @@ void on_present_end(IDXGISwapChain* swapchain) {
 void on_resize() {
     // Recreated at the new backbuffer size on the next frame.
     destroy_swapchains();
+    release_mirror();
 }
 
 void draw_debug_ui() {
@@ -1217,6 +1319,11 @@ void draw_debug_ui() {
         ImGui::Text("pace guard: skipped %u waits, %u keepalives, last wait %u ms",
                     paceSkips, g_paceKeepalives.load(std::memory_order_relaxed),
                     g_lastWaitMs.load(std::memory_order_relaxed));
+    uint32_t mirrorBlits = g_mirrorBlits.load(std::memory_order_relaxed);
+    if (mirrorBlits)
+        ImGui::Text("mirror: %s | %u left holds, %u re-blits",
+                    g_mirror.load(std::memory_order_relaxed) ? "left eye" : "OFF",
+                    g_mirrorHolds.load(std::memory_order_relaxed), mirrorBlits);
 
     input_draw_debug_ui(); // M5 action-layer status line
 
@@ -1302,6 +1409,22 @@ void handle_pace_command(const char* args) {
     }
 }
 
+void handle_mirror_command(const char* args) {
+    if (strncmp(args, "on", 2) == 0) {
+        g_mirror.store(true, std::memory_order_relaxed);
+        BVR_LOG("xr: desktop mirror ON (window pinned to the LEFT eye under stereo)");
+    } else if (strncmp(args, "off", 3) == 0) {
+        g_mirror.store(false, std::memory_order_relaxed);
+        BVR_LOG("xr: desktop mirror OFF (pre-M8 behavior: the window alternates "
+                "eyes under stereo)");
+    } else {
+        BVR_LOG("xr: mirror %s | holds %u blits %u (vrmirror on|off|status)",
+                g_mirror.load(std::memory_order_relaxed) ? "ON" : "off",
+                g_mirrorHolds.load(std::memory_order_relaxed),
+                g_mirrorBlits.load(std::memory_order_relaxed));
+    }
+}
+
 float suggested_hfov_deg() {
     return g_hfovDeg.load(std::memory_order_relaxed);
 }
@@ -1359,6 +1482,7 @@ void set_camera_mode(bool) {}
 void set_enabled(bool) {}
 void set_sr_pair_pacing(bool) {}
 void handle_pace_command(const char*) {}
+void handle_mirror_command(const char*) {}
 float suggested_hfov_deg() { return 0.0f; }
 void set_rendered_hfov(float) {}
 int current_eye_sign() { return 0; }

--- a/src/core/vr/openxr_runtime.cpp
+++ b/src/core/vr/openxr_runtime.cpp
@@ -64,6 +64,7 @@ ID3D11Texture2D* g_laserDot = nullptr; // CPU-generated source, copied in per fr
 std::atomic<bool> g_laserOn{false};
 std::atomic<int> g_laserHand{1};
 std::atomic<float> g_laserPitchTrim{0.0f}, g_laserYawTrim{0.0f};
+std::atomic<float> g_laserPosFwdCm{0.0f}, g_laserPosRightCm{0.0f}, g_laserPosUpCm{0.0f};
 std::atomic<int> g_laserDots{6};
 std::atomic<float> g_laserNearM{0.30f}, g_laserFarM{6.0f}, g_laserSizeDeg{0.7f};
 std::atomic<uint32_t> g_laserLayersSubmitted{0};
@@ -948,6 +949,36 @@ uint32_t build_laser_layers(XrCompositionLayerQuad* quads) {
     d[1] = sinf(pitch);
     d[2] = -cp * cosf(yaw);
 
+    // Ray ORIGIN offset (cm -> m) in the TRIMMED ray's zero-roll frame - the
+    // same offset the game-side ray build applies in UU (aim.cpp), so the
+    // beam and the fire origin move together by construction. right =
+    // d x worldUp (horizontal right of the ray), up completes the frame;
+    // near-vertical rays get the forward component only (degenerate cross).
+    {
+        float ofM = g_laserPosFwdCm.load(std::memory_order_relaxed) * 0.01f;
+        float orM = g_laserPosRightCm.load(std::memory_order_relaxed) * 0.01f;
+        float ouM = g_laserPosUpCm.load(std::memory_order_relaxed) * 0.01f;
+        if (ofM != 0.0f || orM != 0.0f || ouM != 0.0f) {
+            pos[0] += d[0] * ofM;
+            pos[1] += d[1] * ofM;
+            pos[2] += d[2] * ofM;
+            float right[3] = {d[1] * 0.0f - d[2] * 1.0f, d[2] * 0.0f - d[0] * 0.0f,
+                              d[0] * 1.0f - d[1] * 0.0f}; // d x (0,1,0)
+            float rl = sqrtf(right[0] * right[0] + right[1] * right[1] + right[2] * right[2]);
+            if (rl > 1e-3f) {
+                right[0] /= rl;
+                right[1] /= rl;
+                right[2] /= rl;
+                float up2[3] = {right[1] * d[2] - right[2] * d[1],
+                                right[2] * d[0] - right[0] * d[2],
+                                right[0] * d[1] - right[1] * d[0]}; // right x d
+                pos[0] += right[0] * orM + up2[0] * ouM;
+                pos[1] += right[1] * orM + up2[1] * ouM;
+                pos[2] += right[2] * orM + up2[2] * ouM;
+            }
+        }
+    }
+
     // Billboard against the head (midpoint of the two eyes).
     float head[3] = {(g_views[0].pose.position.x + g_views[1].pose.position.x) * 0.5f,
                      (g_views[0].pose.position.y + g_views[1].pose.position.y) * 0.5f,
@@ -1442,6 +1473,9 @@ void set_laser(const LaserConfig& cfg) {
     g_laserHand.store(cfg.hand ? 1 : 0, std::memory_order_relaxed);
     g_laserPitchTrim.store(cfg.pitchTrimDeg, std::memory_order_relaxed);
     g_laserYawTrim.store(cfg.yawTrimDeg, std::memory_order_relaxed);
+    g_laserPosFwdCm.store(cfg.posFwdCm, std::memory_order_relaxed);
+    g_laserPosRightCm.store(cfg.posRightCm, std::memory_order_relaxed);
+    g_laserPosUpCm.store(cfg.posUpCm, std::memory_order_relaxed);
     g_laserDots.store(cfg.dots, std::memory_order_relaxed);
     g_laserNearM.store(cfg.nearM, std::memory_order_relaxed);
     g_laserFarM.store(cfg.farM, std::memory_order_relaxed);

--- a/src/core/vr/openxr_runtime.h
+++ b/src/core/vr/openxr_runtime.h
@@ -69,6 +69,19 @@ void set_camera_mode(bool on);
 void set_enabled(bool on);
 void set_sr_pair_pacing(bool on);
 
+// --- M8: headset-disconnect stall guard --------------------------------------
+// "vrpace ..." seam (game thread). When the session leaves FOCUSED after
+// having held it, presents skip the blocking xrWaitFrame so the flat window
+// keeps running while the headset idles; a 5 s keepalive still paces one real
+// frame so the runtime can re-grant FOCUSED even if it wants to see frames.
+//   on | off          the guard (off = pre-M8 stall behavior, live A/B)
+//   simidle on|off    flat stand-in for a headset idle: the same guard
+//                     decision runs with the state forced VISIBLE and a 1 s
+//                     sleep in place of the runtime's blocked wait (flat has
+//                     no XR session, so this is how the guard is verified)
+//   status            guard state + skip/keepalive/last-wait telemetry
+void handle_pace_command(const char* args);
+
 // Symmetric horizontal FOV (degrees) circumscribing the headset's per-eye
 // FOV at the backbuffer aspect - what the game should render with in camera
 // mode. 0 until the first views are located.

--- a/src/core/vr/openxr_runtime.h
+++ b/src/core/vr/openxr_runtime.h
@@ -82,6 +82,14 @@ void set_sr_pair_pacing(bool on);
 //   status            guard state + skip/keepalive/last-wait telemetry
 void handle_pace_command(const char* args);
 
+// --- M8: desktop mirror ------------------------------------------------------
+// "vrmirror ..." seam (game thread). Under SequentialReentry stereo the flat
+// window alternates L/R eyes per present; the mirror pins it to the LEFT eye
+// (left presents snapshot the backbuffer, right presents re-show the held
+// image AFTER the right eye's XR capture, so the headset feed is untouched).
+//   on | off | status   (off = the pre-M8 alternation, live A/B)
+void handle_mirror_command(const char* args);
+
 // Symmetric horizontal FOV (degrees) circumscribing the headset's per-eye
 // FOV at the backbuffer aspect - what the game should render with in camera
 // mode. 0 until the first views are located.

--- a/src/core/vr/openxr_runtime.h
+++ b/src/core/vr/openxr_runtime.h
@@ -137,6 +137,9 @@ struct LaserConfig {
     int hand = 1;              // 0 left, 1 right
     float pitchTrimDeg = 0.0f; // must match the fire ray's trim
     float yawTrimDeg = 0.0f;
+    float posFwdCm = 0.0f;     // ray ORIGIN offset in the trimmed ray's frame,
+    float posRightCm = 0.0f;   // matching the game-side fire-origin offset
+    float posUpCm = 0.0f;      // (cm here; the game side scales by worldScale)
     int dots = 6;              // clamped to the layer budget
     float nearM = 0.30f;       // first dot, meters from the controller
     float farM = 6.0f;         // last dot

--- a/src/game/bioshock1r/aim.cpp
+++ b/src/game/bioshock1r/aim.cpp
@@ -56,6 +56,17 @@ std::atomic<bool> g_useAimPose{true};
 // posture wants its own trim. 0 = left (plasmid), 1 = right (weapon).
 std::atomic<float> g_pitchOffsetDeg[2] = {0.0f, 0.0f};
 std::atomic<float> g_yawOffsetDeg[2] = {0.0f, 0.0f};
+// Per-hand aim-ray ORIGIN offsets in cm (session 18 part 2, user request):
+// the model offsets move the MESH about its pivot, so a tuned model can sit
+// right while the ray no longer runs along the barrel. These move the RAY
+// itself - laser, fire origin, everything reading g_ray - to re-align with
+// the controller and the tuned model. Applied along the FINAL (trimmed)
+// ray's zero-roll basis at ray build, so the laser and the bullet cannot
+// disagree; the model deliberately does not take them (it has its own
+// sliders, and the two are tuned against each other).
+std::atomic<float> g_posFwdCm[2] = {0.0f, 0.0f};
+std::atomic<float> g_posRightCm[2] = {0.0f, 0.0f};
+std::atomic<float> g_posUpCm[2] = {0.0f, 0.0f};
 // M7 laser: the visible form of this same ray, published to core every frame.
 // It lives here rather than with the hands so it cannot drift from the trim
 // above - a laser that disagrees with the bullet is worse than no laser.
@@ -697,6 +708,14 @@ void log_status() {
             g_yawOffsetDeg[0].load(std::memory_order_relaxed),
             g_pitchOffsetDeg[1].load(std::memory_order_relaxed),
             g_yawOffsetDeg[1].load(std::memory_order_relaxed));
+    BVR_LOG("[aim] ray origin offset L fwd%+.1f right%+.1f up%+.1f | R fwd%+.1f right%+.1f "
+            "up%+.1f cm",
+            g_posFwdCm[0].load(std::memory_order_relaxed),
+            g_posRightCm[0].load(std::memory_order_relaxed),
+            g_posUpCm[0].load(std::memory_order_relaxed),
+            g_posFwdCm[1].load(std::memory_order_relaxed),
+            g_posRightCm[1].load(std::memory_order_relaxed),
+            g_posUpCm[1].load(std::memory_order_relaxed));
     BVR_LOG("[aim] status: %s | seams weapon=%d ability=%d | handOrigin=%d probe=%d",
             g_enabled.load(std::memory_order_relaxed) ? "ON" : "off",
             g_subWeapon.load(std::memory_order_relaxed) ? 1 : 0,
@@ -732,6 +751,25 @@ void init(const bvr::pattern_scan::ProcessImage& image, const patterns::Symbols&
     g_syms = symbols;
     BVR_LOG("[aim] init: weapon fire-start=%p ability fire-start=%p", g_syms.weaponFireStart,
             g_syms.abilityFireStart);
+}
+
+// The origin offset rides the FINAL (trimmed) ray frame - both lanes, the
+// synthetic test lane included, which is what makes it flat-assertable via
+// the ray origins in `vraim status`.
+void apply_origin_offset(int i, Ray& out, float worldScale) {
+    float of = g_posFwdCm[i].load(std::memory_order_relaxed);
+    float orr = g_posRightCm[i].load(std::memory_order_relaxed);
+    float ou = g_posUpCm[i].load(std::memory_order_relaxed);
+    if (of == 0.0f && orr == 0.0f && ou == 0.0f) return;
+    float fwd[3], right[3], up[3];
+    ue_rot_basis(out.rot, fwd, right, up);
+    float uuPerCm = worldScale / 100.0f;
+    of *= uuPerCm;
+    orr *= uuPerCm;
+    ou *= uuPerCm;
+    out.origin.x += fwd[0] * of + right[0] * orr + up[0] * ou;
+    out.origin.y += fwd[1] * of + right[1] * orr + up[1] * ou;
+    out.origin.z += fwd[2] * of + right[2] * orr + up[2] * ou;
 }
 
 void on_calcview(const FrameContext& ctx) {
@@ -793,6 +831,7 @@ void on_calcview(const FrameContext& ctx) {
             out.rot.pitch = ctx.camPitch +
                             static_cast<int32_t>(g_test[i].pitchDeg * kRotUnitsPerDegree);
             out.rot.roll = 0;
+            apply_origin_offset(i, out, ctx.worldScale);
             continue;
         }
 
@@ -815,6 +854,7 @@ void on_calcview(const FrameContext& ctx) {
                                            g_pitchOffsetDeg[i].load(std::memory_order_relaxed) *
                                            kRotUnitsPerDegree);
         out.rot.roll = 0; // aim carries no roll; the camera owns roll
+        apply_origin_offset(i, out, ctx.worldScale);
         out.valid = true;
     }
 
@@ -827,6 +867,9 @@ void on_calcview(const FrameContext& ctx) {
     int lh = lc.hand == 0 ? 0 : 1;
     lc.pitchTrimDeg = g_pitchOffsetDeg[lh].load(std::memory_order_relaxed);
     lc.yawTrimDeg = g_yawOffsetDeg[lh].load(std::memory_order_relaxed);
+    lc.posFwdCm = g_posFwdCm[lh].load(std::memory_order_relaxed);
+    lc.posRightCm = g_posRightCm[lh].load(std::memory_order_relaxed);
+    lc.posUpCm = g_posUpCm[lh].load(std::memory_order_relaxed);
     lc.dots = g_laserDots.load(std::memory_order_relaxed);
     lc.nearM = g_laserNearM.load(std::memory_order_relaxed);
     lc.farM = g_laserFarM.load(std::memory_order_relaxed);
@@ -913,6 +956,30 @@ void handle_command(const char* args) {
                     hand < 0 ? "both" : hand == 1 ? "right" : "left", pitch, yaw);
         } else {
             BVR_LOG("[aim] usage: vraim cal [l|r] <pitchDeg> [yawDeg]  (+pitch aims higher)");
+        }
+    } else if (strcmp(verb, "pos") == 0) {
+        // "pos [l|r] <fwd> <right> <up>" (cm) - the aim-ray ORIGIN offset;
+        // no side = both hands, mirroring cal.
+        int hand = -1;
+        const char* nums = rest;
+        if ((rest[0] == 'l' || rest[0] == 'r') && (rest[1] == ' ' || rest[1] == '\t')) {
+            hand = rest[0] == 'r' ? 1 : 0;
+            nums = rest + 1;
+            while (*nums == ' ' || *nums == '\t') ++nums;
+        }
+        float f = 0.0f, r = 0.0f, u = 0.0f;
+        if (sscanf_s(nums, "%f %f %f", &f, &r, &u) == 3) {
+            for (int h = 0; h < 2; ++h) {
+                if (hand >= 0 && h != hand) continue;
+                g_posFwdCm[h].store(f, std::memory_order_relaxed);
+                g_posRightCm[h].store(r, std::memory_order_relaxed);
+                g_posUpCm[h].store(u, std::memory_order_relaxed);
+            }
+            BVR_LOG("[aim] ray origin offset (%s): fwd%+.1f right%+.1f up%+.1f cm "
+                    "(laser + fire origin move together)",
+                    hand < 0 ? "both" : hand == 1 ? "right" : "left", f, r, u);
+        } else {
+            BVR_LOG("[aim] usage: vraim pos [l|r] <fwdCm> <rightCm> <upCm>");
         }
     } else if (strcmp(verb, "laser") == 0) {
         // "laser on|off" or "laser <dots> <nearM> <farM> <sizeDeg>"
@@ -1003,6 +1070,25 @@ float trim_yaw_deg(int hand) {
     return g_yawOffsetDeg[hand == 0 ? 0 : 1].load(std::memory_order_relaxed);
 }
 
+float pos_fwd_cm(int hand) {
+    return g_posFwdCm[hand == 0 ? 0 : 1].load(std::memory_order_relaxed);
+}
+
+float pos_right_cm(int hand) {
+    return g_posRightCm[hand == 0 ? 0 : 1].load(std::memory_order_relaxed);
+}
+
+float pos_up_cm(int hand) {
+    return g_posUpCm[hand == 0 ? 0 : 1].load(std::memory_order_relaxed);
+}
+
+void set_pos_offset(int hand, float fwdCm, float rightCm, float upCm) {
+    int h = hand == 0 ? 0 : 1;
+    g_posFwdCm[h].store(fwdCm, std::memory_order_relaxed);
+    g_posRightCm[h].store(rightCm, std::memory_order_relaxed);
+    g_posUpCm[h].store(upCm, std::memory_order_relaxed);
+}
+
 void set_trim(int hand, float pitchDeg, float yawDeg) {
     int h = hand == 0 ? 0 : 1;
     g_pitchOffsetDeg[h].store(pitchDeg, std::memory_order_relaxed);
@@ -1035,6 +1121,25 @@ void draw_debug_ui() {
     float ly = g_yawOffsetDeg[0].load(std::memory_order_relaxed);
     if (ImGui::SliderFloat("L aim yaw trim (deg)", &ly, -30.0f, 30.0f))
         g_yawOffsetDeg[0].store(ly, std::memory_order_relaxed);
+
+    // Ray ORIGIN offsets (session 18 part 2): move the laser + fire origin to
+    // line up with the controller and the tuned model. Selector like the
+    // hands section - one set of sliders, per-hand values.
+    static int posHand = 1;
+    ImGui::Text("Ray offset hand:");
+    ImGui::SameLine();
+    ImGui::RadioButton("L##aimpos", &posHand, 0);
+    ImGui::SameLine();
+    ImGui::RadioButton("R##aimpos", &posHand, 1);
+    float pf = g_posFwdCm[posHand].load(std::memory_order_relaxed);
+    if (ImGui::SliderFloat("ray offset forward (cm)", &pf, -30.0f, 30.0f))
+        g_posFwdCm[posHand].store(pf, std::memory_order_relaxed);
+    float pr = g_posRightCm[posHand].load(std::memory_order_relaxed);
+    if (ImGui::SliderFloat("ray offset right (cm)", &pr, -30.0f, 30.0f))
+        g_posRightCm[posHand].store(pr, std::memory_order_relaxed);
+    float pu = g_posUpCm[posHand].load(std::memory_order_relaxed);
+    if (ImGui::SliderFloat("ray offset up (cm)", &pu, -30.0f, 30.0f))
+        g_posUpCm[posHand].store(pu, std::memory_order_relaxed);
 
     bool handOrigin = g_handOrigin.load(std::memory_order_relaxed);
     if (ImGui::Checkbox("Ray starts at the hand (off = engine origin, direction only)",

--- a/src/game/bioshock1r/aim.h
+++ b/src/game/bioshock1r/aim.h
@@ -72,6 +72,15 @@ float trim_pitch_deg(int hand);
 float trim_yaw_deg(int hand);
 void set_trim(int hand, float pitchDeg, float yawDeg);
 
+// The aim-ray ORIGIN offset (cm, in the trimmed ray's frame), PER HAND -
+// session 18 part 2. Moves the laser AND the fire origin together (applied
+// once at ray build); the viewmodel keeps its own offsets. `vraim pos [l|r]
+// <fwd> <right> <up>`; set_pos_offset is the VR-preset load path.
+float pos_fwd_cm(int hand);
+float pos_right_cm(int hand);
+float pos_up_cm(int hand);
+void set_pos_offset(int hand, float fwdCm, float rightCm, float upCm);
+
 // True while substitution is armed (master switch + a usable hand ray).
 bool active();
 

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -435,6 +435,9 @@ void save_vr_preset() {
     fprintf(f, "bodyDeadzoneDeg=%.1f\n", body::deadzone_deg());
     fclose(f);
     BVR_LOG("[b1r] VR preset values saved to vrpreset.ini");
+    // The per-hand model offsets live in hands.ini; saving them here too makes
+    // the one in-headset save button cover every tuned slider.
+    hands::save_offsets();
 }
 
 void load_vr_preset_values() {

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -72,6 +72,18 @@ std::atomic<float> g_headOffFwdUu{0.0f};
 // run on the game thread next frame.
 std::atomic<bool> g_vrPresetPending{false};
 std::atomic<bool> g_vrPresetSavePending{false};
+
+// M8 session 18 part 2: the flat-screen crosshair, DEFAULT HIDDEN (user ask).
+// The lever is `ShockPlayer.bReticleDisabled` - the game's own RenderReticle
+// then pushes "NoReticle" to the flash HUD every frame (script source read
+// straight from ShockGame.U; ENGINE_NOTES session 18 part 2). It is written
+// through the engine's own console SET handler via the exec seam, so no
+// property offset or bitmask is ever needed, and SET also writes the class
+// default, so pawns spawned later (load crossings) inherit it. Re-asserted
+// on a slow cadence in case anything script-side calls EnableReticle.
+std::atomic<bool> g_crosshairVisible{false}; // `vrxhair on` re-shows it
+int g_crosshairApplied = -1;                 // last state pushed (-1 = never)
+uint64_t g_crosshairAssertMs = 0;            // game thread only
 std::atomic<bool>  g_recenterRequested{true};  // auto-recenter on first drive
 std::atomic<bool>  g_vrDriving{false};         // telemetry for the UI
 std::atomic<bool>  g_forceHeadsetFov{false};   // session 4: now writes the REAL control (the
@@ -405,6 +417,19 @@ void apply_command(const char* cmd, const char* args) {
         bvr::vr::handle_pace_command(args); // M8 disconnect-stall guard
     } else if (strcmp(cmd, "vrmirror") == 0) {
         bvr::vr::handle_mirror_command(args); // M8 single-eye desktop mirror
+    } else if (strcmp(cmd, "vrxhair") == 0) {
+        // M8 part 2: the flat-screen crosshair. Default HIDDEN; "on" re-shows.
+        if (strncmp(args, "on", 2) == 0) {
+            g_crosshairVisible.store(true, std::memory_order_relaxed);
+            BVR_LOG("[b1r] crosshair ON (flat reticle re-enabled)");
+        } else if (strncmp(args, "off", 3) == 0) {
+            g_crosshairVisible.store(false, std::memory_order_relaxed);
+            BVR_LOG("[b1r] crosshair OFF (ShockPlayer.bReticleDisabled via engine SET)");
+        } else {
+            BVR_LOG("[b1r] crosshair %s (applied=%d) - vrxhair on|off|status",
+                    g_crosshairVisible.load(std::memory_order_relaxed) ? "ON" : "off",
+                    g_crosshairApplied);
+        }
     } else if (strcmp(cmd, "reentry") == 0) {
         scenedraw::handle_command(args); // DR-5 probe; logs its own echoes
     }
@@ -435,8 +460,16 @@ void save_vr_preset() {
     fprintf(f, "aimTrimLYaw=%.1f\n", aim::trim_yaw_deg(0));
     fprintf(f, "aimTrimRPitch=%.1f\n", aim::trim_pitch_deg(1));
     fprintf(f, "aimTrimRYaw=%.1f\n", aim::trim_yaw_deg(1));
+    fprintf(f, "aimPosLFwd=%.1f\n", aim::pos_fwd_cm(0));
+    fprintf(f, "aimPosLRight=%.1f\n", aim::pos_right_cm(0));
+    fprintf(f, "aimPosLUp=%.1f\n", aim::pos_up_cm(0));
+    fprintf(f, "aimPosRFwd=%.1f\n", aim::pos_fwd_cm(1));
+    fprintf(f, "aimPosRRight=%.1f\n", aim::pos_right_cm(1));
+    fprintf(f, "aimPosRUp=%.1f\n", aim::pos_up_cm(1));
     fprintf(f, "bodyRate=%.2f\n", body::rate_per_sec());
     fprintf(f, "bodyDeadzoneDeg=%.1f\n", body::deadzone_deg());
+    fprintf(f, "crosshairVisible=%d\n",
+            g_crosshairVisible.load(std::memory_order_relaxed) ? 1 : 0);
     fclose(f);
     BVR_LOG("[b1r] VR preset values saved to vrpreset.ini");
     // The per-hand model offsets live in hands.ini; saving them here too makes
@@ -453,6 +486,8 @@ void load_vr_preset_values() {
     int n = 0;
     float lp = aim::trim_pitch_deg(0), ly = aim::trim_yaw_deg(0);
     float rp = aim::trim_pitch_deg(1), ry = aim::trim_yaw_deg(1);
+    float plf = aim::pos_fwd_cm(0), plr = aim::pos_right_cm(0), plu = aim::pos_up_cm(0);
+    float prf = aim::pos_fwd_cm(1), prr = aim::pos_right_cm(1), pru = aim::pos_up_cm(1);
     float bodyRate = body::rate_per_sec(), bodyDz = body::deadzone_deg();
     while (fgets(line, sizeof line, f)) {
         char key[48] = {};
@@ -469,13 +504,23 @@ void load_vr_preset_values() {
         else if (strcmp(key, "aimTrimLYaw") == 0) ly = v;
         else if (strcmp(key, "aimTrimRPitch") == 0) rp = v;
         else if (strcmp(key, "aimTrimRYaw") == 0) ry = v;
+        else if (strcmp(key, "aimPosLFwd") == 0) plf = v;
+        else if (strcmp(key, "aimPosLRight") == 0) plr = v;
+        else if (strcmp(key, "aimPosLUp") == 0) plu = v;
+        else if (strcmp(key, "aimPosRFwd") == 0) prf = v;
+        else if (strcmp(key, "aimPosRRight") == 0) prr = v;
+        else if (strcmp(key, "aimPosRUp") == 0) pru = v;
         else if (strcmp(key, "bodyRate") == 0) bodyRate = v;
         else if (strcmp(key, "bodyDeadzoneDeg") == 0) bodyDz = v;
+        else if (strcmp(key, "crosshairVisible") == 0)
+            g_crosshairVisible.store(v != 0.0f, std::memory_order_relaxed);
         else --n;
     }
     fclose(f);
     aim::set_trim(0, lp, ly);
     aim::set_trim(1, rp, ry);
+    aim::set_pos_offset(0, plf, plr, plu);
+    aim::set_pos_offset(1, prf, prr, pru);
     body::set_tuning(bodyRate, bodyDz);
     if (n) BVR_LOG("[b1r] VR preset: %d value(s) loaded from vrpreset.ini", n);
 }
@@ -497,6 +542,20 @@ void apply_vr_preset() {
     load_vr_preset_values();           // tuned sliders (ini) over defaults
     scenedraw::handle_command("vrstereo on"); // last: 1t + stereo, sticky
     BVR_LOG("[b1r] VR PRESET 1 armed (unwind: vrstereo off + overlay checkboxes)");
+}
+
+// Crosshair upkeep (see the globals): push the wanted state through the
+// engine's SET handler on change, and re-assert every 15 s while hidden in
+// case script-side EnableReticle callers exist somewhere. Game thread.
+void assert_crosshair(uint64_t now) {
+    int want = g_crosshairVisible.load(std::memory_order_relaxed) ? 1 : 0;
+    bool due = want != g_crosshairApplied ||
+               (want == 0 && now - g_crosshairAssertMs >= 15000);
+    if (!due) return;
+    g_crosshairApplied = want;
+    g_crosshairAssertMs = now;
+    console_exec::run_engine(want ? "set ShockPlayer bReticleDisabled False"
+                                  : "set ShockPlayer bReticleDisabled True");
 }
 
 void poll_command_file(uint64_t now) {
@@ -604,6 +663,7 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
     // M5: pump the engine's own pad pipeline against the synthetic gamepad
     // (self-throttles to once per present; no-op while vrinput is off).
     input_drive::on_frame(now);
+    assert_crosshair(now); // M8 part 2: flat crosshair hidden by default
     if (g_logCamera.load(std::memory_order_relaxed)) {
         if (g_lastHeartbeatMs == 0) {
             g_lastHeartbeatMs = now;
@@ -1055,6 +1115,9 @@ void draw_debug_ui() {
         ImGui::SameLine();
         if (ImGui::Button("Save preset values"))
             g_vrPresetSavePending.store(true, std::memory_order_relaxed);
+        bool xhair = g_crosshairVisible.load(std::memory_order_relaxed);
+        if (ImGui::Checkbox("Flat-screen crosshair (default off in VR)", &xhair))
+            g_crosshairVisible.store(xhair, std::memory_order_relaxed);
         atomic_slider("World scale (UU per m)", g_worldScale, 10.0f, 200.0f);
         atomic_slider("IPD (mm)", g_ipdMm, 55.0f, 75.0f);
         atomic_slider("Head offset up (UU)", g_headOffUpUu, -150.0f, 150.0f);

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -403,6 +403,8 @@ void apply_command(const char* cmd, const char* args) {
         else apply_vr_preset();
     } else if (strcmp(cmd, "vrpace") == 0) {
         bvr::vr::handle_pace_command(args); // M8 disconnect-stall guard
+    } else if (strcmp(cmd, "vrmirror") == 0) {
+        bvr::vr::handle_mirror_command(args); // M8 single-eye desktop mirror
     } else if (strcmp(cmd, "reentry") == 0) {
         scenedraw::handle_command(args); // DR-5 probe; logs its own echoes
     }

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -401,6 +401,8 @@ void apply_command(const char* cmd, const char* args) {
     } else if (strcmp(cmd, "vrpreset") == 0) {
         if (strncmp(args, "save", 4) == 0) save_vr_preset();
         else apply_vr_preset();
+    } else if (strcmp(cmd, "vrpace") == 0) {
+        bvr::vr::handle_pace_command(args); // M8 disconnect-stall guard
     } else if (strcmp(cmd, "reentry") == 0) {
         scenedraw::handle_command(args); // DR-5 probe; logs its own echoes
     }

--- a/src/game/bioshock1r/hands.cpp
+++ b/src/game/bioshock1r/hands.cpp
@@ -50,6 +50,12 @@ std::atomic<int> g_mode{2};           // 0 = gun (inert), 1 = hands (actor pin,
 std::atomic<bool> g_useAimPose{true}; // aim pose = the ray the laser/bullet use
 std::atomic<int> g_handMode{2};       // 0 left, 1 right, 2 auto
 std::atomic<int> g_autoHand{1};       // the latched auto choice
+// Session 18 part 3 (user report): OFF by default - the aim CALIBRATION trim
+// used to be applied to the model too, so re-trimming the ray dragged the
+// already-tuned model with it. Now the model is raw aim pose + its own trim,
+// and the ray is raw aim pose + aim trim + origin offset; each is tuned
+// against the other. `vrhands aligntrim on` restores the old coupling.
+std::atomic<bool> g_alignAimTrim{false};
 
 // Model offsets, PER HAND (0 left / 1 right, same convention as aim.cpp): the
 // pistol and the plasmid hand sit differently in the mesh, so one shared set
@@ -568,12 +574,15 @@ void on_calcview(const FrameContext& ctx) {
 
         gp = xr_pose_to_game(mapCtx, pos, q2);
 
-        // The aim calibration trim (per hand), applied exactly the way the
-        // fire ray and the laser apply it - barrel and bullet stay one ray.
-        gp.rot.pitch += static_cast<int32_t>(bvr::b1r::aim::trim_pitch_deg(hand) *
-                                             kRotUnitsPerDegree);
-        gp.rot.yaw += static_cast<int32_t>(bvr::b1r::aim::trim_yaw_deg(hand) *
-                                           kRotUnitsPerDegree);
+        // The aim calibration trim is NOT applied to the model by default
+        // (see g_alignAimTrim above) - re-trimming the ray must not move the
+        // tuned model.
+        if (g_alignAimTrim.load(std::memory_order_relaxed)) {
+            gp.rot.pitch += static_cast<int32_t>(bvr::b1r::aim::trim_pitch_deg(hand) *
+                                                 kRotUnitsPerDegree);
+            gp.rot.yaw += static_cast<int32_t>(bvr::b1r::aim::trim_yaw_deg(hand) *
+                                               kRotUnitsPerDegree);
+        }
     }
 
     // Position offset rides the final (trimmed) frame: "2 cm forward" means
@@ -706,6 +715,12 @@ void handle_command(const char* args) {
         } else {
             BVR_LOG("[hands] usage: vrhands rot [l|r] <pitchDeg> <yawDeg> <rollDeg>");
         }
+    } else if (strcmp(verb, "aligntrim") == 0) {
+        bool on = strncmp(rest, "on", 2) == 0;
+        g_alignAimTrim.store(on, std::memory_order_relaxed);
+        BVR_LOG("[hands] aim-trim coupling %s (%s)", on ? "ON" : "off",
+                on ? "model follows the aim calibration trim - pre-part-3 behavior"
+                   : "model independent of the aim trim (default)");
     } else if (strcmp(verb, "writerot") == 0) {
         bool on = strncmp(rest, "on", 2) == 0;
         g_writeRot.store(on, std::memory_order_relaxed);

--- a/src/game/bioshock1r/hands.cpp
+++ b/src/game/bioshock1r/hands.cpp
@@ -51,18 +51,23 @@ std::atomic<bool> g_useAimPose{true}; // aim pose = the ray the laser/bullet use
 std::atomic<int> g_handMode{2};       // 0 left, 1 right, 2 auto
 std::atomic<int> g_autoHand{1};       // the latched auto choice
 
-// Model offsets. Position is in CENTIMETRES in the model's final (trimmed)
-// frame; the rotation trim is degrees, applied in the CONTROLLER'S LOCAL frame
-// as a quaternion compose - euler adds after conversion only behave at one
-// controller orientation (the first headset test's "pivot" bug).
+// Model offsets, PER HAND (0 left / 1 right, same convention as aim.cpp): the
+// pistol and the plasmid hand sit differently in the mesh, so one shared set
+// meant tuning the weapon also moved the plasmid hand. Position is in
+// CENTIMETRES in the model's final (trimmed) frame; the rotation trim is
+// degrees, applied in the CONTROLLER'S LOCAL frame as a quaternion compose -
+// euler adds after conversion only behave at one controller orientation (the
+// first headset test's "pivot" bug).
 // Defaults are ZERO on purpose. The ideal pivot correction (pull the mesh's gun
 // to the controller, ~-100 cm forward) is CULLED: the engine drops the whole
 // rig the moment the actor origin goes behind the camera (live-proven - the
 // rig vanished with the origin 32 UU back). Forward pull is therefore limited
 // to roughly the controller's own distance from the face, and where that line
 // sits is the user's in-headset call, not a default.
-std::atomic<float> g_posFwdCm{0.0f}, g_posRightCm{0.0f}, g_posUpCm{0.0f};
-std::atomic<float> g_rotPitchDeg{0.0f}, g_rotYawDeg{0.0f}, g_rotRollDeg{0.0f};
+std::atomic<float> g_posFwdCm[2]{0.0f, 0.0f}, g_posRightCm[2]{0.0f, 0.0f},
+    g_posUpCm[2]{0.0f, 0.0f};
+std::atomic<float> g_rotPitchDeg[2]{0.0f, 0.0f}, g_rotYawDeg[2]{0.0f, 0.0f},
+    g_rotRollDeg[2]{0.0f, 0.0f};
 
 std::atomic<bool> g_writeRot{true}; // rotation write can be disabled on its own
 int32_t g_probeLeft = 0;
@@ -283,15 +288,20 @@ void log_status() {
     BVR_LOG("[hands]   weapon actor=%p (learned %p) | hands actor=%p (matches %d)",
             g_weaponActor, bvr::b1r::aim::learned_weapon_object(), g_handsActor,
             g_lastMatches.load(std::memory_order_relaxed));
-    BVR_LOG("[hands]   offset pos fwd%+.1f right%+.1f up%+.1f cm | trim pitch%+.1f yaw%+.1f "
-            "roll%+.1f deg | writeRot=%d",
-            g_posFwdCm.load(std::memory_order_relaxed),
-            g_posRightCm.load(std::memory_order_relaxed),
-            g_posUpCm.load(std::memory_order_relaxed),
-            g_rotPitchDeg.load(std::memory_order_relaxed),
-            g_rotYawDeg.load(std::memory_order_relaxed),
-            g_rotRollDeg.load(std::memory_order_relaxed),
-            g_writeRot.load(std::memory_order_relaxed) ? 1 : 0);
+    for (int h = 0; h < 2; ++h) {
+        BVR_LOG("[hands]   offset %s pos fwd%+.1f right%+.1f up%+.1f cm | trim pitch%+.1f "
+                "yaw%+.1f roll%+.1f deg%s",
+                h == 0 ? "L" : "R",
+                g_posFwdCm[h].load(std::memory_order_relaxed),
+                g_posRightCm[h].load(std::memory_order_relaxed),
+                g_posUpCm[h].load(std::memory_order_relaxed),
+                g_rotPitchDeg[h].load(std::memory_order_relaxed),
+                g_rotYawDeg[h].load(std::memory_order_relaxed),
+                g_rotRollDeg[h].load(std::memory_order_relaxed),
+                h == 1 ? (g_writeRot.load(std::memory_order_relaxed) ? " | writeRot=1"
+                                                                     : " | writeRot=0")
+                       : "");
+    }
     uint64_t now = GetTickCount64();
     BVR_LOG("[hands]   last write loc=(%.1f %.1f %.1f) rot=(%d %d %d) testHold=%dms "
             "simHold=%dms",
@@ -323,16 +333,38 @@ void save_config() {
         return;
     }
     fprintf(f, "# BioShock VR - M7 viewmodel offsets (cm / degrees, model-local frame)\n");
+    fprintf(f, "# Per-hand keys: ...L = left (plasmid), ...R = right (weapon). A legacy\n");
+    fprintf(f, "# suffix-less key (posFwdCm=...) still loads and applies to BOTH hands.\n");
     fprintf(f, "mode=%d\n", g_mode.load(std::memory_order_relaxed));
     fprintf(f, "aimPose=%d\n", g_useAimPose.load(std::memory_order_relaxed) ? 1 : 0);
-    fprintf(f, "posFwdCm=%.2f\n", g_posFwdCm.load(std::memory_order_relaxed));
-    fprintf(f, "posRightCm=%.2f\n", g_posRightCm.load(std::memory_order_relaxed));
-    fprintf(f, "posUpCm=%.2f\n", g_posUpCm.load(std::memory_order_relaxed));
-    fprintf(f, "rotPitchDeg=%.2f\n", g_rotPitchDeg.load(std::memory_order_relaxed));
-    fprintf(f, "rotYawDeg=%.2f\n", g_rotYawDeg.load(std::memory_order_relaxed));
-    fprintf(f, "rotRollDeg=%.2f\n", g_rotRollDeg.load(std::memory_order_relaxed));
+    for (int h = 0; h < 2; ++h) {
+        const char* s = h == 0 ? "L" : "R";
+        fprintf(f, "posFwdCm%s=%.2f\n", s, g_posFwdCm[h].load(std::memory_order_relaxed));
+        fprintf(f, "posRightCm%s=%.2f\n", s, g_posRightCm[h].load(std::memory_order_relaxed));
+        fprintf(f, "posUpCm%s=%.2f\n", s, g_posUpCm[h].load(std::memory_order_relaxed));
+        fprintf(f, "rotPitchDeg%s=%.2f\n", s, g_rotPitchDeg[h].load(std::memory_order_relaxed));
+        fprintf(f, "rotYawDeg%s=%.2f\n", s, g_rotYawDeg[h].load(std::memory_order_relaxed));
+        fprintf(f, "rotRollDeg%s=%.2f\n", s, g_rotRollDeg[h].load(std::memory_order_relaxed));
+    }
     fclose(f);
     BVR_LOG("[hands] offsets saved to hands.ini");
+}
+
+// "posFwdCmL"/"posFwdCmR" store one hand; the legacy suffix-less "posFwdCm"
+// (pre-per-hand ini files) stores BOTH, so an old hands.ini keeps working.
+bool store_hand_key(const char* key, const char* base, std::atomic<float> (&dst)[2], float v) {
+    size_t n = strlen(base);
+    if (strncmp(key, base, n) != 0) return false;
+    if (key[n] == '\0') {
+        dst[0].store(v, std::memory_order_relaxed);
+        dst[1].store(v, std::memory_order_relaxed);
+        return true;
+    }
+    if ((key[n] == 'L' || key[n] == 'R') && key[n + 1] == '\0') {
+        dst[key[n] == 'R' ? 1 : 0].store(v, std::memory_order_relaxed);
+        return true;
+    }
+    return false;
 }
 
 void load_config() {
@@ -353,12 +385,12 @@ void load_config() {
             g_mode.store(m < 0 ? 0 : m > 2 ? 2 : m, std::memory_order_relaxed);
         }
         else if (strcmp(key, "aimPose") == 0) g_useAimPose.store(v != 0.0f, std::memory_order_relaxed);
-        else if (strcmp(key, "posFwdCm") == 0) g_posFwdCm.store(v, std::memory_order_relaxed);
-        else if (strcmp(key, "posRightCm") == 0) g_posRightCm.store(v, std::memory_order_relaxed);
-        else if (strcmp(key, "posUpCm") == 0) g_posUpCm.store(v, std::memory_order_relaxed);
-        else if (strcmp(key, "rotPitchDeg") == 0) g_rotPitchDeg.store(v, std::memory_order_relaxed);
-        else if (strcmp(key, "rotYawDeg") == 0) g_rotYawDeg.store(v, std::memory_order_relaxed);
-        else if (strcmp(key, "rotRollDeg") == 0) g_rotRollDeg.store(v, std::memory_order_relaxed);
+        else if (store_hand_key(key, "posFwdCm", g_posFwdCm, v)) {}
+        else if (store_hand_key(key, "posRightCm", g_posRightCm, v)) {}
+        else if (store_hand_key(key, "posUpCm", g_posUpCm, v)) {}
+        else if (store_hand_key(key, "rotPitchDeg", g_rotPitchDeg, v)) {}
+        else if (store_hand_key(key, "rotYawDeg", g_rotYawDeg, v)) {}
+        else if (store_hand_key(key, "rotRollDeg", g_rotRollDeg, v)) {}
         else --n;
     }
     fclose(f);
@@ -456,7 +488,9 @@ void on_calcview(const FrameContext& ctx) {
     void* target = find_hands_actor(ctx, false);
     if (!target) return;
 
-    // Where the model goes.
+    // Where the model goes. The hand is resolved once and used for the pose,
+    // the aim trim, and both per-hand model offsets below.
+    const int hand = active_hand();
     GamePose gp{};
     uint64_t now = GetTickCount64();
     if (now < g_test.deadline) {
@@ -491,7 +525,7 @@ void on_calcview(const FrameContext& ctx) {
         } else {
             bvr::vr::HeadPose hp{};
             bool aimPose = g_useAimPose.load(std::memory_order_relaxed);
-            if (!ctx.vrDriving || !bvr::vr::get_hand_pose(active_hand(), aimPose, hp)) return;
+            if (!ctx.vrDriving || !bvr::vr::get_hand_pose(hand, aimPose, hp)) return;
             pos[0] = hp.px;
             pos[1] = hp.py;
             pos[2] = hp.pz;
@@ -505,27 +539,28 @@ void on_calcview(const FrameContext& ctx) {
                     lastTlm = now;
                     BVR_LOG("[tlm] ctrl%d xr p=(%.3f %.3f %.3f) q=(%.3f %.3f %.3f %.3f) "
                             "pose=%s",
-                            active_hand(), hp.px, hp.py, hp.pz, hp.qx, hp.qy, hp.qz, hp.qw,
+                            hand, hp.px, hp.py, hp.pz, hp.qx, hp.qy, hp.qz, hp.qw,
                             aimPose ? "aim" : "grip");
                 }
             }
         }
 
-        // Mesh-alignment trim, composed in the controller's local frame so it
-        // holds at EVERY controller orientation.
+        // Mesh-alignment trim (per hand), composed in the controller's local
+        // frame so it holds at EVERY controller orientation.
         float trim[4], q2[4];
-        xr_local_trim_quat(g_rotPitchDeg.load(std::memory_order_relaxed) / kRadToDeg,
-                           g_rotYawDeg.load(std::memory_order_relaxed) / kRadToDeg,
-                           g_rotRollDeg.load(std::memory_order_relaxed) / kRadToDeg, trim);
+        xr_local_trim_quat(g_rotPitchDeg[hand].load(std::memory_order_relaxed) / kRadToDeg,
+                           g_rotYawDeg[hand].load(std::memory_order_relaxed) / kRadToDeg,
+                           g_rotRollDeg[hand].load(std::memory_order_relaxed) / kRadToDeg,
+                           trim);
         quat_mul(quat, trim, q2);
 
         gp = xr_pose_to_game(mapCtx, pos, q2);
 
         // The aim calibration trim (per hand), applied exactly the way the
         // fire ray and the laser apply it - barrel and bullet stay one ray.
-        gp.rot.pitch += static_cast<int32_t>(bvr::b1r::aim::trim_pitch_deg(active_hand()) *
+        gp.rot.pitch += static_cast<int32_t>(bvr::b1r::aim::trim_pitch_deg(hand) *
                                              kRotUnitsPerDegree);
-        gp.rot.yaw += static_cast<int32_t>(bvr::b1r::aim::trim_yaw_deg(active_hand()) *
+        gp.rot.yaw += static_cast<int32_t>(bvr::b1r::aim::trim_yaw_deg(hand) *
                                            kRotUnitsPerDegree);
     }
 
@@ -534,9 +569,9 @@ void on_calcview(const FrameContext& ctx) {
     float fwd[3], right[3], up[3];
     ue_rot_basis(gp.rot, fwd, right, up);
     float uuPerCm = ctx.worldScale / 100.0f;
-    float of = g_posFwdCm.load(std::memory_order_relaxed) * uuPerCm;
-    float orr = g_posRightCm.load(std::memory_order_relaxed) * uuPerCm;
-    float ou = g_posUpCm.load(std::memory_order_relaxed) * uuPerCm;
+    float of = g_posFwdCm[hand].load(std::memory_order_relaxed) * uuPerCm;
+    float orr = g_posRightCm[hand].load(std::memory_order_relaxed) * uuPerCm;
+    float ou = g_posUpCm[hand].load(std::memory_order_relaxed) * uuPerCm;
     float loc[3] = {gp.loc.x + fwd[0] * of + right[0] * orr + up[0] * ou,
                     gp.loc.y + fwd[1] * of + right[1] * orr + up[1] * ou,
                     gp.loc.z + fwd[2] * of + right[2] * orr + up[2] * ou};
@@ -546,7 +581,7 @@ void on_calcview(const FrameContext& ctx) {
         // culling, correct engine-side FX anchoring) and the hand CLUSTER
         // moves to the controller instead.
         gp.loc = {loc[0], loc[1], loc[2]};
-        if (!bones::drive(ctx, target, gp, active_hand())) return;
+        if (!bones::drive(ctx, target, gp, hand)) return;
     } else {
         uint8_t* p = static_cast<uint8_t*>(target);
         bool wrote = write12(p + patterns::kActorLocOffset, loc);
@@ -616,24 +651,48 @@ void handle_command(const char* args) {
         g_handMode.store(mode, std::memory_order_relaxed);
         BVR_LOG("[hands] hand = %s", mode == 0 ? "LEFT" : mode == 1 ? "RIGHT" : "auto");
     } else if (strcmp(verb, "pos") == 0) {
+        // "pos [l|r] <fwd> <right> <up>" - no side = both hands (the legacy
+        // form, kept so the acceptance harness and old scripts still work).
+        int side = -1;
+        const char* nums = rest;
+        if ((rest[0] == 'l' || rest[0] == 'r') && (rest[1] == ' ' || rest[1] == '\t')) {
+            side = rest[0] == 'r' ? 1 : 0;
+            nums = rest + 1;
+            while (*nums == ' ' || *nums == '\t') ++nums;
+        }
         float f = 0.0f, r = 0.0f, u = 0.0f;
-        if (sscanf_s(rest, "%f %f %f", &f, &r, &u) == 3) {
-            g_posFwdCm.store(f, std::memory_order_relaxed);
-            g_posRightCm.store(r, std::memory_order_relaxed);
-            g_posUpCm.store(u, std::memory_order_relaxed);
-            BVR_LOG("[hands] pos offset fwd%+.1f right%+.1f up%+.1f cm", f, r, u);
+        if (sscanf_s(nums, "%f %f %f", &f, &r, &u) == 3) {
+            for (int h = 0; h < 2; ++h) {
+                if (side >= 0 && h != side) continue;
+                g_posFwdCm[h].store(f, std::memory_order_relaxed);
+                g_posRightCm[h].store(r, std::memory_order_relaxed);
+                g_posUpCm[h].store(u, std::memory_order_relaxed);
+            }
+            BVR_LOG("[hands] pos offset (%s) fwd%+.1f right%+.1f up%+.1f cm",
+                    side < 0 ? "both" : side == 1 ? "right" : "left", f, r, u);
         } else {
-            BVR_LOG("[hands] usage: vrhands pos <fwdCm> <rightCm> <upCm>");
+            BVR_LOG("[hands] usage: vrhands pos [l|r] <fwdCm> <rightCm> <upCm>");
         }
     } else if (strcmp(verb, "rot") == 0) {
+        int side = -1;
+        const char* nums = rest;
+        if ((rest[0] == 'l' || rest[0] == 'r') && (rest[1] == ' ' || rest[1] == '\t')) {
+            side = rest[0] == 'r' ? 1 : 0;
+            nums = rest + 1;
+            while (*nums == ' ' || *nums == '\t') ++nums;
+        }
         float p = 0.0f, y = 0.0f, r = 0.0f;
-        if (sscanf_s(rest, "%f %f %f", &p, &y, &r) == 3) {
-            g_rotPitchDeg.store(p, std::memory_order_relaxed);
-            g_rotYawDeg.store(y, std::memory_order_relaxed);
-            g_rotRollDeg.store(r, std::memory_order_relaxed);
-            BVR_LOG("[hands] rot trim pitch%+.1f yaw%+.1f roll%+.1f deg", p, y, r);
+        if (sscanf_s(nums, "%f %f %f", &p, &y, &r) == 3) {
+            for (int h = 0; h < 2; ++h) {
+                if (side >= 0 && h != side) continue;
+                g_rotPitchDeg[h].store(p, std::memory_order_relaxed);
+                g_rotYawDeg[h].store(y, std::memory_order_relaxed);
+                g_rotRollDeg[h].store(r, std::memory_order_relaxed);
+            }
+            BVR_LOG("[hands] rot trim (%s) pitch%+.1f yaw%+.1f roll%+.1f deg",
+                    side < 0 ? "both" : side == 1 ? "right" : "left", p, y, r);
         } else {
-            BVR_LOG("[hands] usage: vrhands rot <pitchDeg> <yawDeg> <rollDeg>");
+            BVR_LOG("[hands] usage: vrhands rot [l|r] <pitchDeg> <yawDeg> <rollDeg>");
         }
     } else if (strcmp(verb, "writerot") == 0) {
         bool on = strncmp(rest, "on", 2) == 0;
@@ -696,6 +755,10 @@ bool active() {
            (g_weaponActor != nullptr || g_handsActor != nullptr);
 }
 
+void save_offsets() {
+    save_config();
+}
+
 void draw_debug_ui() {
     if (!ImGui::CollapsingHeader("Hands + weapon (M7)")) return;
 
@@ -714,25 +777,36 @@ void draw_debug_ui() {
     ImGui::SameLine();
     if (ImGui::RadioButton("auto", &hand, 2)) g_handMode.store(2, std::memory_order_relaxed);
 
-    float f = g_posFwdCm.load(std::memory_order_relaxed);
-    if (ImGui::SliderFloat("offset forward (cm)", &f, -120.0f, 120.0f))
-        g_posFwdCm.store(f, std::memory_order_relaxed);
-    float r = g_posRightCm.load(std::memory_order_relaxed);
-    if (ImGui::SliderFloat("offset right (cm)", &r, -120.0f, 120.0f))
-        g_posRightCm.store(r, std::memory_order_relaxed);
-    float u = g_posUpCm.load(std::memory_order_relaxed);
-    if (ImGui::SliderFloat("offset up (cm)", &u, -120.0f, 120.0f))
-        g_posUpCm.store(u, std::memory_order_relaxed);
+    // The six sliders below edit ONE hand's offsets - the selector picks
+    // which (in-headset tuning wants one set of sliders, not twelve).
+    // Separate from the drive-hand radio above: that picks which controller
+    // OWNS the viewmodel, this picks which hand's numbers the sliders show.
+    static int tuneHand = 1; // start on the weapon hand
+    ImGui::Text("Tuning hand:");
+    ImGui::SameLine();
+    ImGui::RadioButton("L (plasmid)", &tuneHand, 0);
+    ImGui::SameLine();
+    ImGui::RadioButton("R (weapon)", &tuneHand, 1);
 
-    float rp = g_rotPitchDeg.load(std::memory_order_relaxed);
+    float f = g_posFwdCm[tuneHand].load(std::memory_order_relaxed);
+    if (ImGui::SliderFloat("offset forward (cm)", &f, -120.0f, 120.0f))
+        g_posFwdCm[tuneHand].store(f, std::memory_order_relaxed);
+    float r = g_posRightCm[tuneHand].load(std::memory_order_relaxed);
+    if (ImGui::SliderFloat("offset right (cm)", &r, -120.0f, 120.0f))
+        g_posRightCm[tuneHand].store(r, std::memory_order_relaxed);
+    float u = g_posUpCm[tuneHand].load(std::memory_order_relaxed);
+    if (ImGui::SliderFloat("offset up (cm)", &u, -120.0f, 120.0f))
+        g_posUpCm[tuneHand].store(u, std::memory_order_relaxed);
+
+    float rp = g_rotPitchDeg[tuneHand].load(std::memory_order_relaxed);
     if (ImGui::SliderFloat("trim pitch (deg)", &rp, -90.0f, 90.0f))
-        g_rotPitchDeg.store(rp, std::memory_order_relaxed);
-    float ry = g_rotYawDeg.load(std::memory_order_relaxed);
+        g_rotPitchDeg[tuneHand].store(rp, std::memory_order_relaxed);
+    float ry = g_rotYawDeg[tuneHand].load(std::memory_order_relaxed);
     if (ImGui::SliderFloat("trim yaw (deg)", &ry, -90.0f, 90.0f))
-        g_rotYawDeg.store(ry, std::memory_order_relaxed);
-    float rr = g_rotRollDeg.load(std::memory_order_relaxed);
+        g_rotYawDeg[tuneHand].store(ry, std::memory_order_relaxed);
+    float rr = g_rotRollDeg[tuneHand].load(std::memory_order_relaxed);
     if (ImGui::SliderFloat("trim roll (deg)", &rr, -180.0f, 180.0f))
-        g_rotRollDeg.store(rr, std::memory_order_relaxed);
+        g_rotRollDeg[tuneHand].store(rr, std::memory_order_relaxed);
 
     if (ImGui::Button("Save offsets")) save_config();
     ImGui::SameLine();

--- a/src/game/bioshock1r/hands.cpp
+++ b/src/game/bioshock1r/hands.cpp
@@ -281,9 +281,10 @@ void log_status() {
             g_enabled.load(std::memory_order_relaxed) ? "ON" : "off",
             mode == 0 ? "GUN" : mode == 1 ? "HANDS" : "BONES",
             g_useAimPose.load(std::memory_order_relaxed) ? "aim" : "grip",
-            g_handMode.load(std::memory_order_relaxed) == 0   ? "LEFT"
-            : g_handMode.load(std::memory_order_relaxed) == 1 ? "RIGHT"
-                                                              : "auto",
+            g_handMode.load(std::memory_order_relaxed) == 0 ? "LEFT"
+            : g_handMode.load(std::memory_order_relaxed) == 1
+                ? "RIGHT"
+                : (g_autoHand.load(std::memory_order_relaxed) == 0 ? "auto(L)" : "auto(R)"),
             g_writes.load(std::memory_order_relaxed));
     BVR_LOG("[hands]   weapon actor=%p (learned %p) | hands actor=%p (matches %d)",
             g_weaponActor, bvr::b1r::aim::learned_weapon_object(), g_handsActor,
@@ -399,14 +400,25 @@ void load_config() {
 
 } // namespace
 
-// BioShock holds ONE thing at a time (the trigger that fires also switches
-// hands - XENON_RT/LT), so the viewmodel belongs to whichever hand last fired.
-// Seeded from the triggers the bridge itself composes, exactly like aim.cpp's
-// object map. Shared with the aim laser so the beam leaves the hand that is
-// actually holding the weapon.
+// BioShock holds ONE thing at a time, so the viewmodel belongs to whichever
+// hand the player last engaged. Two ways to engage, both latched here from
+// the state the bridge itself composes (same source as aim.cpp's object map):
+//   - the TRIGGERS (fire = switch-and-fire, XENON_RT/LT), and
+//   - the BUMPERS (the grips compose to LB/RB, and a bumper press switches
+//     the raised hand with NO trigger event - the M8 grip-switch bug was the
+//     latch only learning from triggers, so a grip switch left the model on
+//     the stale controller until the next trigger pull).
+// Bumpers are checked first so a same-frame trigger wins (firing is the
+// stronger evidence of which hand the player means). Shared with the aim
+// laser so the beam leaves the hand that is actually holding the weapon.
 int active_hand() {
     int mode = g_handMode.load(std::memory_order_relaxed);
     if (mode == 0 || mode == 1) return mode;
+
+    bool lb = false, rb = false;
+    bvr::input::last_composed_bumpers(&lb, &rb);
+    if (rb && !lb) g_autoHand.store(1, std::memory_order_relaxed);
+    else if (lb && !rb) g_autoHand.store(0, std::memory_order_relaxed);
 
     uint8_t lt = 0, rt = 0;
     bvr::input::last_composed_triggers(&lt, &rt);

--- a/src/game/bioshock1r/hands.cpp
+++ b/src/game/bioshock1r/hands.cpp
@@ -83,6 +83,7 @@ void* g_handsActor = nullptr;
 void* g_weaponActor = nullptr;
 uint64_t g_lastHandsScanMs = 0;
 uint64_t g_lastWeaponScanMs = 0;
+uint32_t g_handsScanFails = 0; // consecutive empty scans -> backoff
 void* g_lastPc = nullptr;
 std::atomic<uint32_t> g_writes{0};
 std::atomic<int32_t> g_lastMatches{0};
@@ -234,17 +235,35 @@ void* find_hands_actor(const FrameContext& ctx, bool probeOnly) {
         if (has_vtable(g_handsActor, patterns::kHandsVtableRva)) return g_handsActor;
         g_handsActor = nullptr;
         uint64_t now = GetTickCount64();
-        if (now - g_lastHandsScanMs < 2000) return nullptr;
+        // Exponential backoff on consecutive empty scans (2s -> 32s cap).
+        // The rig legitimately does not exist for long stretches (the NG+
+        // intro runs minutes with no hands), and the full heap scan can take
+        // SECONDS on a grown late-game heap - without backoff the 2 s
+        // cooldown dragged the whole game to ~1 fps for the entire intro
+        // (session 18 part 3, live). Reset on success, world change, and
+        // re-enable, so pickup stays prompt when the rig actually appears.
+        uint32_t shift = g_handsScanFails > 4 ? 4 : g_handsScanFails;
+        if (now - g_lastHandsScanMs < (2000ull << shift)) return nullptr;
         g_lastHandsScanMs = now;
     }
     ScanCtx sc{ctx.camX, ctx.camY, ctx.camZ, probeOnly, !probeOnly};
     int matches = 0;
+    uint64_t scanStart = GetTickCount64();
     void* found = patterns::scan_for_vtable_object(
         patterns::kHandsVtableRva, patterns::kActorViewDirOffset + 12, &accept_hands, &sc,
         "AHands", &matches);
     g_lastMatches.store(matches, std::memory_order_relaxed);
     if (probeOnly) return nullptr;
     g_handsActor = found;
+    if (found) {
+        g_handsScanFails = 0;
+    } else {
+        if (g_handsScanFails == 0)
+            BVR_LOG("[hands] no live AHands in this world yet (scan %u ms) - "
+                    "retrying with backoff",
+                    static_cast<uint32_t>(GetTickCount64() - scanStart));
+        ++g_handsScanFails;
+    }
     return g_handsActor;
 }
 
@@ -448,6 +467,7 @@ void on_calcview(const FrameContext& ctx) {
     int pending = g_pendingEnable.exchange(-1, std::memory_order_relaxed);
     if (pending == 1) {
         g_enabled.store(true, std::memory_order_relaxed);
+        g_handsScanFails = 0; // re-enable: scan promptly
         BVR_LOG("[hands] ON (overlay) - viewmodel follows the controller");
     } else if (pending == 0) {
         g_enabled.store(false, std::memory_order_relaxed);
@@ -465,6 +485,7 @@ void on_calcview(const FrameContext& ctx) {
         g_weaponActor = nullptr;
         g_lastHandsScanMs = 0;
         g_lastWeaponScanMs = 0;
+        g_handsScanFails = 0; // new world: scan promptly again
         bones::on_world_change();
     }
 
@@ -636,6 +657,7 @@ void handle_command(const char* args) {
 
     if (strcmp(verb, "on") == 0) {
         g_enabled.store(true, std::memory_order_relaxed);
+        g_handsScanFails = 0; // re-enable: scan promptly
         BVR_LOG("[hands] ON - viewmodel follows the controller");
         log_status();
     } else if (strcmp(verb, "off") == 0) {

--- a/src/game/bioshock1r/hands.h
+++ b/src/game/bioshock1r/hands.h
@@ -48,10 +48,14 @@ void on_calcview(const FrameContext& ctx);
 //   probe [n]               log every AHands + player-weapon instance, choose none
 //   hand l|r|auto           which controller drives the model (auto = the hand
 //                           whose trigger was last pulled; default)
-//   pos <fwd> <right> <up>  model offset in cm, in the model's final frame
-//   rot <pitch> <yaw> <roll>  mesh-alignment trim in degrees, composed in the
-//                           controller's LOCAL frame (holds at any orientation)
-//   save | reload           persist / re-read the offsets
+//   pos [l|r] <fwd> <right> <up>  model offset in cm, in the model's final
+//                           frame; no side = BOTH hands (legacy form, what the
+//                           harness and old scripts use)
+//   rot [l|r] <pitch> <yaw> <roll>  mesh-alignment trim in degrees, composed in
+//                           the controller's LOCAL frame (holds at any
+//                           orientation); no side = BOTH hands
+//   save | reload           persist / re-read the offsets (per-hand keys in
+//                           hands.ini; a legacy suffix-less key loads to both)
 //   test <dYaw> <dPitch> [distUU] [holdMs]   camera-relative placement (proves
 //                           the write lands; no pose math)
 //   simpose <yaw> <pitch> <roll> [holdMs]    synthetic XR controller pose fed
@@ -64,6 +68,11 @@ void handle_command(const char* args);
 // whose trigger last fired, or the forced choice. Shared with the aim laser so
 // the beam leaves the hand that is actually holding the weapon.
 int active_hand();
+
+// Persist the per-hand model offsets to hands.ini (same as `vrhands save`).
+// Called by `vrpreset save` too, so the one in-headset save button covers the
+// model sliders along with the preset's own values.
+void save_offsets();
 
 // Overlay section (render thread).
 void draw_debug_ui();

--- a/src/game/bioshock1r/patterns.cpp
+++ b/src/game/bioshock1r/patterns.cpp
@@ -85,7 +85,13 @@ void* scan_for_vtable_object(uint32_t vtableRva, uint32_t needBytes, ObjectAccep
 
     uintptr_t p = 0x10000;
     MEMORY_BASIC_INFORMATION mbi{};
-    while (p < 0x7FFF0000u &&
+    // Walk the FULL 4 GB range: the game is Large-Address-Aware, and after a
+    // long session the engine allocates actors ABOVE 2 GB - a 0x7FFF0000 cap
+    // made the live AHands invisible after a level transition (session 18
+    // part 4, live: "2 matches, chosen=0" forever while the rig rendered on
+    // screen). VirtualQuery just fails past the top on non-LAA processes, so
+    // the loop still terminates there.
+    while (p < 0xFFFE0000u &&
            VirtualQuery(reinterpret_cast<void*>(p), &mbi, sizeof(mbi)) == sizeof(mbi)) {
         uintptr_t base = reinterpret_cast<uintptr_t>(mbi.BaseAddress);
         uintptr_t end = base + mbi.RegionSize;


### PR DESCRIPTION
Session 18 (parts 1-4) on top of M7.5.

Release blockers (M8):
- Pace guard: skip xrWaitFrame when the session leaves FOCUSED (headset-idle stall fixed; field-validated: 75k skips, clean FOCUSED recovery)
- Desktop mirror pinned to the left eye under SR stereo (streamable window; compositor feed untouched)

Tuning (user asks):
- Per-hand viewmodel offsets (pos/rot), tuning-hand selector, per-hand hands.ini keys with legacy fallback
- Per-hand aim-ray origin offsets (laser + fire origin move as one ray)
- Aim trim decoupled from the model (aligntrim off default)
- Flat crosshair hidden by default via ShockPlayer.bReticleDisabled through the engine SET seam
- vrpreset save now persists hands.ini too

Fixes:
- Grip-switch wrong-controller: hand latch learns from grip-mapped bumpers
- Exponential backoff on empty AHands scans (NG+ intro 1 fps storm)
- Heap scans walk the full 4 GB LAA range (post-transition rig loss)

Docs: ENGINE_NOTES session 18 (present duty cycle, SET seam, source-text extraction), STATUS handoff, session 19 plan. Release zip staged; tag after the user's go.