### PR TITLE
M8 completion: HUD quad, VR bindings, hide-inactive, stick-pitch kill (v0.2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To uninstall, delete the two DLLs (restore itsloopyo's backup if you made one).
 | Right grip | switch/cycle weapon (hold for the radial) |
 | Left grip | switch/cycle plasmid (hold for the radial) |
 | Left stick | move (crouch on click) |
-| Right stick | turn; quick click = zoom; **hold click + push up/down/left = select ammo type** |
+| Right stick | turn; **hold click + push up/down/left = select ammo type** (zoom is removed in VR) |
 | A | use / interact (and menu confirm) |
 | B | jump |
 | X | reload / hack / inject EVE |

--- a/README.md
+++ b/README.md
@@ -8,12 +8,14 @@ The mod is a DLL injected into the game's process. It hooks the game's DirectX 1
 the Vengeance engine (Unreal Engine 2.5 lineage) camera path, and drives them from an OpenXR
 session. No game files are modified and no game assets are distributed.
 
-> **Status:** first playable release. Working today: full-rate stereo rendering, 6DOF head
-> tracking, motion-controller aim with a laser (right hand = weapons, left hand = plasmids),
-> the visible viewmodel following the controller, body-follows-head movement ("walk where you
-> look"), a single-eye desktop mirror, and in-headset tuning sliders that persist. See
+> **Status:** playable. Working today: full-rate stereo rendering, 6DOF head tracking,
+> motion-controller aim with a laser (right hand = weapons, left hand = plasmids), the visible
+> viewmodel following the controller with the inactive hand hidden, body-follows-head movement
+> ("walk where you look"), the game HUD (health/EVE/ammo - and the pause menu) on a readable
+> floating panel in VR, VR-standard controller bindings with stick-flick ammo switching, a
+> single-eye desktop mirror, and in-headset tuning sliders that persist. See
 > [docs/STATUS.md](docs/STATUS.md) for the current state and [docs/ROADMAP.md](docs/ROADMAP.md)
-> for what is next (HUD readability in VR is the known big gap).
+> for what is next (per-weapon aim alignment is the known big gap).
 
 ## Requirements
 
@@ -41,8 +43,24 @@ To uninstall, delete the two DLLs (restore itsloopyo's backup if you made one).
 2. Press **F10** to open the mod overlay and click **VR PRESET 1** - one press arms
    everything in the right order: VR pacing, 6DOF camera, motion controllers, controller aim +
    laser, the viewmodel drive, body-follows-head, and stereo last.
-3. Quest 3 Touch: right controller aims and fires weapons, left controller aims and casts
-   plasmids, grips switch hands, sticks move and turn.
+3. Quest 3 Touch controls:
+
+| Input | Action |
+|---|---|
+| Right trigger | fire weapon (first pull raises it) |
+| Left trigger | cast plasmid (first pull raises it) |
+| Right grip | switch/cycle weapon (hold for the radial) |
+| Left grip | switch/cycle plasmid (hold for the radial) |
+| Left stick | move (crouch on click) |
+| Right stick | turn; **flick up/down = switch ammo type**; zoom on click |
+| A | jump |
+| B | use / interact |
+| X | reload / hack / inject EVE |
+| Y | first-aid kit |
+| Left menu button | pause (hold: map/objectives) |
+
+   Under VR the right stick no longer pitches the view (your head does); `vrinput pitchkill
+   off` restores stick pitch if you want it back.
 
 Tuning (all in the overlay, all persisted by **"Save preset values"** / `vrpreset save`):
 
@@ -57,6 +75,11 @@ Tuning (all in the overlay, all persisted by **"Save preset values"** / `vrprese
 
 The flat-screen crosshair is hidden by default (the laser replaces it); the "Flat-screen
 crosshair" checkbox or `vrxhair on` brings it back.
+
+The game HUD (health, EVE, ammo - and the pause menu) shows on a head-locked floating panel
+during stereo gameplay; "HUD distance/width/height offset" sliders place it, `vrhud off`
+disables the capture entirely, and the inactive hand's model is hidden while the other hand
+is raised (`vrhands hideinactive off` shows both).
 
 The desktop window mirrors the **left eye** while stereo runs (`vrmirror off` restores the raw
 alternating view), and the game keeps running at full speed on the monitor when you take the

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ To uninstall, delete the two DLLs (restore itsloopyo's backup if you made one).
 | Right grip | switch/cycle weapon (hold for the radial) |
 | Left grip | switch/cycle plasmid (hold for the radial) |
 | Left stick | move (crouch on click) |
-| Right stick | turn; **flick up/down = switch ammo type**; zoom on click |
-| A | jump |
-| B | use / interact |
+| Right stick | turn; quick click = zoom; **hold click + push up/down/left = select ammo type** |
+| A | use / interact (and menu confirm) |
+| B | jump |
 | X | reload / hack / inject EVE |
 | Y | first-aid kit |
 | Left menu button | pause (hold: map/objectives) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -130,16 +130,17 @@ to VR conventions (jump on the lower-right button) instead of passing through.
 |---|---|---|
 | Left thumbstick | LS | move |
 | Right thumbstick | RS | look (Y zeroed during VR gameplay - the HMD owns pitch; `vrinput pitchkill off` restores) |
-| Right stick flick up / down | DPAD_UP / DPAD_DOWN pulse | ammo-type cycle (suppressed while a grip is held - the radials read the stick) |
+| Right stick, CLICK HELD + push up/down/left | DPAD_UP / DOWN / LEFT pulse | ammo-slot select (each dpad direction selects its slot; turning suppressed while held; grips suppress it - the radials read the stick) |
+| Right stick, quick click-tap | RS click pulse | zoom (unchanged; only the tap is delayed past the select window) |
 | Right trigger | RT | fire weapon |
 | Left trigger | LT | fire plasmid |
 | Right grip (squeeze, 0.70/0.55 hysteresis) | RB | next weapon / weapon radial on hold |
 | Left grip (same) | LB | next plasmid / plasmid radial on hold |
-| A | Y | jump |
-| B | A | use / interact |
+| A | A | use / interact / menu confirm (headset verdict: A stays use) |
+| B | Y | jump |
 | X | X | reload / hack / inject EVE |
 | Y | B | first-aid (med hypo) |
-| Stick clicks | LS / RS click | crouch / zoom |
+| Left stick click | LS click | crouch |
 | Left menu, short press (<500 ms, pulsed on release) | START | pause menu |
 | Left menu, hold (>=500 ms) | BACK | map/objectives |
 - **Lane 2 - engine-level**: console-exec dispatcher for discrete actions (weapon/plasmid

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -131,7 +131,8 @@ to VR conventions (jump on the lower-right button) instead of passing through.
 | Left thumbstick | LS | move |
 | Right thumbstick | RS | look (Y zeroed during VR gameplay - the HMD owns pitch; `vrinput pitchkill off` restores) |
 | Right stick, CLICK HELD + push up/down/left | DPAD_UP / DOWN / LEFT pulse | ammo-slot select (each dpad direction selects its slot; turning suppressed while held; grips suppress it - the radials read the stick) |
-| Right stick, quick click-tap | RS click pulse | zoom (unchanged; only the tap is delayed past the select window) |
+| Right stick click alone | (nothing) | zoom is REMOVED in VR (user's call - an HMD FOV zoom is a comfort hazard; RS click never reaches the game) |
+| (while a grip/bumper is held) | RS Y passes through | the radial wheels read stick Y for selection - the pitch kill lifts for the hold, and the game side snapshots/restores the PC pitch around it so wheel-time look drift cannot stick |
 | Right trigger | RT | fire weapon |
 | Left trigger | LT | fire plasmid |
 | Right grip (squeeze, 0.70/0.55 hysteresis) | RB | next weapon / weapon radial on hold |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -120,22 +120,28 @@ Known hard parts of re-entry and their mitigations:
   set) + game/bioshock1r/input_drive (drives UWindowsViewport::UpdateInput and the engine's own
   SetUseController). Details: ENGINE_NOTES "Gamepad architecture".*
 
-### Controller mapping (Quest 3 Touch -> Xbox 360 pad, M5)
+### Controller mapping (Quest 3 Touch -> Xbox 360 pad, M5; face buttons re-routed session 19)
+
+The game's own layout (User.ini XENON_*, ENGINE_NOTES session 19) is A=Use,
+B=Heal, X=Reload/Hack/EVE, Y=Jump - so the XR layer re-routes the face buttons
+to VR conventions (jump on the lower-right button) instead of passing through.
 
 | Touch input | XInput output | BioShock meaning |
 |---|---|---|
 | Left thumbstick | LS | move |
-| Right thumbstick | RS | look |
+| Right thumbstick | RS | look (Y zeroed during VR gameplay - the HMD owns pitch; `vrinput pitchkill off` restores) |
+| Right stick flick up / down | DPAD_UP / DPAD_DOWN pulse | ammo-type cycle (suppressed while a grip is held - the radials read the stick) |
 | Right trigger | RT | fire weapon |
 | Left trigger | LT | fire plasmid |
-| Right grip (squeeze, 0.70/0.55 hysteresis) | RB | next weapon |
-| Left grip (same) | LB | next plasmid |
-| A / B (right) | A / B | use / jump (game layout) |
-| X / Y (left) | X / Y | reload / EVE (game layout) |
-| Stick clicks | LS / RS click | crouch / zoom (game layout) |
+| Right grip (squeeze, 0.70/0.55 hysteresis) | RB | next weapon / weapon radial on hold |
+| Left grip (same) | LB | next plasmid / plasmid radial on hold |
+| A | Y | jump |
+| B | A | use / interact |
+| X | X | reload / hack / inject EVE |
+| Y | B | first-aid (med hypo) |
+| Stick clicks | LS / RS click | crouch / zoom |
 | Left menu, short press (<500 ms, pulsed on release) | START | pause menu |
 | Left menu, hold (>=500 ms) | BACK | map/objectives |
-| (unmapped - no spare inputs) | dpad | quick-select; test-only via `vrinput test press DU/DD/DL/DR`; real selection belongs to the M8 radial wheels |
 - **Lane 2 - engine-level**: console-exec dispatcher for discrete actions (weapon/plasmid
   switch, ToggleHUD, SetFOV - one high-value hook makes dozens of features one-liners); direct
   hooks for continuous aim.

--- a/docs/ENGINE_NOTES.md
+++ b/docs/ENGINE_NOTES.md
@@ -1436,3 +1436,82 @@ two lines (`Damager = Instigator; InitiateDamage('None')`).
 trigger pull only switches hands ("SwitchToWeapons"/"SwitchToPlasmids"), the
 second one fires. A single synthetic pull therefore looks like it did nothing.
 `LeftMouse = Fire` (active hand), `RightMouse = SwitchWeaponsOrPlasmids`.
+
+## Session 19 - the gameswf HUD pipeline, the pad layout, and hide-inactive constraints
+
+### The in-game HUD fingerprint, corrected (supersedes the session-6 note)
+
+Frame-dump ground truth (stereo gameplay, lite+full dumps, 2026-07-28): the whole
+gameswf HUD is drawn EVERY present interval (both eye passes) as a contiguous run
+of ~119 NON-INDEXED `Draw` calls on the TONEMAP TARGET (backbuffer-sized RGBA8,
+RTV|SRV) **with the scene DSV still bound** (depth-testing off in state) - the
+session-6 "no DSV bound" detail was inverted for gameplay. The tonemap itself is
+the interval's only no-DSV draw on that target and samples the HDR scene RT
+(R11G11B10F). The world renders exclusively via `DrawIndexed`. Every HUD draw's
+stack carries the gameswf batch-flush at exe RVA **0x7B8EB5** (above the shared
+draw helper 0x765C1C), with the recursive movie-clip walk 0x7ED6A1 deeper in.
+DrawAuto/Dispatch/ExecuteCommandList are never used (census hooks added, all 0) -
+no deferred contexts anywhere.
+
+Classifier shipped in `core/gfx/hud_capture.cpp` (per present interval): the
+scene RT is the resource hosting the most DSV-bound DrawIndexed calls (vote, >=32
+wins); the first non-indexed draw on an LDR-1080 target sampling the vote leader
+is the tonemap and marks that target; every later non-indexed draw on it is HUD
+and gets our RTV substituted at draw time (through the ORIGINAL OMSetRenderTargets
+so the classifier's own binding state stays honest). Flat: ~119 hudDraws per
+interval, leaks=0 (nothing DrawIndexes the target post-tonemap), menus never arm
+(no scene votes), the pause menu redirects too (world keeps rendering under it -
+in-headset it lands on the readable quad).
+
+### gameswf destination alpha is garbage - repair before blending
+
+The capture RT (cleared to 0,0,0,0) receives gameswf output whose RGB is
+premultiplied BY CONSTRUCTION (SrcAlpha*src + InvSrcAlpha*black), but the alpha
+channel ends up unusable - a SOURCE_ALPHA consumer draws nothing. Shipped repair
+(`core/gfx/blit.cpp` ps_process): alpha = max(stored, saturate(luminance*2.5)),
+rgb untouched, blend OFF, into a second RT; every consumer (window composite,
+XR quad) reads the processed copy with PREMULTIPLIED blending (ONE/INV_SRC_ALPHA;
+quad submits WITHOUT the UNPREMULTIPLIED flag). Cosmetic cost: semi-transparent
+HUD glass reads slightly more vivid.
+
+### Frame dumps and the stereo pair phase
+
+A dump armed from the command seam (game thread, CalcView poll) always opens on
+the SAME phase of the stereo pair - single-window dumps can never see what the
+other half draws (this hid the HUD for half a session). `dumpframe [full] [n]`
+now records n consecutive present windows (files suffixed `_qN`).
+
+### The gamepad action layout (User.ini XENON_*, flat-verified)
+
+A=Use, B=UseHypoOfType MedHypo (heal), X=Hack|Reload|InjectBioAmmo (contextual),
+Y=Jump, LB/RB hold=ability/weapon radial (sticks feed xRadial* while held),
+LT/RT=SwitchAndFireAbility/Weapon, LS=Duck, RS=ZoomCycle, START=Pause,
+BACK=ShowContextHelp, DPAD_RIGHT=hints. **DPAD_UP and DPAD_DOWN cycle the
+equipped weapon's AMMO TYPE** (CallHudFunction DPadUp/DownPressed - flat-proven:
+00 Buck -> Electric Buck -> Exploding Buck on the shotgun). The VR bindings
+re-route the face buttons XR-side (openxr_input.cpp): Touch A->XInput Y (jump),
+B->A (use), Y->B (heal), X->X; right-stick Y flicks pulse DPAD_UP/DOWN for ammo
+(rising edge past 0.65 pre-deadzone, re-arm inside 0.30, 300 ms cooldown,
+suppressed while a grip is held - the radials read the stick).
+
+### Hide-inactive: the attach bone must never be scaled
+
+`vrhands hideinactive` collapses the inactive hand's cluster+sleeve by zero
+scale (positions pinned at the driven target), EXCEPT the weapon-attach bone 43:
+the engine's attach path inverse-decomposes chain scale (session 16 - any wrist
+chain scale blows the weapon up near-plane; zero would be 1/0), so the equipped
+weapon hides by TRANSLATING bone 43 to (0,0,-5000) component space instead
+(frustum-culled, scale untouched). Restore comes from g_ref BEFORE the incoming
+hand is driven on a switch - the rigid write sets p/q but never .s, so a stale
+zero scale would leave the hand invisible. An engine re-evaluation rewrites the
+whole array scales included, so g_ref can never hold our zeros.
+
+### The strict gameplay-view signal
+
+`body::is_gameplay_view` (ShockPlayer vtable on the view actor, no viewActor==pc
+escape hatch) is now computed every CalcView and published to the input bridge as
+the stick-pitch-kill gate, and logged on transition as
+`[b1r] view state: GAMEPLAY (ShockPlayer view)` / `menu/cutscene` - the harness's
+generic "save is loaded" detector (tools/boot.ps1). The intro and main menu read
+menu/cutscene (viewActor==pc there); the transition to GAMEPLAY fires exactly at
+save load, any save, any level.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -459,6 +459,30 @@ fixed or the release waits:**
 
 ## M9 - Comfort + UI/config + release polish (~2–3 sessions)
 
+**Two-hand track (user's call 2026-07-28, sequenced AFTER the session-20 aim work):**
+- [ ] **Off-hand tracking** (`vrhands offhand track|hide`, default hide until judged by
+      eye): drive the INACTIVE hand's cluster from its controller instead of collapsing
+      it - the same rigid drive run on both clusters per frame. Reload/idle anims on the
+      tracked hand are overwritten by construction (the weapon's own skeleton still
+      animates itself). The open question is the off-hand's SHAPE (the engine's last
+      evaluated pose may be a grab/reach); mitigation on file: snapshot a good cluster
+      shape (e.g. the plasmid idle) and use it as the off-hand's fixed reference.
+      Prerequisite: none hard, but do it after the session-20 trim unification so both
+      hands ride one algebra.
+- [ ] **Two-handed weapon handling** (shotgun/MG/GL/crossbow/chemical thrower): left
+      hand within ~10 cm of the foregrip + grip = engage; weapon then aims along the
+      rear-hand -> front-hand line (a different ray source into the same fire-seam
+      substitution; the model gets the same target rotation) and the left cluster sits
+      at "bone-43 world transform + per-weapon foregrip offset" - a transform we WRITE,
+      so no engine cooperation needed. Release on grip-off or distance. Purely
+      presentation + aim math - the game has no two-hand mechanic to desync. What makes
+      it cheap here: no arms/elbows = no IK, and the art already contains authored
+      grip shapes to snapshot (the shotgun's two-hand idle). PREREQUISITES, in order:
+      session-20 trim-algebra unification (do not build two-hand aim on the algebra
+      being replaced), then FName/per-weapon identity + the muzzle/foregrip bone probe
+      (per-weapon foregrip offsets; the weapon skeletons may carry foregrip bones).
+      Per-weapon engage radius + offsets tuned by eye.
+
 - [ ] Snap turn, height/seated recenter, optional vignette
 - [ ] Better overlay/config UI (user's call 2026-07-27: current UI is good - this is polish
       only: grouping, naming, hiding the debug-only controls behind an advanced toggle)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -483,6 +483,12 @@ fixed or the release waits:**
       (per-weapon foregrip offsets; the weapon skeletons may carry foregrip bones).
       Per-weapon engage radius + offsets tuned by eye.
 
+- [ ] **Wrench swing gesture (user's call 2026-07-28)**: trigger the melee hit from the
+      physical SWING instead of (or in addition to) the trigger - velocity threshold on
+      the right controller while the wrench is equipped -> pulse RT, cooldown against
+      double-fires. The user play-tested timing the trigger to their swing and it felt
+      right, so the gesture only needs to reproduce that timing. Hand poses per frame
+      already exist (velocity = dP/dt); keep the trigger working as-is.
 - [ ] Snap turn, height/seated recenter, optional vignette
 - [ ] Better overlay/config UI (user's call 2026-07-27: current UI is good - this is polish
       only: grouping, naming, hiding the debug-only controls behind an advanced toggle)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -541,5 +541,15 @@ fixed or the release waits:**
   (elbow poking the wrong way, body clipping) reads worse than M7's floating hands+weapon, so
   this is opt-in polish - only ship it if it actually looks right. Pairs with two-handed
   weapons + physical melee swings.
+- **Left-handed mode** (user's call 2026-07-28): a `handedness left` toggle swapping
+  every ROLE assignment in the mod's own mapping - the weapon viewmodel/aim/laser
+  follow the LEFT controller, plasmid the right, triggers/grips/radials/ammo modifier
+  swap with them, optional second toggle for stick swap (move on right stick). The
+  per-hand tuning (trims/offsets) must follow the ROLE, not the physical hand.
+  Accepted cosmetic compromise: the visible weapon hand stays the RIGHT-hand mesh
+  (mirroring is a wall - negative bone scale hits the session-16 attach-path
+  inverse-scale minefield and flips triangle winding; re-attaching to the left hand
+  has no grip art). The input/pose swap is what handedness is actually for and is
+  roughly a session of work incl. testing.
 - BioShock Infinite (UE3 build 6829) adapter feasibility study
 - OpenVR backend (if some runtime needs it)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -437,10 +437,22 @@ fixed or the release waits:**
       bright center pixels on a clean boot, toggle exact both ways.
 
 **HUD usability:**
-- [ ] See health + EVE clearly in VR: gameswf HUD draws redirected to offscreen RT → a
-      floating quad during stereo gameplay (moved up from M9 - it IS the "better HUD" work)
-- [ ] Keybind audit on Quest 3 Touch: every needed action reachable and correct (the M5
-      "rebinds wanted later" list gets resolved here)
+- [x] See health + EVE clearly in VR - DONE flat 2026-07-28 (session 19): the gameswf
+      HUD draws are classified per present interval (scene-vote + tonemap detection,
+      corrected fingerprint in ENGINE_NOTES) and redirected to an offscreen RT; the
+      alpha-repaired copy feeds a head-locked XrCompositionLayerQuad (distance/width/
+      height sliders, vrpreset.ini) AND a post-capture window composite, so the flat
+      window keeps its HUD while both eyes come out clean - this also fixes the old
+      "HUD in both eyes" defect, and the pause menu lands on the readable quad for
+      free. Flat: 119 HUD draws/interval classified, leaks=0, redirect removes the
+      HUD from the frame, composite restores the window, round-trips exact. The
+      in-headset quad verdict is on the session-19 checklist.
+- [x] Keybind audit on Quest 3 Touch - DONE flat 2026-07-28 (session 19): ground truth
+      pulled from User.ini XENON_* (ENGINE_NOTES - the game layout is A=Use, B=Heal,
+      X=Reload/Hack/EVE, Y=Jump; DPAD_UP/DOWN cycle ammo, flat-proven); the XR layer
+      re-routes Touch A->jump, B->use, Y->heal, X->reload, and right-stick Y FLICKS
+      (freed by the stick-pitch kill) pulse dpad up/down = ammo-type cycling. Headset
+      walkthrough on the checklist.
 - [ ] **Done when:** a friend can install from the release zip, press VR PRESET 1, see
       their health/EVE, and every binding they need works - and someone watching the
       monitor sees a normal single-eye picture, including after the headset comes off.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -140,11 +140,29 @@ churn this round. Queued to M9 by the user: the WRENCH SWING GESTURE
 (velocity-triggered melee - they play-tested the timing manually and it
 felt right).
 
-**RE-VERIFY IN-HEADSET (quick, 5 items):** (1) pause menu + a vending
+**5. (part 3, same night) The weapon wheel was unselectable up/down - the
+pitch kill was eating stick Y in the radial state too.** The kill now LIFTS
+while a grip/bumper is held (the wheel reads stick Y), and because the
+wheel's binding state keeps the look axis bound, camera.cpp snapshots the PC
+pitch at bumper-down and writes it back at release - the wheel selects, and
+wheel-time look drift cannot stick. Flat, exact: pitch frozen at 853 under
+full-up stick with no bumper; RB held -> pitch moved to 4001 (and the
+calls/s dropped = the wheel actually opened); release -> pitch restored to
+EXACTLY 853.
+
+**6. (part 3) ZOOM IS REMOVED in VR (user's call - nothing needs it and an
+HMD FOV zoom is a comfort hazard).** RS-click never reaches the game; the
+click is purely the ammo modifier now (the tap-vs-hold logic is gone with
+it). The `vrinput test press RS` lane still injects raw XInput for harness
+use.
+
+**RE-VERIFY IN-HEADSET (quick, 6 items):** (1) pause menu + a vending
 machine: opaque panels, counters clipped; (2) A loots/confirms menus, B
 jumps; (3) ammo: hold right-stick click + up/down/left selects the right
-slot each time, quick tap still zooms, no selects while turning normally;
-(4) FPS feel vs `vrhud off` in the same spot; (5) nothing else moved.
+slot each time, no selects while turning normally, clicking alone does
+NOTHING (zoom gone); (4) WEAPON WHEEL: hold grip, select with the stick
+incl. up/down, release - and the view pitch must be exactly where you left
+it; (5) FPS feel vs `vrhud off` in the same spot; (6) nothing else moved.
 
 ## Previous state (2026-07-27, session 18 - M8 QUICK PHASE CODE-COMPLETE FLAT: both release blockers fixed, per-hand offsets, grip-switch fix, release zip staged)
 
@@ -1613,6 +1631,17 @@ and it resumes.
   (install.ps1 backs theirs up automatically).
 
 ## Session log (newest first)
+
+### 2026-07-28 - Session 19 part 3 (wheel-select fix + zoom removed)
+
+- The pitch kill was eating stick Y inside the radial state too - the weapon
+  wheel could not select up/down. The kill now lifts while a grip/bumper is
+  held, with a PC-pitch snapshot/restore around the hold (the radial state
+  keeps the look axis bound, so wheel-time drift would otherwise stick).
+  Flat-exact: 853 frozen no-bumper; 853 -> 4001 during the RB hold (calls/s
+  drop = wheel open); restored to exactly 853 on release.
+- Zoom removed in VR by the user's call: RS-click never reaches the game;
+  the click is purely the ammo modifier. Test lane unaffected.
 
 ### 2026-07-28 - Session 19 part 2 (headset PASSED; the four feedback fixes flat the same night)
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,7 +2,101 @@
 
 > Handoff file. Rewrite "Current state" and "Next steps" every session; append to the session log.
 
-## Current state (2026-07-27, session 18 - M8 QUICK PHASE CODE-COMPLETE FLAT: both release blockers fixed, per-hand offsets, grip-switch fix, release zip staged)
+## Current state (2026-07-28, session 19 - M8 COMPLETE FLAT: HUD on a floating quad, VR-standard bindings + ammo flicks, inactive hand hidden, stick pitch killed; v0.2.0 awaits the headset run)
+
+**Branch `s19-m8-completion` (from main at v0.1.0). Everything below is
+flat-verified on clean boots with numeric acceptance; the in-headset checklist
+below is the open gate, and v0.2.0 publishes only after it + the user's
+explicit go. Per the user's call, item 4 of the session-19 plan (aim-sync
+algebra unification + the synccheck/record-replay testing framework + FName +
+muzzle probe + idle-sway kill) moves WHOLE to session 20 / v0.3.0 - its root
+causes and designs are fully written down in the session-19 plan file and the
+"SESSION 20 PLAN" block below.**
+
+**1. Hide the inactive hand (`vrhands hideinactive`, DEFAULT ON).** The
+inactive hand's whole cluster + sleeve collapse exactly like the driven
+sleeve (zero scale, positions pinned at the driven target, cached and
+replayed by `reapply()` for the stereo second eye) - EXCEPT the weapon-attach
+bone 43, which hides by TRANSLATION to (0,0,-5000) component space: the
+attach path inverse-decomposes chain scale (session 16), so zero scale would
+be 1/0. On a hand switch the incoming cluster restores from g_ref BEFORE the
+rigid write (which sets p/q but never .s). Flat: ghost-arm region diff 2.64
+mean/6.9% changed ON-vs-OFF with the drive live, ON-vs-ON2 at the 0.75 noise
+floor; both switch directions round-trip (shotgun back at full scale, no
+attach blowup); Electro Bolt cast executed with the collapse live (EVE
+consumed, FX shell riding the DRIVEN hand); fire test passed; dumps 8->8.
+
+**2. Right-stick pitch is dead under VR gameplay (`vrinput pitchkill`,
+DEFAULT ON).** camera.cpp computes the STRICT gameplay-view predicate
+(body.cpp's, now public) every CalcView and publishes vrDrove && strict to
+the input bridge; compose_over() zeroes the composed right-stick Y while the
+gate holds (self-expiring - fails open). Menus/cutscenes keep pitch (strict
+false there). Flat: gate ACTIVE (published 16 ms fresh), pitch frozen through
+8 s of full-up stick at two different pitch values while YAW still spun;
+pitchkill off freed the pitch instantly (853 -> the 18000 clamp); packet
+numbers still bump. The wrench-melee question (does it now hit where the hand
+points?) is measured on the headset checklist before any body-pitch drive
+gets built.
+
+**3. THE HUD IS ON A FLOATING QUAD (M8 "HUD usability" - the release
+headline).** The frame-dump fingerprint was re-derived and CORRECTED
+(ENGINE_NOTES session 19: the HUD is ~119 NON-INDEXED Draw calls per present
+interval on the tonemap target with the scene DSV still BOUND - session 6 had
+that inverted; the tonemap is the interval's only no-DSV draw; the world is
+pure DrawIndexed; gameswf's batch flush 0x7B8EB5 is in every HUD stack).
+`core/gfx/hud_capture.cpp` classifies per interval (scene-RT vote by
+DSV-bound DrawIndexed, tonemap = first non-indexed draw sampling the vote
+leader, everything non-indexed after it on that target = HUD) and substitutes
+our RTV at draw time. gameswf's destination alpha is GARBAGE, so consumers
+read an alpha-repaired copy (luminance-derived, `core/gfx/blit.cpp`,
+premultiplied semantics). The processed capture feeds (a) a HEAD-LOCKED
+XrCompositionLayerQuad during stereo gameplay (distance/width/height sliders,
+persisted; +1 layer = 10 of the 16 runtimes must accept) and (b) a
+post-eye-capture window composite at all three present exits, so the FLAT
+window keeps its HUD while the compositor feed stays clean - which also
+fixes the parked "HUD renders in both eyes" defect, and the PAUSE MENU lands
+on the readable quad for free. Flat: classification 119/interval with
+leaks=0 across every boot; `vrhud force on` removes the HUD from the frame
+(4.5% region diff, no blackout) and the composite restores the window
+(HUD-corner pixels back, slightly more vivid from the alpha repair); menus
+never classify; pause menu redirects + composites; round-trips exact; dumps
+8->8. `vrhud on|off|force on|force off|status`; the quad itself renders only
+with a session - ITS visual verdict is the headset checklist's headline item.
+
+**4. VR-standard bindings + stick-flick ammo switching (the controls
+audit).** Ground truth pulled from the live User.ini XENON_* block
+(ENGINE_NOTES): the game's pad layout is A=Use, B=Heal(MedHypo),
+X=Reload/Hack/InjectEVE, Y=Jump - confirming the user's complaint exactly
+(jump sat on Touch Y). The XR layer now re-routes the face buttons: Touch
+A->jump, B->use, Y->heal, X->reload (VR convention per the HL2VR/VRChat/
+Pavlov survey: jump belongs on A). DPAD_UP/DOWN were flat-PROVEN to cycle the
+equipped weapon's ammo type (00 Buck -> Electric -> Exploding on the
+shotgun), so right-stick Y FLICKS (freed by the pitch kill) pulse them:
+rising edge past 0.65 pre-deadzone, re-arm inside 0.30, 300 ms cooldown,
+suppressed while a grip is held (the radials read the stick). README +
+ARCHITECTURE tables rewritten. The remap lives in the XR-session-only path,
+so flat coverage is the dpad ground truth + boot smoke (clean); the button
+walkthrough is on the headset checklist.
+
+**5. Harness upgrades that paid for themselves the same session.**
+`tools/boot.ps1` is now IN THE REPO and save-agnostic: it watches for the
+new `[b1r] view state: GAMEPLAY` transition line (the strict predicate,
+logged on change) instead of the old wall-save location - verified on five
+boots this session, 3-15 presses each. `dumpframe [full] [n]` records n
+CONSECUTIVE present windows (`_qN` files) - a command-armed dump always
+opens on the same stereo-pair phase, which is exactly why the HUD hid from
+single-window dumps for half a session. The frame inspector now also hooks
+DrawAuto/Dispatch/CopySubresourceRegion/CopyResource/UpdateSubresource/
+ExecuteCommandList (census + events; all zero for this game - no deferred
+contexts, which the HUD hunt needed proven).
+
+**Promoted-build clean-boot smoke (remap build):** preset chain in order,
+stereo heartbeat clean (mode=1T, presents = 2x builds, guardskips 0), two
+right-trigger pulls fired, HUD classifier live with redirects 0 while
+ungated, dumps 8->8. The vrpreset.ini gained hudQuadDistM/WidthM/UpM keys
+(defaults 1.30/1.25/-0.10 m) - the user's live ini keeps every old key.
+
+## Previous state (2026-07-27, session 18 - M8 QUICK PHASE CODE-COMPLETE FLAT: both release blockers fixed, per-hand offsets, grip-switch fix, release zip staged)
 
 **Branch `m8-release-quick-phase` (from main at PR #2's merge). Everything below
 is flat-verified on clean boots with numeric acceptance; the in-headset run is
@@ -1083,67 +1177,64 @@ https://github.com/mohamad-balouza/bioshock-vr. Em dashes banned repo-wide.
 
 ## Next steps
 
-0. **SESSION 19 PLAN - the user's four reports from the all-weapons run
-   (investigated 2026-07-27 session 18 part 4, code untouched; work them in
-   this order):**
+0. **THE IN-HEADSET CHECKLIST BELOW, then v0.2.0** (tag on merged main,
+   `build.ps1 -Release`, zip both RelWithDebInfo DLLs + README.txt, notes
+   leading with what moved off the v0.1.0 known-issues list: HUD readability,
+   bindings, the ghost hand, stick pitch). PR is open; merge + publish only
+   on the user's explicit go.
 
-   (a) **Model/laser sync - the ROOT CAUSE is two different trim algebras,
-   so one tuning only holds at ONE controller orientation.** The ray's trim
-   is rotator ADDS in game space (yaw about world-up, pitch about horizon -
-   aim.cpp ray build and the laser's XR-side math, deliberately identical);
-   the model's trim is a QUATERNION COMPOSED IN THE CONTROLLER'S LOCAL FRAME
-   (hands.cpp, the session-11 fix for the "pivot breaks everything" bug).
-   Those agree at the tuning pose and DIVERGE as the controller rotates -
-   the divergence grows with both the trim size and the rotation from the
-   tuning pose. It did NOT regress: before part 3 the coupling HID it
-   (the model inherited the ray's trim on top of its own); decoupling made
-   it visible. FIX: convert the aim trim (ray + laser, both sides) to the
-   SAME local-frame quaternion compose the model uses; after that one
-   tuning holds at every orientation. Numeric gate BEFORE any headset ask:
-   a `synccheck` self-test that sweeps ~20 simpose orientations and prints
-   the angle between the model's driven rot and the ray rot - max
-   divergence should collapse to ~0 after the algebra unification (it will
-   NOT be 0 before). The render lock is position-only (gain 0.9) and can
-   still shift the model a few UU relative to the beam - measure it in the
-   same sweep, list it separately.
+1. **SESSION 20 PLAN - aim/laser/model sync + the flat testing framework
+   (session-19 plan item 4, deferred whole by the user's call; the full
+   design incl. the design-check agent's refinements is in the session-19
+   plan file `~/.claude/plans/continue-the-bioshock-vr-project-frolicking-
+   hinton.md`, stages 4.1-4.6):**
 
-   (b) **Auto-derive the barrel per weapon (the user's ask) - feasible via
-   the weapon's OWN skeleton, and the FName resolution unlocks it.** The
-   equipped weapon is a skeletal mesh (reload anims) attached to hand bone
-   43; muzzle-flash FX anchor somewhere on it, so a muzzle bone/socket very
-   likely exists. Probe: read the weapon ACTOR's SkeletonInstance (try the
-   AHands offset +0x3FC first - same engine actor layout), dump its bone
-   array per weapon, find the muzzle bone (tip-most along the barrel axis;
-   names make it trivial). Then aim ray := muzzle bone's world transform
-   mapped through the existing chain - laser and bullets follow the
-   RENDERED barrel exactly, zero manual tuning, per-weapon automatic, and
-   the whole per-weapon-profile question dissolves. PREREQUISITE that pays
-   twice: FName index -> string resolution (parked since session 11; also
-   the key for per-weapon ini profiles as the fallback if no muzzle bone
-   exists). Fallback if skeleton probing fails: per-weapon manual profiles
-   keyed by class name.
+   (a) `synccheck` FIRST (the failing baseline): refactor the ray and model
+   pose->rot chains into pure functions, cache the last FrameContext, sweep
+   ~20 axis-angle orientations INCLUDING roll, print max ray-vs-barrel
+   divergence for live AND canonical (10/10) trims. Expect nonzero pre-fix.
+   (b) Unify the trim algebra: ray + laser adopt the model's local-frame
+   quat compose (q_ctrl x q_trim, trim built by xr_local_trim_quat, roll
+   dropped only at the final rotator write); laser origin basis adopts the
+   ray's zero-roll convention (kill its near-vertical degeneracy bail);
+   DELETE the legacy aligntrim euler path; promote quat helpers to a core
+   math header. Gate: synccheck collapses to ~0 at every orientation; the
+   user's tuned trim values carry over (they agree at the tuning pose).
+   The model's own full-roll offset basis stays UNTOUCHED (live tuning).
+   (c) Record+replay (`vrrec start|stop|play|status`): ONE tap in
+   camera.cpp's CalcView tail (works flat AND in-headset - an
+   on_present_begin tap cannot record flat), heads via a replayHead lane
+   (simHead is angles-only), hands via NEW sim slots at the
+   input_get_hand_pose funnel, pad via publish_xr_state; RECENTER STATE +
+   worldScale serialized in the file header or every comparison fails;
+   frame-for-frame replay; `[rec] mark` lines every 10th frame; refuse
+   play while a session lives. Gate: neutral-stick record/replay with
+   |dloc| < 0.01 UU, |drot| <= 2 units, pad exact.
+   (d) FName index->string: capture the FName-ctor address
+   find_fname_index_global already computes AND DISCARDS (:129-134),
+   disassemble to GNames (capstone), licensee layout prior = UTF-16
+   POSITIVE count 8-byte flags; fallback = the GetHighBone{Name,Index}
+   native oracle via find_native_function.
+   (e) Muzzle-bone probe: bones::locate() is already generic - run it on
+   the cached g_weaponActor (produced every frame, currently unused), dump
+   bone names via (d), derive the ray from the muzzle bone's rendered
+   transform (compose weapon component space through the attach at hands
+   bone 43). Fallback: per-weapon manual profiles keyed by class name.
+   Cheap alternative on file: hands-rig bone 44 = "muzzle-ish tip" at
+   x=+71.
+   (f) Idle-sway investigation + kill (user 2026-07-27: clearly visible
+   in-headset, likely less than flat - "worth it to put our minds at
+   ease"): MEASURE the surviving amplitude flat first (shot series, lock
+   on/off), decompile UpdateHandBobAnimationParameters + Hands
+   defaultproperties (dump.ps1, ~40% fail rate), then zero the bob params
+   via the SET seam (re-assert like vrxhair); toggle + armed by PRESET 1.
 
-   (c) **Right-stick pitch must die under VR.** The composed pad's right
-   stick Y feeds the game's pitch: the PC/pawn ViewRotation pitches, and
-   the renderer orients the rig by the ACTOR fields, so the MODEL rides the
-   stick (the user's report) - and the wrench's Havok melee phantom swings
-   where the BODY pitch points, not the hand (the melee-hitbox half of the
-   report). Fix step 1 (surgical): zero the right-stick Y in the composed
-   pad while the VR camera drives (gameplay only - menus keep it). Fix
-   step 2 (evaluate after 1): drive the body PITCH from the HMD the way
-   M7.5 drives yaw, so melee/interactions follow the head; the M7.5
-   probe/commit machinery is the template. Step 1 alone likely kills both
-   symptoms - measure melee aim before building step 2.
+   Watch also: whether the wrench melee needs the HMD-pitch body drive
+   (checklist question this session decides it); map-pan-under-pause if the
+   user reports the right stick dead there (the pitchkill gate is strict-
+   view, which stays true while paused).
 
-   (d) **Hide the inactive hand.** The mechanism already exists: the sleeve
-   collapse (bones.cpp `g_collapse`, zero-scale). Extend it to the whole
-   INACTIVE hand cluster - left wrist 6 + fingers 7-21 when the weapon is
-   up; right wrist 27 + fingers 28-42 + weapon bone 43 when the plasmid is
-   up. `vrhands hideinactive on|off`, default ON. Watch: FX anchored to
-   collapsed bones (Electro Bolt shell on a hidden left hand) - verify the
-   plasmid FX parity test still passes with the collapse live.
-
-1. **DONE 2026-07-27: v0.1.0 IS PUBLISHED** - tag on main at PR #3's merge,
+2. **DONE 2026-07-27: v0.1.0 IS PUBLISHED** - tag on main at PR #3's merge,
    release zip (both RelWithDebInfo DLLs + README.txt) at
    https://github.com/mohamad-balouza/bioshock-vr/releases/tag/v0.1.0, known
    issues listed (HUD, per-weapon alignment, bindings, flat menus = the v0.2
@@ -1215,7 +1306,65 @@ Carried-over backlog (numbering kept from session 17):
 13. **Parked in M9** (user's call 2026-07-24): IPD slider verification, small
     head-motion bobbing, the vrstereo off/re-arm state bug, HUD-in-both-eyes.
 
-### IN-HEADSET CHECKLIST - M8 quick phase (session 18)
+### IN-HEADSET CHECKLIST - M8 completion (session 19)
+
+Setup as always: Quest 3 + Virtual Desktop (VDXR), launch from Steam, load the
+newest save (CONTINUE = the NG+ Medical Pavilion all-weapons anchor), press
+**VR PRESET 1**. Nothing in the camera/recenter/body path changed - head
+decoupling and body-follow must feel identical to v0.1.0; any difference there
+is a regression, say so first. Live A/Bs: `vrhud off`, `vrhands hideinactive
+off`, `vrinput pitchkill off`, `vrhud force off`.
+
+1. **Non-regression sweep (60 s, do first).** Park the hand, look around wide,
+   stick-walk, turn past 90 both ways, two right-trigger pulls + an Electro
+   Bolt. Anything session 18 did not do: stop and report.
+2. **THE HUD QUAD (the headline).** From the moment stereo is up in gameplay:
+   health/EVE/ammo must float on a readable head-locked panel - no more
+   eye-searing screen-edge double vision. Judge: readability at a glance,
+   size/distance/height (three "HUD" sliders in the VR section tune it -
+   "Save preset values" persists), and that it never blocks aiming. Check the
+   ammo counter updates when you fire and switch types. Then open the PAUSE
+   MENU: it should land on the same readable panel (bonus feature - tell me
+   if navigating it feels fine). `vrhud off` = HUD back in the game frame.
+3. **THE MONITOR while stereo runs**: the flat window must still show the
+   HUD over the single-eye mirror (slightly more vivid bars than stock is
+   expected - the alpha repair). During headset-off idle the window keeps
+   running WITH its HUD.
+4. **HIDE-INACTIVE.** With the weapon up: NO ghost left hand/arm anywhere
+   (the sweater arm reaching for the shotgun forend is the defect that
+   died). Switch to plasmid (grip or trigger): weapon AND right hand
+   gone, plasmid hand normal with FX. Switch back: weapon returns at FULL
+   size instantly (a tiny/invisible/blown-up weapon after a switch = the
+   restore failed, report + `vrhands hideinactive off`). Cast Electro Bolt:
+   FX on the visible hand, nothing floating in the air.
+5. **STICK PITCH.** The right stick turns you but can NO LONGER pitch the
+   view - pitch is your head alone. The viewmodel must no longer ride
+   vertically when you push the stick. THE WRENCH QUESTION (answer this one
+   carefully - it decides whether session 20 builds the body-pitch drive):
+   swing the wrench at things above/below eye level while aiming with your
+   HAND, head level - does it hit where the hand points now, or still where
+   the body faces? `vrinput pitchkill off` = old behavior live.
+6. **THE NEW BINDINGS walkthrough** (README table): A jumps, B uses/loots,
+   X reloads (and hacks/injects EVE in context), Y pops a first-aid kit,
+   grips still switch/radial, triggers still fire, stick clicks
+   crouch/zoom, menu short/hold = pause/map. **AMMO FLICKS**: with a gun
+   up, flick the right stick UP = next ammo type, DOWN = previous - check
+   it never fires accidentally while turning (the flick needs a sharp
+   full push; report if it triggers on normal turns), and that holding a
+   grip + moving the stick still drives the radial without ammo flips.
+7. **Expected noise, not bugs**: the HUD quad is head-locked (moves with
+   you by design - say if you'd prefer it lazier/world-locked, that is a
+   slider-able follow-up); HUD glass slightly more vivid; the VD overlay
+   still parks the model dead-center (VISIBLE state, known); one
+   `engine exec 'set ShockPlayer bReticleDisabled True' -> HANDLED` line
+   every 15 s.
+8. **The 4 GB-scan field watch**: if the model EVER stops following after a
+   level transition, grab the log immediately ("AHands scan" lines).
+9. **Anything off**: `vrhud off` / `vrhands hideinactive off` /
+   `vrinput pitchkill off` first - if the symptom survives all three, it
+   predates this session.
+
+### PREVIOUS CHECKLIST - M8 quick phase (session 18) - PASSED (v0.1.0 shipped on it)
 
 Setup as always: Quest 3 + Virtual Desktop (VDXR), launch from Steam, load the
 newest save, press **VR PRESET 1**. Four changes to judge; `vrmirror off`,
@@ -1407,7 +1556,50 @@ and it resumes.
 
 ## Session log (newest first)
 
-### 2026-07-27 - Session 18 part 4 (the 2 GB scan wall: level transition lost the viewmodel)
+### 2026-07-28 - Session 19 (M8 COMPLETE flat: HUD quad, VR bindings + ammo flicks, hide-inactive, stick-pitch kill; item 4 deferred whole to session 20)
+
+- Branch `s19-m8-completion` off main at v0.1.0. Worked the SESSION 19 PLAN
+  items in the user's order; per their call, v0.2.0 ships after items 1-3
+  (this session) and item 4 (aim-sync algebra + testing framework) moves
+  whole to session 20 - designs written down in Next steps + the plan file.
+- **Harness first**: tools/boot.ps1 rewritten save-agnostic around a new
+  `[b1r] view state: GAMEPLAY` transition log (the strict ShockPlayer
+  predicate, promoted public from body.cpp) - five clean boots this session,
+  3-15 A-presses each. One early misread (the NG+ save's Medical Pavilion
+  coords pattern-matched to what looked like a menu loc from the old log)
+  cost 38 stray A-presses before the screenshot showed live gameplay - the
+  detector had been right all along.
+- **Hide-inactive (1a)**: inactive cluster+sleeve zero-scale collapse, weapon
+  bone 43 hidden BY TRANSLATION (attach path inverse-decomposes scale),
+  restore-from-ref before the incoming hand drives. Flat: ghost-arm diff
+  2.64/6.9% vs 0.75 floor, both switch directions, FX parity cast live,
+  fire test, dumps 8->8. One trap self-inflicted mid-run: the 120 s
+  simpose cap expired silently and a whole plasmid-phase test ran on the
+  ENGINE pose - caught by the frozen writes counter, redone armed.
+- **Stick-pitch kill (1b)**: compose_over zeroes right-stick Y while
+  camera.cpp publishes vrDrove && strict-gameplay. Pitch frozen through
+  full-up holds while yaw spun; kill-off freed it instantly (853 -> 18000
+  clamp); packet bumps intact.
+- **THE HUD (2)**: the hunt falsified the session-6 fingerprint (dumps
+  showed the HUD draws carry the scene DSV; the tonemap is the no-DSV one),
+  after first proving the HUD wasn't in ANY single dump window (dumpframe N
+  built - command-armed dumps always open on the same pair phase) and that
+  no deferred contexts exist (six new census hooks, all zero). Classifier =
+  scene-vote + tonemap detection + non-indexed-after; redirect at draw time
+  via the original SetRT; leaks=0 every boot. gameswf's garbage destination
+  alpha found the hard way (first composite drew nothing) -> luminance
+  repair pass; premultiplied consumers. Window composite at all three
+  present exits; head-locked quad + sliders + preset keys; pause menu rides
+  the quad. vrhud on|off|force|status.
+- **Controls (3)**: User.ini XENON_* ground truth (A=Use B=Heal X=Reload/
+  Hack/EVE Y=Jump - the user's "jump is on Y" confirmed); DPAD_UP/DOWN
+  flat-proven as AMMO CYCLE (shotgun 00->Electric->Exploding); Touch face
+  buttons re-routed to VR convention + right-stick flick ammo switching
+  (edge 0.65, re-arm 0.30, cooldown 300 ms, grip-suppressed). README +
+  ARCHITECTURE tables rewritten.
+- Commits: hideinactive, pitchkill, boot.ps1, dumpframe N + census hooks +
+  hud classifier/redirect, quad + composite + alpha repair, bindings +
+  flicks, docs. In-headset checklist written; PR + v0.2.0 wait on the user.
 
 - **User report from the long NG+ play session: after a level transition the
   model stopped following, re-enabling did nothing, and the game froze

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -96,6 +96,56 @@ right-trigger pulls fired, HUD classifier live with redirects 0 while
 ungated, dumps 8->8. The vrpreset.ini gained hudQuadDistM/WidthM/UpM keys
 (defaults 1.30/1.25/-0.10 m) - the user's live ini keeps every old key.
 
+### Session 19 part 2 - IN-HEADSET VERDICT + the feedback round (same day)
+
+**THE HEADSET RUN PASSED: "I tested and it looks amazing... there's just some
+small fixes."** No regression (item 1 perfect); HUD panel "very good...
+amazing"; ghost hands "perfect... exactly as intended"; monitor perfect; and
+THE WRENCH WORKS with the pitch kill alone - the HMD-pitch body drive is NOT
+needed (dropped from session 20). Four fixes came back and ALL FOUR ARE DONE
+FLAT the same night:
+
+**1. Menus were transparent on the quad -> gameswf's blend states accumulate
+GARBAGE COVERAGE in the alpha channel** (they blend alpha like color). Every
+blend state seen on a redirected draw now gets a cached variant with the
+alpha ops corrected to over-composite (ONE / INV_SRC_ALPHA - rgb ops
+untouched), so true coverage accumulates and the luminance repair dropped to
+a 0.35 safety floor. Flat: the pause menu's cityscape panels render SOLID
+black with the yellow glow correct - the original art.
+
+**2. The odometer digit strips sprawled unclipped (user's screenshot) ->
+flash MASKS are STENCIL-based and the redirect bound no DSV.** The capture
+RT now owns a D24S8 depth-stencil, bound with every substitution and cleared
+per interval. Flat: the pause menu's money (0451) and ADAM (2580) counters
+render CLIPPED to their windows - strips gone.
+
+**3. Buttons revised by feel: Touch A goes BACK to use/loot/menu-confirm
+(it is the game's confirm button - looting and menus were unintuitive
+remapped), jump moves to B.** X reload / Y heal stay.
+
+**4. Ammo select redesigned - three types, three directions: HOLD the
+right-stick CLICK, then push UP / DOWN / LEFT to select that slot (the dpad
+directions each SELECT a slot, they do not cycle - which is why up/down
+flicks could only reach two). Turning is suppressed while the click is held;
+a QUICK click-tap with no push still zooms** (the click's original owner -
+the tap is just delayed past the 400 ms select window). Flick-without-click
+is gone entirely, which also removes any accidental-flick worry.
+
+**FPS question measured flat: the whole HUD capture costs ~4% of an
+UNCAPPED flat frame (336 vs 349 presents/s = ~0.11 ms/frame) - under 1% of
+a headset frame budget.** The perceived hit is most likely the zone or the
+Debug build; `vrhud off` is the live in-headset A/B if it recurs. A
+per-present resource-desc cache also removed most of the classifier's COM
+churn this round. Queued to M9 by the user: the WRENCH SWING GESTURE
+(velocity-triggered melee - they play-tested the timing manually and it
+felt right).
+
+**RE-VERIFY IN-HEADSET (quick, 5 items):** (1) pause menu + a vending
+machine: opaque panels, counters clipped; (2) A loots/confirms menus, B
+jumps; (3) ammo: hold right-stick click + up/down/left selects the right
+slot each time, quick tap still zooms, no selects while turning normally;
+(4) FPS feel vs `vrhud off` in the same spot; (5) nothing else moved.
+
 ## Previous state (2026-07-27, session 18 - M8 QUICK PHASE CODE-COMPLETE FLAT: both release blockers fixed, per-hand offsets, grip-switch fix, release zip staged)
 
 **Branch `m8-release-quick-phase` (from main at PR #2's merge). Everything below
@@ -1229,10 +1279,10 @@ https://github.com/mohamad-balouza/bioshock-vr. Em dashes banned repo-wide.
    defaultproperties (dump.ps1, ~40% fail rate), then zero the bob params
    via the SET seam (re-assert like vrxhair); toggle + armed by PRESET 1.
 
-   Watch also: whether the wrench melee needs the HMD-pitch body drive
-   (checklist question this session decides it); map-pan-under-pause if the
-   user reports the right stick dead there (the pitchkill gate is strict-
-   view, which stays true while paused).
+   ANSWERED by the session-19 headset run: the wrench works with the pitch
+   kill alone - the HMD-pitch body drive is NOT needed and is dropped. Watch
+   only: map-pan-under-pause if the user ever reports the right stick dead
+   there (the pitchkill gate is strict-view, which stays true while paused).
 
    FOLLOW-ONS QUEUED BEHIND THIS WORK (user's call 2026-07-28, detailed in
    ROADMAP M9): off-hand tracking (`vrhands offhand track` - drive the
@@ -1563,6 +1613,27 @@ and it resumes.
   (install.ps1 backs theirs up automatically).
 
 ## Session log (newest first)
+
+### 2026-07-28 - Session 19 part 2 (headset PASSED; the four feedback fixes flat the same night)
+
+- The user's in-headset verdict: "looks amazing" - no regression, HUD panel
+  and ghost-hand removal called out as perfect, monitor perfect, and the
+  WRENCH passed with the pitch kill alone (the HMD-pitch body drive is
+  dropped from session 20).
+- Feedback fixes, all flat-green: menu transparency root-caused to gameswf
+  blend states accumulating garbage alpha coverage -> cached alpha-corrected
+  blend-state variants per redirected draw (lum repair down to a 0.35
+  floor); the sprawling odometer strips root-caused to stencil-based flash
+  MASKS with no DSV bound -> the capture RT owns a D24S8 now (pause-menu
+  counters render clipped, panels opaque - both verified on the window
+  composite); Touch A back to use/confirm with jump on B; ammo select
+  redesigned as right-stick CLICK-HELD + up/down/left (three slots, three
+  directions - the dpad SELECTS slots, it does not cycle), quick tap still
+  zooms, bare flicks removed.
+- FPS measured flat: the full capture costs ~4% of an uncapped flat frame
+  (~0.11 ms) - the perceived dip is likely zone/Debug-build. Desc cache
+  added against the classifier's COM churn. Wrench swing gesture queued to
+  M9 (user's call). Docs + tables updated; re-verify list in Current state.
 
 ### 2026-07-28 - Session 19 (M8 COMPLETE flat: HUD quad, VR bindings + ammo flicks, hide-inactive, stick-pitch kill; item 4 deferred whole to session 20)
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1234,6 +1234,14 @@ https://github.com/mohamad-balouza/bioshock-vr. Em dashes banned repo-wide.
    user reports the right stick dead there (the pitchkill gate is strict-
    view, which stays true while paused).
 
+   FOLLOW-ONS QUEUED BEHIND THIS WORK (user's call 2026-07-28, detailed in
+   ROADMAP M9): off-hand tracking (`vrhands offhand track` - drive the
+   inactive cluster from its controller instead of collapsing it; do after
+   (b) so both hands ride one algebra) and TWO-HANDED weapon handling
+   (foregrip engage + rear-to-front-hand aim line; hard prerequisites are
+   (b) and (d)/(e) - per-weapon identity and foregrip offsets). Neither
+   blocks v0.2.0.
+
 2. **DONE 2026-07-27: v0.1.0 IS PUBLISHED** - tag on main at PR #3's merge,
    release zip (both RelWithDebInfo DLLs + README.txt) at
    https://github.com/mohamad-balouza/bioshock-vr/releases/tag/v0.1.0, known

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -205,6 +205,11 @@ evidence, and both need a headset.
   game first and retries past the poller's transient file lock. IMPORTANT: the poller runs
   inside the CalcView hook, which the engine pauses while the window is unfocused - after
   game-cmd, run a game-shot (it holds focus ~2.5 s) so the poll actually fires.
+- **Controlled boot to gameplay**: `powershell -ExecutionPolicy Bypass -File .\tools\boot.ps1`
+  (its OWN PowerShell call) launches via Steam, dismisses the revert-Options dialog with No,
+  and A-presses through the menus until the mod logs the `view state: GAMEPLAY` transition
+  (save-agnostic since session 19 - the strict ShockPlayer view predicate, any save). It ends
+  with one B press (closes a stray MAP screen); still screenshot-verify before measuring.
 - **Stale command.txt re-applies at boot** (learned 2026-07-24 session 7: a leftover
   "reentry stereo on" armed hooks at the menu on a fresh launch). Delete
   `%LOCALAPPDATA%\BioshockVR\command.txt` (or overwrite it) before a launch that must

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,8 @@ add_library(bioshockvr SHARED
     core/debug/value_scan.h
     core/gfx/frame_inspector.cpp
     core/gfx/frame_inspector.h
+    core/gfx/hud_capture.cpp
+    core/gfx/hud_capture.h
     core/hooks/d3d11_hook.cpp
     core/hooks/d3d11_hook.h
     core/hooks/pattern_scan.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,8 @@ add_library(bioshockvr SHARED
     core/framework/framework.h
     core/debug/value_scan.cpp
     core/debug/value_scan.h
+    core/gfx/blit.cpp
+    core/gfx/blit.h
     core/gfx/frame_inspector.cpp
     core/gfx/frame_inspector.h
     core/gfx/hud_capture.cpp
@@ -67,6 +69,7 @@ target_link_libraries(bioshockvr PRIVATE
     minhook
     imgui
     d3d11
+    d3dcompiler
     dbghelp
 )
 if(BIOSHOCKVR_WITH_OPENXR)

--- a/src/core/gfx/blit.cpp
+++ b/src/core/gfx/blit.cpp
@@ -1,0 +1,215 @@
+#include "core/gfx/blit.h"
+
+#include "core/util/log.h"
+
+#include <d3dcompiler.h>
+
+namespace bvr::blit {
+namespace {
+
+const char* kShader = R"(
+Texture2D tex0 : register(t0);
+SamplerState samp0 : register(s0);
+struct VSOut { float4 pos : SV_Position; float2 uv : TEXCOORD0; };
+VSOut vs_main(uint id : SV_VertexID) {
+    // Fullscreen triangle, no vertex buffer.
+    VSOut o;
+    float2 uv = float2((id << 1) & 2, id & 2);
+    o.pos = float4(uv * float2(2, -2) + float2(-1, 1), 0, 1);
+    o.uv = uv;
+    return o;
+}
+float4 ps_main(VSOut i) : SV_Target {
+    return tex0.Sample(samp0, i.uv);
+}
+// Alpha repair: gameswf leaves garbage in dest alpha; rgb over a zero clear
+// is premultiplied, so luminance approximates coverage.
+float4 ps_process(VSOut i) : SV_Target {
+    float4 c = tex0.Sample(samp0, i.uv);
+    float lum = dot(c.rgb, float3(0.299, 0.587, 0.114));
+    c.a = max(c.a, saturate(lum * 2.5));
+    return c;
+}
+)";
+
+ID3D11VertexShader* g_vs = nullptr;
+ID3D11PixelShader* g_ps = nullptr;
+ID3D11PixelShader* g_psProcess = nullptr;
+ID3D11BlendState* g_blend = nullptr;
+ID3D11SamplerState* g_sampler = nullptr;
+ID3D11RasterizerState* g_raster = nullptr;
+ID3D11DepthStencilState* g_depth = nullptr;
+bool g_failed = false;
+
+bool ensure_pipeline(ID3D11DeviceContext* ctx) {
+    if (g_vs) return true;
+    if (g_failed) return false;
+    ID3D11Device* dev = nullptr;
+    ctx->GetDevice(&dev);
+    if (!dev) return false;
+
+    ID3DBlob* vsb = nullptr;
+    ID3DBlob* psb = nullptr;
+    ID3DBlob* ppb = nullptr;
+    ID3DBlob* err = nullptr;
+    bool ok = SUCCEEDED(D3DCompile(kShader, strlen(kShader), nullptr, nullptr, nullptr,
+                                   "vs_main", "vs_4_0", 0, 0, &vsb, &err)) &&
+              SUCCEEDED(D3DCompile(kShader, strlen(kShader), nullptr, nullptr, nullptr,
+                                   "ps_main", "ps_4_0", 0, 0, &psb, &err)) &&
+              SUCCEEDED(D3DCompile(kShader, strlen(kShader), nullptr, nullptr, nullptr,
+                                   "ps_process", "ps_4_0", 0, 0, &ppb, &err));
+    if (ok)
+        ok = SUCCEEDED(dev->CreateVertexShader(vsb->GetBufferPointer(), vsb->GetBufferSize(),
+                                               nullptr, &g_vs)) &&
+             SUCCEEDED(dev->CreatePixelShader(psb->GetBufferPointer(), psb->GetBufferSize(),
+                                              nullptr, &g_ps)) &&
+             SUCCEEDED(dev->CreatePixelShader(ppb->GetBufferPointer(), ppb->GetBufferSize(),
+                                              nullptr, &g_psProcess));
+    if (vsb) vsb->Release();
+    if (psb) psb->Release();
+    if (ppb) ppb->Release();
+    if (err) {
+        BVR_LOG("[blit] shader compile: %s", static_cast<const char*>(err->GetBufferPointer()));
+        err->Release();
+    }
+
+    if (ok) {
+        D3D11_BLEND_DESC bd{};
+        bd.RenderTarget[0].BlendEnable = TRUE;
+        // Premultiplied: the source rgb is already scaled by coverage.
+        bd.RenderTarget[0].SrcBlend = D3D11_BLEND_ONE;
+        bd.RenderTarget[0].DestBlend = D3D11_BLEND_INV_SRC_ALPHA;
+        bd.RenderTarget[0].BlendOp = D3D11_BLEND_OP_ADD;
+        bd.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_ONE;
+        bd.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_INV_SRC_ALPHA;
+        bd.RenderTarget[0].BlendOpAlpha = D3D11_BLEND_OP_ADD;
+        bd.RenderTarget[0].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL;
+        D3D11_SAMPLER_DESC sd{};
+        sd.Filter = D3D11_FILTER_MIN_MAG_MIP_LINEAR;
+        sd.AddressU = sd.AddressV = sd.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
+        D3D11_RASTERIZER_DESC rd{};
+        rd.FillMode = D3D11_FILL_SOLID;
+        rd.CullMode = D3D11_CULL_NONE;
+        rd.DepthClipEnable = TRUE;
+        D3D11_DEPTH_STENCIL_DESC dd{};
+        dd.DepthEnable = FALSE;
+        dd.StencilEnable = FALSE;
+        ok = SUCCEEDED(dev->CreateBlendState(&bd, &g_blend)) &&
+             SUCCEEDED(dev->CreateSamplerState(&sd, &g_sampler)) &&
+             SUCCEEDED(dev->CreateRasterizerState(&rd, &g_raster)) &&
+             SUCCEEDED(dev->CreateDepthStencilState(&dd, &g_depth));
+    }
+    dev->Release();
+    if (!ok) {
+        release();
+        g_failed = true; // log once, stay quiet after
+        BVR_LOG("[blit] pipeline creation FAILED - window HUD composite disabled");
+    }
+    return ok;
+}
+
+} // namespace
+
+namespace {
+
+bool draw_internal(ID3D11DeviceContext* ctx, ID3D11RenderTargetView* dst,
+                   ID3D11ShaderResourceView* src, UINT dstW, UINT dstH,
+                   ID3D11PixelShader* ps, ID3D11BlendState* blend) {
+    if (!ctx || !dst || !src || !dstW || !dstH) return false;
+    if (!ensure_pipeline(ctx)) return false;
+
+    // Backup the slices of state we touch (the game re-binds most of this per
+    // frame, but the present chain must be transparent regardless).
+    ID3D11RenderTargetView* oldRtv = nullptr;
+    ID3D11DepthStencilView* oldDsv = nullptr;
+    ctx->OMGetRenderTargets(1, &oldRtv, &oldDsv);
+    ID3D11BlendState* oldBlend = nullptr;
+    FLOAT oldBf[4];
+    UINT oldMask = 0;
+    ctx->OMGetBlendState(&oldBlend, oldBf, &oldMask);
+    ID3D11DepthStencilState* oldDepth = nullptr;
+    UINT oldStencilRef = 0;
+    ctx->OMGetDepthStencilState(&oldDepth, &oldStencilRef);
+    ID3D11RasterizerState* oldRaster = nullptr;
+    ctx->RSGetState(&oldRaster);
+    UINT nVp = 1;
+    D3D11_VIEWPORT oldVp{};
+    ctx->RSGetViewports(&nVp, &oldVp);
+    ID3D11VertexShader* oldVs = nullptr;
+    ID3D11PixelShader* oldPs = nullptr;
+    ctx->VSGetShader(&oldVs, nullptr, nullptr);
+    ctx->PSGetShader(&oldPs, nullptr, nullptr);
+    ID3D11ShaderResourceView* oldSrv = nullptr;
+    ctx->PSGetShaderResources(0, 1, &oldSrv);
+    ID3D11SamplerState* oldSamp = nullptr;
+    ctx->PSGetSamplers(0, 1, &oldSamp);
+    ID3D11InputLayout* oldLayout = nullptr;
+    ctx->IAGetInputLayout(&oldLayout);
+    D3D11_PRIMITIVE_TOPOLOGY oldTopo{};
+    ctx->IAGetPrimitiveTopology(&oldTopo);
+
+    D3D11_VIEWPORT vp{};
+    vp.Width = static_cast<FLOAT>(dstW);
+    vp.Height = static_cast<FLOAT>(dstH);
+    vp.MaxDepth = 1.0f;
+    ctx->OMSetRenderTargets(1, &dst, nullptr);
+    ctx->OMSetBlendState(blend, nullptr, 0xFFFFFFFF);
+    ctx->OMSetDepthStencilState(g_depth, 0);
+    ctx->RSSetState(g_raster);
+    ctx->RSSetViewports(1, &vp);
+    ctx->IASetInputLayout(nullptr);
+    ctx->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+    ctx->VSSetShader(g_vs, nullptr, 0);
+    ctx->PSSetShader(ps, nullptr, 0);
+    ctx->PSSetShaderResources(0, 1, &src);
+    ctx->PSSetSamplers(0, 1, &g_sampler);
+    ctx->Draw(3, 0);
+
+    ctx->OMSetRenderTargets(1, &oldRtv, oldDsv);
+    ctx->OMSetBlendState(oldBlend, oldBf, oldMask);
+    ctx->OMSetDepthStencilState(oldDepth, oldStencilRef);
+    ctx->RSSetState(oldRaster);
+    if (nVp) ctx->RSSetViewports(1, &oldVp);
+    ctx->VSSetShader(oldVs, nullptr, 0);
+    ctx->PSSetShader(oldPs, nullptr, 0);
+    ctx->PSSetShaderResources(0, 1, &oldSrv);
+    ctx->PSSetSamplers(0, 1, &oldSamp);
+    ctx->IASetInputLayout(oldLayout);
+    ctx->IASetPrimitiveTopology(oldTopo);
+    if (oldRtv) oldRtv->Release();
+    if (oldDsv) oldDsv->Release();
+    if (oldBlend) oldBlend->Release();
+    if (oldDepth) oldDepth->Release();
+    if (oldRaster) oldRaster->Release();
+    if (oldVs) oldVs->Release();
+    if (oldPs) oldPs->Release();
+    if (oldSrv) oldSrv->Release();
+    if (oldSamp) oldSamp->Release();
+    if (oldLayout) oldLayout->Release();
+    return true;
+}
+
+} // namespace
+
+bool alpha_premul(ID3D11DeviceContext* ctx, ID3D11RenderTargetView* dst,
+                  ID3D11ShaderResourceView* src, UINT dstW, UINT dstH) {
+    return draw_internal(ctx, dst, src, dstW, dstH, g_ps, g_blend);
+}
+
+bool process(ID3D11DeviceContext* ctx, ID3D11RenderTargetView* dst,
+             ID3D11ShaderResourceView* src, UINT dstW, UINT dstH) {
+    // Blend OFF (null state = replace): rgb passes through, alpha repaired.
+    return draw_internal(ctx, dst, src, dstW, dstH, g_psProcess, nullptr);
+}
+
+void release() {
+    if (g_vs) { g_vs->Release(); g_vs = nullptr; }
+    if (g_ps) { g_ps->Release(); g_ps = nullptr; }
+    if (g_psProcess) { g_psProcess->Release(); g_psProcess = nullptr; }
+    if (g_blend) { g_blend->Release(); g_blend = nullptr; }
+    if (g_sampler) { g_sampler->Release(); g_sampler = nullptr; }
+    if (g_raster) { g_raster->Release(); g_raster = nullptr; }
+    if (g_depth) { g_depth->Release(); g_depth = nullptr; }
+}
+
+} // namespace bvr::blit

--- a/src/core/gfx/blit.cpp
+++ b/src/core/gfx/blit.cpp
@@ -22,12 +22,14 @@ VSOut vs_main(uint id : SV_VertexID) {
 float4 ps_main(VSOut i) : SV_Target {
     return tex0.Sample(samp0, i.uv);
 }
-// Alpha repair: gameswf leaves garbage in dest alpha; rgb over a zero clear
-// is premultiplied, so luminance approximates coverage.
+// Alpha safety floor: coverage now accumulates correctly (the redirect swaps
+// gameswf blend states for alpha-corrected variants), so the luminance term
+// is only a low floor against any state that slips through - bright pixels
+// can never be fully invisible.
 float4 ps_process(VSOut i) : SV_Target {
     float4 c = tex0.Sample(samp0, i.uv);
     float lum = dot(c.rgb, float3(0.299, 0.587, 0.114));
-    c.a = max(c.a, saturate(lum * 2.5));
+    c.a = max(c.a, saturate(lum * 0.35));
     return c;
 }
 )";

--- a/src/core/gfx/blit.h
+++ b/src/core/gfx/blit.h
@@ -1,0 +1,34 @@
+// Minimal alpha-blend textured blit (session 19): draws `src` over `dst` as a
+// fullscreen triangle with straight-alpha blending. Used to composite the
+// captured HUD back onto the flat window AFTER the XR eye capture - the one
+// consumer ImGui cannot serve (the overlay draws before the capture, so an
+// ImGui composite would put the HUD back into both eyes).
+//
+// Pipeline objects are created lazily from the context's device on first use
+// (D3DCompile, like imgui_impl_dx11); full state backup/restore around the
+// draw. Render thread only.
+
+#pragma once
+
+#include <d3d11.h>
+
+namespace bvr::blit {
+
+// Draw src over the full dst viewport (dstW x dstH) with PREMULTIPLIED
+// blending (ONE / INV_SRC_ALPHA). The source is expected to carry sane alpha
+// (see process below). Returns false if pipeline creation failed (logged once).
+bool alpha_premul(ID3D11DeviceContext* ctx, ID3D11RenderTargetView* dst,
+                  ID3D11ShaderResourceView* src, UINT dstW, UINT dstH);
+
+// Alpha-repair pass, blending OFF: writes src.rgb unchanged (gameswf output
+// over a zero-cleared RT is premultiplied by construction) with alpha =
+// max(stored, luminance-derived). gameswf's blend states leave garbage in the
+// destination alpha channel, so coverage must be reconstructed before any
+// alpha-blended consumer (the window composite, the XR quad) can show it.
+bool process(ID3D11DeviceContext* ctx, ID3D11RenderTargetView* dst,
+             ID3D11ShaderResourceView* src, UINT dstW, UINT dstH);
+
+// Release device objects (device loss / shutdown; recreated lazily).
+void release();
+
+} // namespace bvr::blit

--- a/src/core/gfx/frame_inspector.cpp
+++ b/src/core/gfx/frame_inspector.cpp
@@ -479,11 +479,15 @@ void STDMETHODCALLTYPE DrawDetour(ID3D11DeviceContext* ctx, UINT vertexCount, UI
     }
     // HUD redirect (session 19): a gameswf-classified draw gets our RT bound
     // instead - through the ORIGINAL SetRT so the substitution does not roll
-    // the classifier's own binding state.
+    // the classifier's own binding state. Our DSV rides along (flash masks
+    // stencil against it) and the blend state swaps to its alpha-corrected
+    // variant (checked per draw - gameswf changes states mid-stream).
     if (t_suppress == 0) {
         if (ID3D11RenderTargetView* sub = bvr::hud::on_draw(ctx)) {
             ++t_suppress;
-            g_origOMSetRenderTargets(ctx, 1, &sub, nullptr);
+            ID3D11DepthStencilView* dsv = bvr::hud::capture_dsv();
+            g_origOMSetRenderTargets(ctx, 1, &sub, dsv);
+            bvr::hud::fix_blend_alpha(ctx);
             --t_suppress;
         }
     }

--- a/src/core/gfx/frame_inspector.cpp
+++ b/src/core/gfx/frame_inspector.cpp
@@ -12,6 +12,8 @@
 
 #include "core/gfx/frame_inspector.h"
 
+#include "core/gfx/hud_capture.h"
+
 #include "core/util/log.h"
 
 #include <windows.h>
@@ -39,8 +41,25 @@ thread_local int t_suppress = 0;
 
 // Lifetime call census per hooked slot (diagnostic): are the detours even
 // being called? Indexed by EventKind order below.
-std::atomic<uint32_t> g_callCensus[7]{};
-enum CensusIdx { CxDrawIndexed, CxDraw, CxDrawIdxInst, CxDrawInst, CxSetRT, CxClearRtv, CxClearDsv };
+std::atomic<uint32_t> g_callCensus[13]{};
+enum CensusIdx {
+    CxDrawIndexed,
+    CxDraw,
+    CxDrawIdxInst,
+    CxDrawInst,
+    CxSetRT,
+    CxClearRtv,
+    CxClearDsv,
+    // Session 19 (the HUD hunt): draws that never showed in any window meant
+    // the HUD reaches the backbuffer some other way - count every remaining
+    // lane that can move pixels.
+    CxDrawAuto,
+    CxDispatch,
+    CxCopySubRes,
+    CxCopyRes,
+    CxUpdateSubRes,
+    CxExecCmdList,
+};
 
 constexpr size_t kMaxEvents = 20000;
 constexpr size_t kMaxStack = 12;
@@ -62,6 +81,12 @@ enum class EventKind : uint8_t {
     ClearRtv,
     ClearDsv,
     SetRenderTargets,
+    DrawAuto,
+    Dispatch,
+    CopySubRes,  // rtv0 = dst, srv0 = src (field reuse)
+    CopyRes,     // rtv0 = dst, srv0 = src
+    UpdateSubRes,// rtv0 = dst
+    ExecCmdList, // a = RestoreContextState
 };
 
 struct Event {
@@ -116,6 +141,23 @@ using MapFn = HRESULT(STDMETHODCALLTYPE*)(ID3D11DeviceContext*, ID3D11Resource*,
 using UnmapFn = void(STDMETHODCALLTYPE*)(ID3D11DeviceContext*, ID3D11Resource*, UINT);
 MapFn g_origMap = nullptr;
 UnmapFn g_origUnmap = nullptr;
+
+using DrawAutoFn = void(STDMETHODCALLTYPE*)(ID3D11DeviceContext*);
+using DispatchFn = void(STDMETHODCALLTYPE*)(ID3D11DeviceContext*, UINT, UINT, UINT);
+using CopySubResFn = void(STDMETHODCALLTYPE*)(ID3D11DeviceContext*, ID3D11Resource*, UINT, UINT,
+                                              UINT, UINT, ID3D11Resource*, UINT,
+                                              const D3D11_BOX*);
+using CopyResFn = void(STDMETHODCALLTYPE*)(ID3D11DeviceContext*, ID3D11Resource*,
+                                           ID3D11Resource*);
+using UpdateSubResFn = void(STDMETHODCALLTYPE*)(ID3D11DeviceContext*, ID3D11Resource*, UINT,
+                                                const D3D11_BOX*, const void*, UINT, UINT);
+using ExecCmdListFn = void(STDMETHODCALLTYPE*)(ID3D11DeviceContext*, ID3D11CommandList*, BOOL);
+DrawAutoFn g_origDrawAuto = nullptr;
+DispatchFn g_origDispatch = nullptr;
+CopySubResFn g_origCopySubRes = nullptr;
+CopyResFn g_origCopyRes = nullptr;
+UpdateSubResFn g_origUpdateSubRes = nullptr;
+ExecCmdListFn g_origExecCmdList = nullptr;
 
 // ---- cb watch (session 13) --------------------------------------------------
 // The engine uploads per-draw constants through Map(WRITE_DISCARD)/memcpy/
@@ -224,6 +266,24 @@ int register_resource(ID3D11View* view) {
     }
     g_resources.emplace(res, info);
     res->Release(); // table keys are identity only, never dereferenced
+    return info.id;
+}
+
+// Raw-resource variant (the Copy/Update lanes have no view). Identity-keyed
+// like the view path; does NOT take a reference.
+int register_resource_raw(ID3D11Resource* res) {
+    if (!res) return -1;
+    auto it = g_resources.find(res);
+    if (it != g_resources.end()) return it->second.id;
+    ResourceInfo info{};
+    info.id = g_nextResourceId++;
+    ID3D11Texture2D* tex = nullptr;
+    if (SUCCEEDED(res->QueryInterface(IID_PPV_ARGS(&tex)))) {
+        tex->GetDesc(&info.desc);
+        info.isTexture2d = true;
+        tex->Release();
+    }
+    g_resources.emplace(res, info);
     return info.id;
 }
 
@@ -394,6 +454,7 @@ Event& push_event(EventKind kind, const void* retAddr, void* espHint) {
 void STDMETHODCALLTYPE DrawIndexedDetour(ID3D11DeviceContext* ctx, UINT indexCount,
                                          UINT startIndex, INT baseVertex) {
     g_callCensus[CxDrawIndexed].fetch_add(1, std::memory_order_relaxed);
+    if (t_suppress == 0) bvr::hud::on_draw_indexed();
     if (should_record()) {
         ++t_suppress; // our own Get* calls must not recurse into recording
         Event& ev = push_event(EventKind::DrawIndexed, _ReturnAddress(),
@@ -415,6 +476,16 @@ void STDMETHODCALLTYPE DrawDetour(ID3D11DeviceContext* ctx, UINT vertexCount, UI
         ev.b = startVertex;
         capture_draw_state(ctx, ev);
         --t_suppress;
+    }
+    // HUD redirect (session 19): a gameswf-classified draw gets our RT bound
+    // instead - through the ORIGINAL SetRT so the substitution does not roll
+    // the classifier's own binding state.
+    if (t_suppress == 0) {
+        if (ID3D11RenderTargetView* sub = bvr::hud::on_draw(ctx)) {
+            ++t_suppress;
+            g_origOMSetRenderTargets(ctx, 1, &sub, nullptr);
+            --t_suppress;
+        }
     }
     g_origDraw(ctx, vertexCount, startVertex);
 }
@@ -454,6 +525,7 @@ void STDMETHODCALLTYPE OMSetRenderTargetsDetour(ID3D11DeviceContext* ctx, UINT n
                                                 ID3D11RenderTargetView* const* rtvs,
                                                 ID3D11DepthStencilView* dsv) {
     g_callCensus[CxSetRT].fetch_add(1, std::memory_order_relaxed);
+    if (t_suppress == 0) bvr::hud::on_setrt(numViews, rtvs, dsv);
     if (should_record()) {
         ++t_suppress;
         Event& ev = push_event(EventKind::SetRenderTargets, _ReturnAddress(),
@@ -492,6 +564,87 @@ void STDMETHODCALLTYPE ClearDsvDetour(ID3D11DeviceContext* ctx, ID3D11DepthStenc
     g_origClearDsv(ctx, dsv, flags, depth, stencil);
 }
 
+void STDMETHODCALLTYPE DrawAutoDetour(ID3D11DeviceContext* ctx) {
+    g_callCensus[CxDrawAuto].fetch_add(1, std::memory_order_relaxed);
+    if (should_record()) {
+        ++t_suppress;
+        Event& ev = push_event(EventKind::DrawAuto, _ReturnAddress(), _AddressOfReturnAddress());
+        capture_draw_state(ctx, ev);
+        --t_suppress;
+    }
+    g_origDrawAuto(ctx);
+}
+
+void STDMETHODCALLTYPE DispatchDetour(ID3D11DeviceContext* ctx, UINT x, UINT y, UINT z) {
+    g_callCensus[CxDispatch].fetch_add(1, std::memory_order_relaxed);
+    if (should_record()) {
+        ++t_suppress;
+        Event& ev = push_event(EventKind::Dispatch, _ReturnAddress(), _AddressOfReturnAddress());
+        ev.a = x;
+        ev.b = y;
+        --t_suppress;
+    }
+    g_origDispatch(ctx, x, y, z);
+}
+
+void STDMETHODCALLTYPE CopySubResDetour(ID3D11DeviceContext* ctx, ID3D11Resource* dst,
+                                        UINT dstSub, UINT dstX, UINT dstY, UINT dstZ,
+                                        ID3D11Resource* src, UINT srcSub,
+                                        const D3D11_BOX* box) {
+    g_callCensus[CxCopySubRes].fetch_add(1, std::memory_order_relaxed);
+    if (should_record()) {
+        ++t_suppress;
+        Event& ev = push_event(EventKind::CopySubRes, _ReturnAddress(),
+                               _AddressOfReturnAddress());
+        ev.rtv0 = register_resource_raw(dst);
+        ev.srv0 = register_resource_raw(src);
+        ev.a = dstX;
+        ev.b = dstY;
+        --t_suppress;
+    }
+    g_origCopySubRes(ctx, dst, dstSub, dstX, dstY, dstZ, src, srcSub, box);
+}
+
+void STDMETHODCALLTYPE CopyResDetour(ID3D11DeviceContext* ctx, ID3D11Resource* dst,
+                                     ID3D11Resource* src) {
+    g_callCensus[CxCopyRes].fetch_add(1, std::memory_order_relaxed);
+    if (should_record()) {
+        ++t_suppress;
+        Event& ev = push_event(EventKind::CopyRes, _ReturnAddress(), _AddressOfReturnAddress());
+        ev.rtv0 = register_resource_raw(dst);
+        ev.srv0 = register_resource_raw(src);
+        --t_suppress;
+    }
+    g_origCopyRes(ctx, dst, src);
+}
+
+void STDMETHODCALLTYPE UpdateSubResDetour(ID3D11DeviceContext* ctx, ID3D11Resource* dst,
+                                          UINT dstSub, const D3D11_BOX* box, const void* data,
+                                          UINT rowPitch, UINT depthPitch) {
+    g_callCensus[CxUpdateSubRes].fetch_add(1, std::memory_order_relaxed);
+    if (should_record()) {
+        ++t_suppress;
+        Event& ev = push_event(EventKind::UpdateSubRes, _ReturnAddress(),
+                               _AddressOfReturnAddress());
+        ev.rtv0 = register_resource_raw(dst);
+        --t_suppress;
+    }
+    g_origUpdateSubRes(ctx, dst, dstSub, box, data, rowPitch, depthPitch);
+}
+
+void STDMETHODCALLTYPE ExecCmdListDetour(ID3D11DeviceContext* ctx, ID3D11CommandList* list,
+                                         BOOL restore) {
+    g_callCensus[CxExecCmdList].fetch_add(1, std::memory_order_relaxed);
+    if (should_record()) {
+        ++t_suppress;
+        Event& ev = push_event(EventKind::ExecCmdList, _ReturnAddress(),
+                               _AddressOfReturnAddress());
+        ev.a = restore ? 1 : 0;
+        --t_suppress;
+    }
+    g_origExecCmdList(ctx, list, restore);
+}
+
 // ---- dump writer --------------------------------------------------------
 
 const char* kind_name(EventKind k) {
@@ -503,6 +656,12 @@ const char* kind_name(EventKind k) {
         case EventKind::ClearRtv: return "ClearRTV";
         case EventKind::ClearDsv: return "ClearDSV";
         case EventKind::SetRenderTargets: return "SetRT";
+        case EventKind::DrawAuto: return "DrawAuto";
+        case EventKind::Dispatch: return "Dispatch";
+        case EventKind::CopySubRes: return "CopySubRes";
+        case EventKind::CopyRes: return "CopyRes";
+        case EventKind::UpdateSubRes: return "UpdateSubRes";
+        case EventKind::ExecCmdList: return "ExecCmdList";
     }
     return "?";
 }
@@ -512,14 +671,16 @@ bool is_draw(EventKind k) {
            k == EventKind::DrawIndexedInstanced || k == EventKind::DrawInstanced;
 }
 
+int g_dumpSeq = 0; // per-boot counter: consecutive-window dumps land in one second
+
 void write_dump() {
     wchar_t path[MAX_PATH];
     wchar_t base[MAX_PATH];
     if (!GetEnvironmentVariableW(L"LOCALAPPDATA", base, MAX_PATH)) return;
     SYSTEMTIME st{};
     GetLocalTime(&st);
-    swprintf_s(path, L"%s\\BioshockVR\\framedump_%02u%02u%02u.txt", base, st.wHour, st.wMinute,
-               st.wSecond);
+    swprintf_s(path, L"%s\\BioshockVR\\framedump_%02u%02u%02u_q%d.txt", base, st.wHour,
+               st.wMinute, st.wSecond, g_dumpSeq++);
 
     FILE* f = nullptr;
     if (_wfopen_s(&f, path, L"wt") != 0 || !f) {
@@ -531,11 +692,15 @@ void write_dump() {
             static_cast<unsigned>(g_events.size()), g_mode == 2 ? "full" : "lite",
             static_cast<unsigned>(g_exeBase));
     fprintf(f, "lifetime call census: DrawIndexed=%u Draw=%u DrawIdxInst=%u DrawInst=%u "
-               "SetRT=%u ClearRTV=%u ClearDSV=%u\n\n",
+               "SetRT=%u ClearRTV=%u ClearDSV=%u DrawAuto=%u Dispatch=%u CopySubRes=%u "
+               "CopyRes=%u UpdateSubRes=%u ExecCmdList=%u\n\n",
             g_callCensus[CxDrawIndexed].load(), g_callCensus[CxDraw].load(),
             g_callCensus[CxDrawIdxInst].load(), g_callCensus[CxDrawInst].load(),
             g_callCensus[CxSetRT].load(), g_callCensus[CxClearRtv].load(),
-            g_callCensus[CxClearDsv].load());
+            g_callCensus[CxClearDsv].load(), g_callCensus[CxDrawAuto].load(),
+            g_callCensus[CxDispatch].load(), g_callCensus[CxCopySubRes].load(),
+            g_callCensus[CxCopyRes].load(), g_callCensus[CxUpdateSubRes].load(),
+            g_callCensus[CxExecCmdList].load());
     BVR_LOG("[gfx] census: DrawIndexed=%u Draw=%u DrawIdxInst=%u DrawInst=%u SetRT=%u "
             "ClearRTV=%u ClearDSV=%u",
             g_callCensus[CxDrawIndexed].load(), g_callCensus[CxDraw].load(),
@@ -664,6 +829,19 @@ bool install(void** ctxVtable) {
         {14, reinterpret_cast<void*>(&MapDetour), reinterpret_cast<void**>(&g_origMap), "Map"},
         {15, reinterpret_cast<void*>(&UnmapDetour), reinterpret_cast<void**>(&g_origUnmap),
          "Unmap"},
+        // Session 19 (the HUD hunt): every other lane that can move pixels.
+        {38, reinterpret_cast<void*>(&DrawAutoDetour),
+         reinterpret_cast<void**>(&g_origDrawAuto), "DrawAuto"},
+        {41, reinterpret_cast<void*>(&DispatchDetour),
+         reinterpret_cast<void**>(&g_origDispatch), "Dispatch"},
+        {46, reinterpret_cast<void*>(&CopySubResDetour),
+         reinterpret_cast<void**>(&g_origCopySubRes), "CopySubresourceRegion"},
+        {47, reinterpret_cast<void*>(&CopyResDetour),
+         reinterpret_cast<void**>(&g_origCopyRes), "CopyResource"},
+        {48, reinterpret_cast<void*>(&UpdateSubResDetour),
+         reinterpret_cast<void**>(&g_origUpdateSubRes), "UpdateSubresource"},
+        {58, reinterpret_cast<void*>(&ExecCmdListDetour),
+         reinterpret_cast<void**>(&g_origExecCmdList), "ExecuteCommandList"},
     };
 
     int hooked = 0;
@@ -676,8 +854,8 @@ bool install(void** ctxVtable) {
             BVR_LOG("[gfx] inspector hook %s FAILED: %s", s.name, MH_StatusToString(status));
         }
     }
-    BVR_LOG("[gfx] frame inspector: %d/9 context slots hooked", hooked);
-    return hooked == 9;
+    BVR_LOG("[gfx] frame inspector: %d/15 context slots hooked", hooked);
+    return hooked == 15;
 }
 
 void set_cb_watch(const float* pattern, uint32_t patFirst, uint32_t patCount,
@@ -725,9 +903,15 @@ bool latest_cb_watch(float* out, uint32_t count, uint64_t* ageMs) {
     return false;
 }
 
-void arm(int mode) {
+std::atomic<int> g_armCount{0}; // windows left to record (consecutive presents)
+
+void arm(int mode, int count) {
+    if (count < 1) count = 1;
+    if (count > 8) count = 8;
+    g_armCount.store(count, std::memory_order_relaxed);
     g_armMode.store(mode == 2 ? 2 : 1, std::memory_order_relaxed);
-    BVR_LOG("[gfx] frame dump armed (%s)", mode == 2 ? "full" : "lite");
+    BVR_LOG("[gfx] frame dump armed (%s, %d window%s)", mode == 2 ? "full" : "lite", count,
+            count == 1 ? "" : "s");
 }
 
 void on_present(IDXGISwapChain*) {
@@ -739,6 +923,15 @@ void on_present(IDXGISwapChain*) {
         g_resources.clear();
         g_nextResourceId = 0;
         g_lastCb0Captured = nullptr;
+        // Consecutive-window capture (session 19): a command armed at CalcView
+        // always opens on the SAME phase of the stereo pair, so a single
+        // window can never see what the other pair half draws (the HUD hunt
+        // hit exactly this). Roll straight into the next window.
+        if (g_armCount.fetch_sub(1, std::memory_order_relaxed) - 1 > 0) {
+            g_events.reserve(4096);
+            g_recording.store(true, std::memory_order_relaxed);
+            return;
+        }
     }
     int pending = g_armMode.exchange(0, std::memory_order_relaxed);
     if (pending) {

--- a/src/core/gfx/frame_inspector.h
+++ b/src/core/gfx/frame_inspector.h
@@ -19,7 +19,11 @@ bool install(void** ctxVtable);
 
 // Arm a one-shot dump of the NEXT full Present-to-Present frame.
 // mode 1 = lite (no constant-buffer readback), 2 = full.
-void arm(int mode);
+// Arm a frame dump: mode 1 = lite, 2 = full (cb bytes). count > 1 records
+// that many CONSECUTIVE present windows (files suffixed _qN) - required to see
+// both halves of a stereo pair, since a game-thread arm always opens on the
+// same pair phase.
+void arm(int mode, int count = 1);
 
 // Frame boundary, called at the head of the Present detour: finalizes and
 // writes a recording frame, or begins a pending one.

--- a/src/core/gfx/hud_capture.cpp
+++ b/src/core/gfx/hud_capture.cpp
@@ -5,6 +5,7 @@
 
 #include <atomic>
 #include <cstring>
+#include <map>
 
 namespace bvr::hud {
 namespace {
@@ -28,6 +29,22 @@ ID3D11ShaderResourceView* g_srv2 = nullptr;
 UINT g_texW = 0, g_texH = 0;
 bool g_processedThisInterval = false;
 
+// Our own depth-stencil for the redirected draws (session 19, headset round):
+// gameswf implements flash MASKS via stencil - redirecting with no DSV left
+// the vending/pause odometer digit strips unclipped (user's screenshot).
+// Cleared each interval; the mask write-then-test is self-contained.
+ID3D11Texture2D* g_depthTex = nullptr;
+ID3D11DepthStencilView* g_dsv = nullptr;
+
+// Alpha-corrected variants of the gameswf blend states (session 19, headset
+// round): gameswf's states blend the ALPHA channel like the color channel
+// (a*a + (1-a)*dst), which accumulates garbage coverage - dark opaque menu
+// panels ended up transparent on the quad. Each state seen on a redirected
+// draw gets a variant with SrcBlendAlpha=ONE, DestBlendAlpha=INV_SRC_ALPHA
+// (correct over-composite coverage), rgb ops untouched. Keyed by the
+// original state pointer; variants are ours and released with the RT.
+std::map<ID3D11BlendState*, ID3D11BlendState*> g_blendVariants;
+
 // ---- per-interval classifier state ----------------------------------------
 // Current binding (tracked at SetRT; resources are identity keys only).
 ID3D11Resource* g_curRt = nullptr;
@@ -35,7 +52,6 @@ bool g_curRtLdr = false;      // desc matches a HUD-capable target
 bool g_curDsvBound = false;
 UINT g_curW = 0, g_curH = 0;
 DXGI_FORMAT g_curFmt = DXGI_FORMAT_UNKNOWN;
-bool g_substituted = false;   // our RTV is currently bound instead
 
 // Scene-RT vote: the resource hosting the most DSV-bound DrawIndexed calls.
 struct Vote { ID3D11Resource* res; unsigned n; };
@@ -71,12 +87,17 @@ bool ensure_rt(ID3D11DeviceContext* ctx, UINT w, UINT h, DXGI_FORMAT fmt) {
     td.SampleDesc.Count = 1;
     td.Usage = D3D11_USAGE_DEFAULT;
     td.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
+    D3D11_TEXTURE2D_DESC dd = td;
+    dd.Format = DXGI_FORMAT_D24_UNORM_S8_UINT;
+    dd.BindFlags = D3D11_BIND_DEPTH_STENCIL;
     bool ok = SUCCEEDED(dev->CreateTexture2D(&td, nullptr, &g_tex)) &&
               SUCCEEDED(dev->CreateRenderTargetView(g_tex, nullptr, &g_rtv)) &&
               SUCCEEDED(dev->CreateShaderResourceView(g_tex, nullptr, &g_srv)) &&
               SUCCEEDED(dev->CreateTexture2D(&td, nullptr, &g_tex2)) &&
               SUCCEEDED(dev->CreateRenderTargetView(g_tex2, nullptr, &g_rtv2)) &&
-              SUCCEEDED(dev->CreateShaderResourceView(g_tex2, nullptr, &g_srv2));
+              SUCCEEDED(dev->CreateShaderResourceView(g_tex2, nullptr, &g_srv2)) &&
+              SUCCEEDED(dev->CreateTexture2D(&dd, nullptr, &g_depthTex)) &&
+              SUCCEEDED(dev->CreateDepthStencilView(g_depthTex, nullptr, &g_dsv));
     dev->Release();
     if (!ok) {
         release_resources();
@@ -87,7 +108,8 @@ bool ensure_rt(ID3D11DeviceContext* ctx, UINT w, UINT h, DXGI_FORMAT fmt) {
     g_texH = h;
     const float clear[4] = {0, 0, 0, 0};
     ctx->ClearRenderTargetView(g_rtv, clear);
-    BVR_LOG("[hud] capture RT created %ux%u fmt=%d", w, h, fmt);
+    ctx->ClearDepthStencilView(g_dsv, D3D11_CLEAR_DEPTH | D3D11_CLEAR_STENCIL, 1.0f, 0);
+    BVR_LOG("[hud] capture RT created %ux%u fmt=%d (+D24S8 for gameswf masks)", w, h, fmt);
     return true;
 }
 
@@ -99,9 +121,20 @@ bool armed() {
 
 } // namespace
 
+// Per-present cache of resource -> HUD-capable desc (the same few RTs rebind
+// ~200x per interval; QI+GetDesc per bind showed up as avoidable per-frame
+// COM churn in the session-19 FPS pass).
+struct DescCacheEntry {
+    ID3D11Resource* res;
+    bool ldr;
+    UINT w, h;
+    DXGI_FORMAT fmt;
+};
+DescCacheEntry g_descCache[8] = {};
+int g_descCacheCount = 0;
+
 void on_setrt(UINT numViews, ID3D11RenderTargetView* const* rtvs,
               ID3D11DepthStencilView* dsv) {
-    g_substituted = false; // any bind from the game supersedes our substitution
     g_curRt = nullptr;
     g_curRtLdr = false;
     g_curDsvBound = dsv != nullptr;
@@ -110,6 +143,17 @@ void on_setrt(UINT numViews, ID3D11RenderTargetView* const* rtvs,
     rtvs[0]->GetResource(&res);
     if (!res) return;
     g_curRt = res;
+    res->Release(); // identity only from here on
+
+    for (int i = 0; i < g_descCacheCount; ++i) {
+        if (g_descCache[i].res == res) {
+            g_curRtLdr = g_descCache[i].ldr;
+            g_curW = g_descCache[i].w;
+            g_curH = g_descCache[i].h;
+            g_curFmt = g_descCache[i].fmt;
+            return;
+        }
+    }
     ID3D11Texture2D* tex = nullptr;
     if (SUCCEEDED(res->QueryInterface(IID_PPV_ARGS(&tex)))) {
         D3D11_TEXTURE2D_DESC d{};
@@ -125,7 +169,14 @@ void on_setrt(UINT numViews, ID3D11RenderTargetView* const* rtvs,
                      (d.BindFlags & D3D11_BIND_SHADER_RESOURCE);
         tex->Release();
     }
-    res->Release(); // identity only from here on
+    if (g_descCacheCount < static_cast<int>(_countof(g_descCache))) {
+        DescCacheEntry& e = g_descCache[g_descCacheCount++];
+        e.res = res;
+        e.ldr = g_curRtLdr;
+        e.w = g_curW;
+        e.h = g_curH;
+        e.fmt = g_curFmt;
+    }
 }
 
 void on_draw_indexed() {
@@ -180,8 +231,9 @@ ID3D11RenderTargetView* on_draw(ID3D11DeviceContext* ctx) {
     if (!armed()) return nullptr;
     if (!ensure_rt(ctx, g_curW, g_curH, g_curFmt)) return nullptr;
     g_cRedirects.fetch_add(1, std::memory_order_relaxed);
-    if (g_substituted) return nullptr; // already bound from a previous draw
-    g_substituted = true;
+    // Returned for EVERY redirected draw - the caller re-binds each time
+    // (cheap, self-healing against mid-stream game binds) and swaps the
+    // blend state to its alpha-corrected variant.
     return g_rtv;
 }
 
@@ -191,14 +243,17 @@ void on_present(ID3D11DeviceContext* ctx) {
     if (g_hudThisInterval && g_rtv && ctx) {
         const float clear[4] = {0, 0, 0, 0};
         ctx->ClearRenderTargetView(g_rtv, clear);
+        if (g_dsv)
+            ctx->ClearDepthStencilView(g_dsv, D3D11_CLEAR_DEPTH | D3D11_CLEAR_STENCIL,
+                                       1.0f, 0);
     }
     g_hudThisInterval = false;
     g_processedThisInterval = false;
     g_hudTarget = nullptr;
-    g_substituted = false;
     g_curRt = nullptr;
     g_curRtLdr = false;
     memset(g_votes, 0, sizeof g_votes);
+    g_descCacheCount = 0;
 }
 
 // Consumers (eye-capture-adjacent composite, quad copy) run in the present
@@ -251,6 +306,52 @@ void get_counters(unsigned* hudDraws, unsigned* redirects, unsigned* leaks,
     if (intervalsWithHud) *intervalsWithHud = g_cIntervals.load(std::memory_order_relaxed);
 }
 
+ID3D11DepthStencilView* capture_dsv() {
+    return g_dsv;
+}
+
+void fix_blend_alpha(ID3D11DeviceContext* ctx) {
+    ID3D11BlendState* cur = nullptr;
+    FLOAT bf[4] = {};
+    UINT mask = 0xFFFFFFFF;
+    ctx->OMGetBlendState(&cur, bf, &mask);
+    // Already one of our variants (consecutive redirected draws with no
+    // game state change in between): nothing to do.
+    for (const auto& [orig, variant] : g_blendVariants) {
+        if (variant == cur) {
+            cur->Release();
+            return;
+        }
+    }
+    auto it = g_blendVariants.find(cur);
+    ID3D11BlendState* variant = nullptr;
+    if (it != g_blendVariants.end()) {
+        variant = it->second;
+    } else {
+        D3D11_BLEND_DESC d{};
+        if (cur) {
+            cur->GetDesc(&d);
+        } else {
+            // Default state: blending off - output alpha is already the
+            // shader's (correct coverage); still force the alpha write on.
+            d.RenderTarget[0].BlendEnable = FALSE;
+        }
+        d.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_ONE;
+        d.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_INV_SRC_ALPHA;
+        d.RenderTarget[0].BlendOpAlpha = D3D11_BLEND_OP_ADD;
+        d.RenderTarget[0].RenderTargetWriteMask |= D3D11_COLOR_WRITE_ENABLE_ALPHA;
+        ID3D11Device* dev = nullptr;
+        ctx->GetDevice(&dev);
+        if (dev) {
+            if (SUCCEEDED(dev->CreateBlendState(&d, &variant)))
+                g_blendVariants.emplace(cur, variant);
+            dev->Release();
+        }
+    }
+    if (variant) ctx->OMSetBlendState(variant, bf, mask);
+    if (cur) cur->Release();
+}
+
 void release_resources() {
     if (g_srv) { g_srv->Release(); g_srv = nullptr; }
     if (g_rtv) { g_rtv->Release(); g_rtv = nullptr; }
@@ -258,6 +359,11 @@ void release_resources() {
     if (g_srv2) { g_srv2->Release(); g_srv2 = nullptr; }
     if (g_rtv2) { g_rtv2->Release(); g_rtv2 = nullptr; }
     if (g_tex2) { g_tex2->Release(); g_tex2 = nullptr; }
+    if (g_dsv) { g_dsv->Release(); g_dsv = nullptr; }
+    if (g_depthTex) { g_depthTex->Release(); g_depthTex = nullptr; }
+    for (auto& [orig, variant] : g_blendVariants)
+        if (variant) variant->Release();
+    g_blendVariants.clear();
     g_texW = g_texH = 0;
     g_processedThisInterval = false;
 }

--- a/src/core/gfx/hud_capture.cpp
+++ b/src/core/gfx/hud_capture.cpp
@@ -1,0 +1,243 @@
+#include "core/gfx/hud_capture.h"
+
+#include "core/util/log.h"
+
+#include <atomic>
+#include <cstring>
+
+namespace bvr::hud {
+namespace {
+
+// All state is render-thread-only except the knobs (atomics) - the game
+// renders single-threaded and Present runs on the same thread.
+std::atomic<bool> g_enabled{true};
+std::atomic<bool> g_force{false};
+std::atomic<bool> g_gate{false};
+
+// Our RT (created lazily to match the tonemap target's desc).
+ID3D11Texture2D* g_tex = nullptr;
+ID3D11RenderTargetView* g_rtv = nullptr;
+ID3D11ShaderResourceView* g_srv = nullptr;
+UINT g_texW = 0, g_texH = 0;
+
+// ---- per-interval classifier state ----------------------------------------
+// Current binding (tracked at SetRT; resources are identity keys only).
+ID3D11Resource* g_curRt = nullptr;
+bool g_curRtLdr = false;      // desc matches a HUD-capable target
+bool g_curDsvBound = false;
+UINT g_curW = 0, g_curH = 0;
+DXGI_FORMAT g_curFmt = DXGI_FORMAT_UNKNOWN;
+bool g_substituted = false;   // our RTV is currently bound instead
+
+// Scene-RT vote: the resource hosting the most DSV-bound DrawIndexed calls.
+struct Vote { ID3D11Resource* res; unsigned n; };
+Vote g_votes[4] = {};
+ID3D11Resource* g_hudTarget = nullptr; // set when the tonemap is identified
+bool g_hudThisInterval = false;
+bool g_hadHudLastInterval = false;
+
+// Lifetime counters.
+std::atomic<unsigned> g_cHudDraws{0}, g_cRedirects{0}, g_cLeaks{0}, g_cIntervals{0};
+
+ID3D11Resource* scene_leader() {
+    Vote* best = nullptr;
+    for (Vote& v : g_votes)
+        if (v.res && (!best || v.n > best->n)) best = &v;
+    // A handful of DSV-bound draws is not a scene (the fg rig pass has ~14);
+    // the world pass has hundreds. 32 is comfortably between.
+    return (best && best->n >= 32) ? best->res : nullptr;
+}
+
+bool ensure_rt(ID3D11DeviceContext* ctx, UINT w, UINT h, DXGI_FORMAT fmt) {
+    if (g_tex && g_texW == w && g_texH == h) return true;
+    release_resources();
+    ID3D11Device* dev = nullptr;
+    ctx->GetDevice(&dev);
+    if (!dev) return false;
+    D3D11_TEXTURE2D_DESC td{};
+    td.Width = w;
+    td.Height = h;
+    td.MipLevels = 1;
+    td.ArraySize = 1;
+    td.Format = fmt;
+    td.SampleDesc.Count = 1;
+    td.Usage = D3D11_USAGE_DEFAULT;
+    td.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
+    bool ok = SUCCEEDED(dev->CreateTexture2D(&td, nullptr, &g_tex)) &&
+              SUCCEEDED(dev->CreateRenderTargetView(g_tex, nullptr, &g_rtv)) &&
+              SUCCEEDED(dev->CreateShaderResourceView(g_tex, nullptr, &g_srv));
+    dev->Release();
+    if (!ok) {
+        release_resources();
+        BVR_LOG("[hud] RT create FAILED (%ux%u)", w, h);
+        return false;
+    }
+    g_texW = w;
+    g_texH = h;
+    const float clear[4] = {0, 0, 0, 0};
+    ctx->ClearRenderTargetView(g_rtv, clear);
+    BVR_LOG("[hud] capture RT created %ux%u fmt=%d", w, h, fmt);
+    return true;
+}
+
+bool armed() {
+    if (!g_enabled.load(std::memory_order_relaxed)) return false;
+    return g_force.load(std::memory_order_relaxed) ||
+           g_gate.load(std::memory_order_relaxed);
+}
+
+} // namespace
+
+void on_setrt(UINT numViews, ID3D11RenderTargetView* const* rtvs,
+              ID3D11DepthStencilView* dsv) {
+    g_substituted = false; // any bind from the game supersedes our substitution
+    g_curRt = nullptr;
+    g_curRtLdr = false;
+    g_curDsvBound = dsv != nullptr;
+    if (!numViews || !rtvs || !rtvs[0]) return;
+    ID3D11Resource* res = nullptr;
+    rtvs[0]->GetResource(&res);
+    if (!res) return;
+    g_curRt = res;
+    ID3D11Texture2D* tex = nullptr;
+    if (SUCCEEDED(res->QueryInterface(IID_PPV_ARGS(&tex)))) {
+        D3D11_TEXTURE2D_DESC d{};
+        tex->GetDesc(&d);
+        g_curW = d.Width;
+        g_curH = d.Height;
+        g_curFmt = d.Format;
+        // HUD-capable: big RGBA8 render+shader target (the tonemap target's
+        // shape; exact size keys off whatever the game runs at).
+        g_curRtLdr = d.Width >= 640 && d.Height >= 480 &&
+                     d.Format == DXGI_FORMAT_R8G8B8A8_UNORM &&
+                     (d.BindFlags & D3D11_BIND_RENDER_TARGET) &&
+                     (d.BindFlags & D3D11_BIND_SHADER_RESOURCE);
+        tex->Release();
+    }
+    res->Release(); // identity only from here on
+}
+
+void on_draw_indexed() {
+    if (!g_curRt) return;
+    if (g_curRt == g_hudTarget && g_hudTarget) {
+        // The fingerprint says the world never DrawIndexes the tonemap target
+        // after the tonemap - if it ever does, that is a leak we must know
+        // about before trusting the redirect.
+        g_cLeaks.fetch_add(1, std::memory_order_relaxed);
+        return;
+    }
+    if (!g_curDsvBound) return;
+    for (Vote& v : g_votes) {
+        if (v.res == g_curRt) {
+            ++v.n;
+            return;
+        }
+    }
+    for (Vote& v : g_votes) {
+        if (!v.res) {
+            v.res = g_curRt;
+            v.n = 1;
+            return;
+        }
+    }
+}
+
+ID3D11RenderTargetView* on_draw(ID3D11DeviceContext* ctx) {
+    if (!g_curRt || !g_curRtLdr) return nullptr;
+
+    if (!g_hudTarget) {
+        // Tonemap check: first non-indexed draw on an LDR target sampling the
+        // scene-vote leader marks this target as the HUD host.
+        ID3D11Resource* leader = scene_leader();
+        if (!leader) return nullptr;
+        ID3D11ShaderResourceView* srv0 = nullptr;
+        ctx->PSGetShaderResources(0, 1, &srv0);
+        if (!srv0) return nullptr;
+        ID3D11Resource* srvRes = nullptr;
+        srv0->GetResource(&srvRes);
+        srv0->Release();
+        if (srvRes) srvRes->Release(); // identity compare only
+        if (srvRes == leader) g_hudTarget = g_curRt;
+        return nullptr; // the tonemap itself always passes through
+    }
+
+    if (g_curRt != g_hudTarget) return nullptr;
+
+    // A non-indexed draw on the HUD target after the tonemap = gameswf.
+    g_cHudDraws.fetch_add(1, std::memory_order_relaxed);
+    g_hudThisInterval = true;
+    if (!armed()) return nullptr;
+    if (!ensure_rt(ctx, g_curW, g_curH, g_curFmt)) return nullptr;
+    g_cRedirects.fetch_add(1, std::memory_order_relaxed);
+    if (g_substituted) return nullptr; // already bound from a previous draw
+    g_substituted = true;
+    return g_rtv;
+}
+
+void on_present(ID3D11DeviceContext* ctx) {
+    if (g_hudThisInterval) g_cIntervals.fetch_add(1, std::memory_order_relaxed);
+    g_hadHudLastInterval = g_hudThisInterval;
+    if (g_hudThisInterval && g_rtv && ctx) {
+        const float clear[4] = {0, 0, 0, 0};
+        ctx->ClearRenderTargetView(g_rtv, clear);
+    }
+    g_hudThisInterval = false;
+    g_hudTarget = nullptr;
+    g_substituted = false;
+    g_curRt = nullptr;
+    g_curRtLdr = false;
+    memset(g_votes, 0, sizeof g_votes);
+}
+
+// Consumers (eye-capture-adjacent composite, quad copy) run in the present
+// chain BEFORE on_present() rolls the interval - so validity keys on the
+// CURRENT interval's redirects.
+ID3D11ShaderResourceView* srv() {
+    return g_hudThisInterval ? g_srv : nullptr;
+}
+
+ID3D11Texture2D* texture() {
+    return g_hudThisInterval ? g_tex : nullptr;
+}
+
+bool redirected_this_interval() {
+    return g_hudThisInterval;
+}
+
+void set_enabled(bool on) {
+    bool was = g_enabled.exchange(on, std::memory_order_relaxed);
+    if (was != on)
+        BVR_LOG("[hud] capture %s", on ? "ON (gameswf HUD redirects while gated)"
+                                       : "off (HUD stays in the game frame)");
+}
+
+bool enabled() { return g_enabled.load(std::memory_order_relaxed); }
+
+void set_gate(bool stereoActive) {
+    g_gate.store(stereoActive, std::memory_order_relaxed);
+}
+
+void set_force(bool on) {
+    g_force.store(on, std::memory_order_relaxed);
+    BVR_LOG("[hud] force %s (redirect %s the stereo gate - flat testing)",
+            on ? "ON" : "off", on ? "ignores" : "respects");
+}
+
+bool force() { return g_force.load(std::memory_order_relaxed); }
+
+void get_counters(unsigned* hudDraws, unsigned* redirects, unsigned* leaks,
+                  unsigned* intervalsWithHud) {
+    if (hudDraws) *hudDraws = g_cHudDraws.load(std::memory_order_relaxed);
+    if (redirects) *redirects = g_cRedirects.load(std::memory_order_relaxed);
+    if (leaks) *leaks = g_cLeaks.load(std::memory_order_relaxed);
+    if (intervalsWithHud) *intervalsWithHud = g_cIntervals.load(std::memory_order_relaxed);
+}
+
+void release_resources() {
+    if (g_srv) { g_srv->Release(); g_srv = nullptr; }
+    if (g_rtv) { g_rtv->Release(); g_rtv = nullptr; }
+    if (g_tex) { g_tex->Release(); g_tex = nullptr; }
+    g_texW = g_texH = 0;
+}
+
+} // namespace bvr::hud

--- a/src/core/gfx/hud_capture.cpp
+++ b/src/core/gfx/hud_capture.cpp
@@ -1,5 +1,6 @@
 #include "core/gfx/hud_capture.h"
 
+#include "core/gfx/blit.h"
 #include "core/util/log.h"
 
 #include <atomic>
@@ -14,11 +15,18 @@ std::atomic<bool> g_enabled{true};
 std::atomic<bool> g_force{false};
 std::atomic<bool> g_gate{false};
 
-// Our RT (created lazily to match the tonemap target's desc).
+// Our RT (created lazily to match the tonemap target's desc), plus the
+// PROCESSED copy: gameswf leaves garbage in the capture's alpha channel, so
+// consumers read RT2 = rgb unchanged + alpha repaired (blit::process) once
+// per interval.
 ID3D11Texture2D* g_tex = nullptr;
 ID3D11RenderTargetView* g_rtv = nullptr;
 ID3D11ShaderResourceView* g_srv = nullptr;
+ID3D11Texture2D* g_tex2 = nullptr;
+ID3D11RenderTargetView* g_rtv2 = nullptr;
+ID3D11ShaderResourceView* g_srv2 = nullptr;
 UINT g_texW = 0, g_texH = 0;
+bool g_processedThisInterval = false;
 
 // ---- per-interval classifier state ----------------------------------------
 // Current binding (tracked at SetRT; resources are identity keys only).
@@ -65,7 +73,10 @@ bool ensure_rt(ID3D11DeviceContext* ctx, UINT w, UINT h, DXGI_FORMAT fmt) {
     td.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
     bool ok = SUCCEEDED(dev->CreateTexture2D(&td, nullptr, &g_tex)) &&
               SUCCEEDED(dev->CreateRenderTargetView(g_tex, nullptr, &g_rtv)) &&
-              SUCCEEDED(dev->CreateShaderResourceView(g_tex, nullptr, &g_srv));
+              SUCCEEDED(dev->CreateShaderResourceView(g_tex, nullptr, &g_srv)) &&
+              SUCCEEDED(dev->CreateTexture2D(&td, nullptr, &g_tex2)) &&
+              SUCCEEDED(dev->CreateRenderTargetView(g_tex2, nullptr, &g_rtv2)) &&
+              SUCCEEDED(dev->CreateShaderResourceView(g_tex2, nullptr, &g_srv2));
     dev->Release();
     if (!ok) {
         release_resources();
@@ -182,6 +193,7 @@ void on_present(ID3D11DeviceContext* ctx) {
         ctx->ClearRenderTargetView(g_rtv, clear);
     }
     g_hudThisInterval = false;
+    g_processedThisInterval = false;
     g_hudTarget = nullptr;
     g_substituted = false;
     g_curRt = nullptr;
@@ -191,13 +203,19 @@ void on_present(ID3D11DeviceContext* ctx) {
 
 // Consumers (eye-capture-adjacent composite, quad copy) run in the present
 // chain BEFORE on_present() rolls the interval - so validity keys on the
-// CURRENT interval's redirects.
-ID3D11ShaderResourceView* srv() {
-    return g_hudThisInterval ? g_srv : nullptr;
+// CURRENT interval's redirects. Both accessors serve the PROCESSED copy
+// (alpha repaired), running the repair pass at most once per interval.
+ID3D11ShaderResourceView* srv(ID3D11DeviceContext* ctx) {
+    if (!g_hudThisInterval || !g_srv2) return nullptr;
+    if (!g_processedThisInterval && ctx) {
+        if (!bvr::blit::process(ctx, g_rtv2, g_srv, g_texW, g_texH)) return nullptr;
+        g_processedThisInterval = true;
+    }
+    return g_processedThisInterval ? g_srv2 : nullptr;
 }
 
-ID3D11Texture2D* texture() {
-    return g_hudThisInterval ? g_tex : nullptr;
+ID3D11Texture2D* texture(ID3D11DeviceContext* ctx) {
+    return srv(ctx) ? g_tex2 : nullptr;
 }
 
 bool redirected_this_interval() {
@@ -237,7 +255,11 @@ void release_resources() {
     if (g_srv) { g_srv->Release(); g_srv = nullptr; }
     if (g_rtv) { g_rtv->Release(); g_rtv = nullptr; }
     if (g_tex) { g_tex->Release(); g_tex = nullptr; }
+    if (g_srv2) { g_srv2->Release(); g_srv2 = nullptr; }
+    if (g_rtv2) { g_rtv2->Release(); g_rtv2 = nullptr; }
+    if (g_tex2) { g_tex2->Release(); g_tex2 = nullptr; }
     g_texW = g_texH = 0;
+    g_processedThisInterval = false;
 }
 
 } // namespace bvr::hud

--- a/src/core/gfx/hud_capture.h
+++ b/src/core/gfx/hud_capture.h
@@ -1,0 +1,70 @@
+// HUD capture (session 19, M8 "HUD usability"): redirect the game's gameswf
+// HUD draws into an offscreen RT so the eye captures come out HUD-free and
+// the RT can be shown as a floating quad in VR (openxr_runtime) and
+// composited back onto the flat window after the eye capture.
+//
+// THE FINGERPRINT (frame dump ground truth, session 19 - supersedes the
+// session-6 note, which had the DSV detail inverted for gameplay): the whole
+// HUD is drawn per PRESENT INTERVAL (both stereo eye passes) as a contiguous
+// run of NON-INDEXED Draw calls on the TONEMAP TARGET (backbuffer-sized
+// RGBA8, RTV|SRV) with the scene DSV still bound but depth-testing off,
+// through the gameswf batch flush (0x7B8EB5 in every stack). The tonemap
+// itself is the interval's FIRST non-indexed draw on that target and samples
+// the scene RT; the world renders exclusively via DrawIndexed. So:
+//
+//   scene RT   := the resource bound as rtv0 for the most DSV-bound
+//                 DrawIndexed calls this interval (vote counter)
+//   tonemap    := first non-indexed Draw on an LDR-1080 target whose srv0
+//                 is the scene-vote leader -> remember that target
+//   HUD draw   := any later non-indexed Draw on that same target
+//
+// The redirect substitutes our RTV (no DSV - gameswf never depth-tests) at
+// draw time; the game's next OMSetRenderTargets clears the substitution.
+// gameswf's own offscreen ping-pong RTs never match the tonemap target and
+// pass through untouched.
+
+#pragma once
+
+#include <d3d11.h>
+
+namespace bvr::hud {
+
+// Called from the frame_inspector detours (render thread, before forwarding).
+void on_setrt(UINT numViews, ID3D11RenderTargetView* const* rtvs,
+              ID3D11DepthStencilView* dsv);
+void on_draw_indexed();
+// Returns the RTV to substitute for this draw (bind it, no DSV), or null to
+// leave the game's binding alone. `ctx` is used to lazily create the RT and
+// to inspect srv0 for the tonemap check.
+ID3D11RenderTargetView* on_draw(ID3D11DeviceContext* ctx);
+
+// Present boundary (render thread, called at the END of the present detour,
+// after every consumer of the RT ran): clears the RT for the next interval
+// and rolls the per-interval classifier state.
+void on_present(ID3D11DeviceContext* ctx);
+
+// The captured HUD as a shader resource (null when nothing was redirected
+// this interval or the RT does not exist). Same thread as the consumers.
+ID3D11ShaderResourceView* srv();
+ID3D11Texture2D* texture();
+bool redirected_this_interval();
+
+// Master enable (the redirect only runs while enabled AND gated).
+void set_enabled(bool on);
+bool enabled();
+// Render-side gate published once per present by the VR runtime: true while
+// stereo gameplay frames flow (projectionMode && srSign != 0). The `force`
+// override arms the redirect with no XR session - REQUIRED for flat testing
+// (projectionReady can never be true without a headset).
+void set_gate(bool stereoActive);
+void set_force(bool on);
+bool force();
+
+// Telemetry for `vrhud status` (per second, reset on read... no - lifetime).
+void get_counters(unsigned* hudDraws, unsigned* redirects, unsigned* leaks,
+                  unsigned* intervalsWithHud);
+
+// Free device objects (device loss / resize; recreated lazily).
+void release_resources();
+
+} // namespace bvr::hud

--- a/src/core/gfx/hud_capture.h
+++ b/src/core/gfx/hud_capture.h
@@ -33,10 +33,17 @@ namespace bvr::hud {
 void on_setrt(UINT numViews, ID3D11RenderTargetView* const* rtvs,
               ID3D11DepthStencilView* dsv);
 void on_draw_indexed();
-// Returns the RTV to substitute for this draw (bind it, no DSV), or null to
-// leave the game's binding alone. `ctx` is used to lazily create the RT and
-// to inspect srv0 for the tonemap check.
+// Returns the RTV to substitute for this draw (bind it together with
+// capture_dsv() - gameswf masks stencil against it), or null to leave the
+// game's binding alone. `ctx` is used to lazily create the RT and to inspect
+// srv0 for the tonemap check.
 ID3D11RenderTargetView* on_draw(ID3D11DeviceContext* ctx);
+// Our depth-stencil for redirected draws (flash masks are stencil-based).
+ID3D11DepthStencilView* capture_dsv();
+// Swap the bound blend state for its alpha-corrected variant (gameswf states
+// accumulate garbage coverage in the alpha channel; the variant fixes only
+// the alpha ops). Call after binding the substitution, before the draw.
+void fix_blend_alpha(ID3D11DeviceContext* ctx);
 
 // Present boundary (render thread, called at the END of the present detour,
 // after every consumer of the RT ran): clears the RT for the next interval

--- a/src/core/gfx/hud_capture.h
+++ b/src/core/gfx/hud_capture.h
@@ -44,9 +44,12 @@ ID3D11RenderTargetView* on_draw(ID3D11DeviceContext* ctx);
 void on_present(ID3D11DeviceContext* ctx);
 
 // The captured HUD as a shader resource (null when nothing was redirected
-// this interval or the RT does not exist). Same thread as the consumers.
-ID3D11ShaderResourceView* srv();
-ID3D11Texture2D* texture();
+// this interval or the RT does not exist). Serves the PROCESSED copy - rgb
+// premultiplied by construction, alpha repaired via blit::process (run at
+// most once per interval; `ctx` may be null to only query). Same thread as
+// the consumers.
+ID3D11ShaderResourceView* srv(ID3D11DeviceContext* ctx);
+ID3D11Texture2D* texture(ID3D11DeviceContext* ctx);
 bool redirected_this_interval();
 
 // Master enable (the redirect only runs while enabled AND gated).

--- a/src/core/hooks/d3d11_hook.cpp
+++ b/src/core/hooks/d3d11_hook.cpp
@@ -1,6 +1,7 @@
 #include "d3d11_hook.h"
 
 #include "core/gfx/frame_inspector.h"
+#include "core/gfx/hud_capture.h"
 #include "core/ui/overlay.h"
 #include "core/util/log.h"
 #include "core/vr/openxr_runtime.h"
@@ -77,6 +78,21 @@ HRESULT WINAPI PresentDetour(IDXGISwapChain* swapchain, UINT syncInterval, UINT 
     vr::on_present_begin(swapchain); // xrWaitFrame paces the game while a session runs
     overlay::on_present(swapchain);
     vr::on_present_end(swapchain);   // copies the finished frame (incl. overlay) to the quad
+    // HUD capture rolls LAST: every consumer of the redirected HUD RT (eye
+    // capture, window composite, quad copy - all inside on_present_end) has
+    // run by now; this clears the RT and resets the interval classifier.
+    {
+        ID3D11Device* device = nullptr;
+        if (SUCCEEDED(swapchain->GetDevice(IID_PPV_ARGS(&device))) && device) {
+            ID3D11DeviceContext* context = nullptr;
+            device->GetImmediateContext(&context);
+            if (context) {
+                hud::on_present(context);
+                context->Release();
+            }
+            device->Release();
+        }
+    }
     return g_origPresent(swapchain, syncInterval, flags);
 }
 
@@ -85,6 +101,7 @@ HRESULT WINAPI ResizeBuffersDetour(IDXGISwapChain* swapchain, UINT bufferCount,
                                    UINT swapchainFlags) {
     vr::on_resize();
     overlay::on_resize();
+    hud::release_resources(); // recreated lazily at the new size
     HRESULT hr = g_origResizeBuffers(swapchain, bufferCount, width, height, format, swapchainFlags);
     BVR_LOG("ResizeBuffers: %ux%u format %u -> hr=0x%08X", width, height, format, hr);
     return hr;

--- a/src/core/input/xinput_bridge.cpp
+++ b/src/core/input/xinput_bridge.cpp
@@ -39,6 +39,18 @@ uint64_t g_xrLastMs = 0;          // publish staleness guard (session teardown
                                   // stops publishing entirely - expire the slot)
 constexpr uint64_t kXrStaleMs = 500;
 
+// Stick-pitch kill (session 19): while the VR camera drives a real gameplay
+// view, the composed right-stick Y is zeroed - the HMD owns pitch there, and
+// a stick-pitched body drags the viewmodel with it and aims the wrench's
+// melee phantom at the body pitch instead of the hand. The game layer
+// publishes the gate once per CalcView; the slot self-expires like the XR pad
+// so a stopped publisher (world unload, drive off) fails open to stock
+// behavior. Menus/cutscenes publish false and keep stick pitch.
+std::atomic<bool> g_pitchKill{true};
+std::atomic<bool> g_vrGameplay{false};
+std::atomic<uint64_t> g_vrGameplayLastMs{0};
+constexpr uint64_t kVrGameplayStaleMs = 500;
+
 // Self-expiring test slots: the command seam polls at 1 Hz, so a "hold" must
 // outlive its command inside the DLL. deadline == 0 means empty.
 struct TimedStick { int16_t x = 0, y = 0; uint64_t deadline = 0; };
@@ -181,6 +193,12 @@ void compose_over(DWORD userIndex, XINPUT_STATE* xs, DWORD* result) {
     uint64_t now = GetTickCount64();
     std::lock_guard<std::mutex> lock(g_mutex);
     Gamepad out = merge(real, compose_synthetic(now));
+    // Stick-pitch kill: yaw (rx) deliberately stays - stick turn composes
+    // with the M7.5 body transfer; only pitch belongs to the HMD.
+    if (g_pitchKill.load(std::memory_order_relaxed) &&
+        g_vrGameplay.load(std::memory_order_relaxed) &&
+        now - g_vrGameplayLastMs.load(std::memory_order_relaxed) <= kVrGameplayStaleMs)
+        out.ry = 0;
     if (g_packetBump || memcmp(&out, &g_lastComposed, sizeof out) != 0) {
         ++g_packet;
         g_packetBump = false;
@@ -468,6 +486,21 @@ void publish_xr_state(const Gamepad& pad, bool active) {
     g_xrLastMs = GetTickCount64();
 }
 
+void publish_vr_gameplay(bool on) {
+    g_vrGameplay.store(on, std::memory_order_relaxed);
+    g_vrGameplayLastMs.store(GetTickCount64(), std::memory_order_relaxed);
+}
+
+void set_pitch_kill(bool on) {
+    bool was = g_pitchKill.exchange(on, std::memory_order_relaxed);
+    if (was != on)
+        BVR_LOG("input: pitchkill %s (right-stick Y %s while the VR camera "
+                "drives gameplay)",
+                on ? "ON" : "off", on ? "zeroed" : "passes through");
+}
+
+bool pitch_kill() { return g_pitchKill.load(std::memory_order_relaxed); }
+
 float stick_deadzone() { return g_deadzone.load(std::memory_order_relaxed); }
 
 void last_composed_triggers(uint8_t* lt, uint8_t* rt) {
@@ -498,6 +531,19 @@ void handle_command(const char* args) {
         set_enabled(false);
     } else if (strcmp(verb, "status") == 0) {
         log_status();
+    } else if (strcmp(verb, "pitchkill") == 0) {
+        if (strncmp(rest, "on", 2) == 0) {
+            set_pitch_kill(true);
+        } else if (strncmp(rest, "off", 3) == 0) {
+            set_pitch_kill(false);
+        } else {
+            uint64_t age = GetTickCount64() -
+                           g_vrGameplayLastMs.load(std::memory_order_relaxed);
+            BVR_LOG("input: pitchkill %s, vr-gameplay gate %s (published %llu ms ago)",
+                    g_pitchKill.load(std::memory_order_relaxed) ? "ON" : "off",
+                    g_vrGameplay.load(std::memory_order_relaxed) ? "ACTIVE" : "inactive",
+                    static_cast<unsigned long long>(age));
+        }
     } else if (strcmp(verb, "test") == 0) {
         char what[16] = {};
         consumed = 0;
@@ -578,6 +624,10 @@ void draw_debug_ui() {
     float dz = g_deadzone.load(std::memory_order_relaxed);
     if (ImGui::SliderFloat("Stick deadzone", &dz, 0.0f, 0.4f, "%.2f"))
         g_deadzone.store(dz, std::memory_order_relaxed);
+
+    bool pk = g_pitchKill.load(std::memory_order_relaxed);
+    if (ImGui::Checkbox("Kill right-stick pitch under VR", &pk))
+        set_pitch_kill(pk);
 
     // GetState poll rate, sampled ~1/s (render thread only).
     static uint64_t lastMs = 0;

--- a/src/core/input/xinput_bridge.cpp
+++ b/src/core/input/xinput_bridge.cpp
@@ -194,10 +194,16 @@ void compose_over(DWORD userIndex, XINPUT_STATE* xs, DWORD* result) {
     std::lock_guard<std::mutex> lock(g_mutex);
     Gamepad out = merge(real, compose_synthetic(now));
     // Stick-pitch kill: yaw (rx) deliberately stays - stick turn composes
-    // with the M7.5 body transfer; only pitch belongs to the HMD.
+    // with the M7.5 body transfer; only pitch belongs to the HMD. The kill
+    // LIFTS while a grip/bumper is held: the radial wheels read stick Y for
+    // selection (session 19 part 2 - the wheel was unselectable). The game
+    // side snapshots the PC pitch at bumper-down and restores it at release,
+    // so the look-pitch the wheel state also accumulates cannot stick.
     if (g_pitchKill.load(std::memory_order_relaxed) &&
         g_vrGameplay.load(std::memory_order_relaxed) &&
-        now - g_vrGameplayLastMs.load(std::memory_order_relaxed) <= kVrGameplayStaleMs)
+        now - g_vrGameplayLastMs.load(std::memory_order_relaxed) <= kVrGameplayStaleMs &&
+        !(out.buttons &
+          (XINPUT_GAMEPAD_LEFT_SHOULDER | XINPUT_GAMEPAD_RIGHT_SHOULDER)))
         out.ry = 0;
     if (g_packetBump || memcmp(&out, &g_lastComposed, sizeof out) != 0) {
         ++g_packet;

--- a/src/core/input/xinput_bridge.h
+++ b/src/core/input/xinput_bridge.h
@@ -32,6 +32,18 @@ bool enabled();
 // focused); the slot also self-expires if publishing stops entirely.
 void publish_xr_state(const Gamepad& pad, bool active);
 
+// The game layer publishes "the VR camera is driving a REAL gameplay view"
+// once per frame (CalcView; strict predicate - menus/cutscenes publish
+// false). While true and pitchkill is on, the composed right-stick Y is
+// zeroed: under VR the HMD owns pitch, and a stick-pitched body drags the
+// viewmodel and the melee phantom with it (session 19). Self-expires if
+// publishing stops, failing open to stock behavior.
+void publish_vr_gameplay(bool on);
+
+// Master toggle for the stick-pitch kill (default ON; `vrinput pitchkill`).
+void set_pitch_kill(bool on);
+bool pitch_kill();
+
 // Radial stick deadzone (fraction 0..0.5) applied by the XR composer.
 float stick_deadzone();
 
@@ -56,6 +68,7 @@ bool hijack_import_slot(void** slot);
 
 // Seam command handler: args after the "vrinput" verb (game thread).
 //   on | off | status
+//   pitchkill on|off|status
 //   test stick l|r <x> <y> [holdMs]   raw -32768..32767
 //   test trig  l|r <0..255> [holdMs]
 //   test press <A|B|X|Y|LB|RB|START|BACK|LS|RS|DU|DD|DL|DR> [holdMs]

--- a/src/core/vr/openxr_input.cpp
+++ b/src/core/vr/openxr_input.cpp
@@ -29,13 +29,11 @@ constexpr uint64_t kStartPulseMs = 150;
 // Ammo-slot select (session 19, headset-revised): while the right-stick
 // CLICK is held, stick directions past kFlickPress select the ammo slot
 // (dpad up/down/left pulses); re-arm inside +-kFlickRearm, cooldown against
-// machine-gunning. A click-tap shorter than kZoomTapMs with no selection
-// still pulses RS-click (the game's zoom).
+// machine-gunning. Zoom is removed - RS-click never reaches the game.
 constexpr float kFlickPress = 0.65f;
 constexpr float kFlickRearm = 0.30f;
 constexpr uint64_t kFlickPulseMs = 150;
 constexpr uint64_t kFlickCooldownMs = 300;
-constexpr uint64_t kZoomTapMs = 400;
 
 XrActionSet g_actionSet = XR_NULL_HANDLE;
 
@@ -77,9 +75,7 @@ bool g_flickArmed = true;
 uint16_t g_flickPulseBit = 0;
 uint64_t g_flickPulseUntilMs = 0;
 uint64_t g_flickCooldownMs = 0;
-uint64_t g_rsClickDownMs = 0;   // 0 = stick click not held
-bool g_rsClickConsumed = false; // a slot was selected during this hold
-uint64_t g_zoomPulseUntilMs = 0;
+bool g_rsClickWasDown = false;
 
 // M6 hand poses. Located on the render thread in input_sync; read from the
 // GAME thread by the adapter's aim path, so publish through atomics-guarded
@@ -418,27 +414,24 @@ void input_sync(XrSession session, XrTime predictedDisplayTime) {
 
     uint64_t now = GetTickCount64();
 
-    // Ammo-slot select (session 19, revised by the headset run): the three
-    // ammo types sit on dpad UP / DOWN / LEFT (each direction SELECTS its
-    // slot - flat-proven CallHudFunction handlers), so a two-direction
-    // flick could only reach two of them. New scheme: HOLD the right-stick
+    // Ammo-slot select (session 19, revised twice by headset runs): the
+    // three ammo types sit on dpad UP / DOWN / LEFT (each direction SELECTS
+    // its slot - flat-proven CallHudFunction handlers). HOLD the right-stick
     // CLICK as a modifier - stick directions then select the slot (dpad
-    // up/down/left pulses) and turning is suppressed; a QUICK click-release
-    // with no selection still pulses RS-click = the game's zoom, so nothing
-    // is lost. Direction reads the PRE-deadzone stick; the re-arm band
-    // allows several selects in one hold; grips suppress it (the radials
-    // read the stick).
+    // pulses) and turning is suppressed. ZOOM IS GONE by the user's call
+    // (a FOV zoom inside an HMD is a comfort hazard and nothing requires
+    // it), so the click is purely the ammo modifier and RS-click never
+    // reaches the game. Direction reads the PRE-deadzone stick; the re-arm
+    // band allows several selects in one hold; grips suppress it (the
+    // radials read the stick).
     {
         float rawX = 0.0f, rawY = 0.0f;
         read_vec2(session, g_look, &rawX, &rawY);
         bool rsClick = read_bool(session, g_stickClickR);
         bool gripHeld = g_gripLatchedL || g_gripLatchedR;
 
-        if (rsClick && g_rsClickDownMs == 0) {
-            g_rsClickDownMs = now;
-            g_rsClickConsumed = false;
-            g_flickArmed = true;
-        }
+        if (rsClick && !g_rsClickWasDown) g_flickArmed = true;
+        g_rsClickWasDown = rsClick;
         if (rsClick && !gripHeld) {
             // Modifier held: the stick selects, the game sees no turn.
             pad.rx = 0;
@@ -453,21 +446,13 @@ void input_sync(XrSession session, XrTime predictedDisplayTime) {
                     g_flickPulseUntilMs = now + kFlickPulseMs;
                     g_flickCooldownMs = now + kFlickCooldownMs;
                     g_flickArmed = false;
-                    g_rsClickConsumed = true;
                 }
             }
             if (rawX > -kFlickRearm && rawX < kFlickRearm && rawY > -kFlickRearm &&
                 rawY < kFlickRearm)
                 g_flickArmed = true;
         }
-        if (!rsClick && g_rsClickDownMs != 0) {
-            // Quick tap with no selection = the original zoom click.
-            if (!g_rsClickConsumed && now - g_rsClickDownMs < kZoomTapMs)
-                g_zoomPulseUntilMs = now + kFlickPulseMs;
-            g_rsClickDownMs = 0;
-        }
         if (now < g_flickPulseUntilMs) pad.buttons |= g_flickPulseBit;
-        if (now < g_zoomPulseUntilMs) pad.buttons |= XINPUT_GAMEPAD_RIGHT_THUMB;
     }
 
     // Left menu: short press pulses START on release, holding it past the

--- a/src/core/vr/openxr_input.cpp
+++ b/src/core/vr/openxr_input.cpp
@@ -26,13 +26,16 @@ constexpr float kGripRelease = 0.55f;
 // the game's per-tick edge detection cannot miss it.
 constexpr uint64_t kMenuLongMs = 500;
 constexpr uint64_t kStartPulseMs = 150;
-// Right-stick Y flick -> ammo-type cycle (session 19): press past kFlickPress,
-// re-arm inside +-kFlickRearm, pulse the dpad bit long enough for the game's
-// per-tick edge detection, cooldown so a held stick cannot machine-gun cycle.
+// Ammo-slot select (session 19, headset-revised): while the right-stick
+// CLICK is held, stick directions past kFlickPress select the ammo slot
+// (dpad up/down/left pulses); re-arm inside +-kFlickRearm, cooldown against
+// machine-gunning. A click-tap shorter than kZoomTapMs with no selection
+// still pulses RS-click (the game's zoom).
 constexpr float kFlickPress = 0.65f;
 constexpr float kFlickRearm = 0.30f;
 constexpr uint64_t kFlickPulseMs = 150;
 constexpr uint64_t kFlickCooldownMs = 300;
+constexpr uint64_t kZoomTapMs = 400;
 
 XrActionSet g_actionSet = XR_NULL_HANDLE;
 
@@ -74,6 +77,9 @@ bool g_flickArmed = true;
 uint16_t g_flickPulseBit = 0;
 uint64_t g_flickPulseUntilMs = 0;
 uint64_t g_flickCooldownMs = 0;
+uint64_t g_rsClickDownMs = 0;   // 0 = stick click not held
+bool g_rsClickConsumed = false; // a slot was selected during this hold
+uint64_t g_zoomPulseUntilMs = 0;
 
 // M6 hand poses. Located on the render thread in input_sync; read from the
 // GAME thread by the adapter's aim path, so publish through atomics-guarded
@@ -396,48 +402,72 @@ void input_sync(XrSession session, XrTime predictedDisplayTime) {
     if (g_gripLatchedL) pad.buttons |= XINPUT_GAMEPAD_LEFT_SHOULDER;
     if (g_gripLatchedR) pad.buttons |= XINPUT_GAMEPAD_RIGHT_SHOULDER;
 
-    // Session 19 controls audit: the game's own pad layout (User.ini XENON_*)
-    // is A=Use, B=MedHypo heal, X=Reload/Hack/EVE, Y=Jump. VR convention puts
-    // JUMP on the lower-right face button, so the face buttons re-route:
-    //   Touch A (right lower) -> XInput Y  = jump
-    //   Touch B (right upper) -> XInput A  = use / interact
+    // Session 19 controls audit (revised by the headset run): the game's own
+    // pad layout (User.ini XENON_*) is A=Use, B=MedHypo heal, X=Reload/Hack/
+    // EVE, Y=Jump. The user's verdict: A must STAY use/loot (it is also the
+    // menu confirm button), jump goes to B:
+    //   Touch A (right lower) -> XInput A  = use / interact / menu confirm
+    //   Touch B (right upper) -> XInput Y  = jump
     //   Touch X (left  lower) -> XInput X  = reload / hack / EVE inject
     //   Touch Y (left  upper) -> XInput B  = first-aid (med hypo)
-    if (read_bool(session, g_btnA)) pad.buttons |= XINPUT_GAMEPAD_Y;
-    if (read_bool(session, g_btnB)) pad.buttons |= XINPUT_GAMEPAD_A;
+    if (read_bool(session, g_btnA)) pad.buttons |= XINPUT_GAMEPAD_A;
+    if (read_bool(session, g_btnB)) pad.buttons |= XINPUT_GAMEPAD_Y;
     if (read_bool(session, g_btnX)) pad.buttons |= XINPUT_GAMEPAD_X;
     if (read_bool(session, g_btnY)) pad.buttons |= XINPUT_GAMEPAD_B;
     if (read_bool(session, g_stickClickL)) pad.buttons |= XINPUT_GAMEPAD_LEFT_THUMB;
-    if (read_bool(session, g_stickClickR)) pad.buttons |= XINPUT_GAMEPAD_RIGHT_THUMB;
 
     uint64_t now = GetTickCount64();
 
-    // Right-stick Y flicks -> ammo-type cycling (session 19): the game's
-    // DPAD_UP/DOWN CallHudFunction handlers cycle the equipped weapon's ammo
-    // (flat-proven), the composed right-stick Y is freed by the stick-pitch
-    // kill, and Touch has no dpad. Rising-edge detection with a re-arm band
-    // and a cooldown; suppressed while a grip is held (the radial menus read
-    // the stick for selection there). Uses the PRE-deadzone value - flicks
-    // must work regardless of the user's deadzone tuning.
+    // Ammo-slot select (session 19, revised by the headset run): the three
+    // ammo types sit on dpad UP / DOWN / LEFT (each direction SELECTS its
+    // slot - flat-proven CallHudFunction handlers), so a two-direction
+    // flick could only reach two of them. New scheme: HOLD the right-stick
+    // CLICK as a modifier - stick directions then select the slot (dpad
+    // up/down/left pulses) and turning is suppressed; a QUICK click-release
+    // with no selection still pulses RS-click = the game's zoom, so nothing
+    // is lost. Direction reads the PRE-deadzone stick; the re-arm band
+    // allows several selects in one hold; grips suppress it (the radials
+    // read the stick).
     {
-        float rawY = 0.0f, rawX = 0.0f;
+        float rawX = 0.0f, rawY = 0.0f;
         read_vec2(session, g_look, &rawX, &rawY);
+        bool rsClick = read_bool(session, g_stickClickR);
         bool gripHeld = g_gripLatchedL || g_gripLatchedR;
-        if (!gripHeld && now >= g_flickCooldownMs) {
-            if (rawY >= kFlickPress && g_flickArmed) {
-                g_flickPulseBit = XINPUT_GAMEPAD_DPAD_UP;
-                g_flickPulseUntilMs = now + kFlickPulseMs;
-                g_flickCooldownMs = now + kFlickCooldownMs;
-                g_flickArmed = false;
-            } else if (rawY <= -kFlickPress && g_flickArmed) {
-                g_flickPulseBit = XINPUT_GAMEPAD_DPAD_DOWN;
-                g_flickPulseUntilMs = now + kFlickPulseMs;
-                g_flickCooldownMs = now + kFlickCooldownMs;
-                g_flickArmed = false;
-            }
+
+        if (rsClick && g_rsClickDownMs == 0) {
+            g_rsClickDownMs = now;
+            g_rsClickConsumed = false;
+            g_flickArmed = true;
         }
-        if (rawY > -kFlickRearm && rawY < kFlickRearm) g_flickArmed = true;
+        if (rsClick && !gripHeld) {
+            // Modifier held: the stick selects, the game sees no turn.
+            pad.rx = 0;
+            pad.ry = 0;
+            if (g_flickArmed && now >= g_flickCooldownMs) {
+                uint16_t bit = 0;
+                if (rawY >= kFlickPress) bit = XINPUT_GAMEPAD_DPAD_UP;
+                else if (rawY <= -kFlickPress) bit = XINPUT_GAMEPAD_DPAD_DOWN;
+                else if (rawX <= -kFlickPress) bit = XINPUT_GAMEPAD_DPAD_LEFT;
+                if (bit) {
+                    g_flickPulseBit = bit;
+                    g_flickPulseUntilMs = now + kFlickPulseMs;
+                    g_flickCooldownMs = now + kFlickCooldownMs;
+                    g_flickArmed = false;
+                    g_rsClickConsumed = true;
+                }
+            }
+            if (rawX > -kFlickRearm && rawX < kFlickRearm && rawY > -kFlickRearm &&
+                rawY < kFlickRearm)
+                g_flickArmed = true;
+        }
+        if (!rsClick && g_rsClickDownMs != 0) {
+            // Quick tap with no selection = the original zoom click.
+            if (!g_rsClickConsumed && now - g_rsClickDownMs < kZoomTapMs)
+                g_zoomPulseUntilMs = now + kFlickPulseMs;
+            g_rsClickDownMs = 0;
+        }
         if (now < g_flickPulseUntilMs) pad.buttons |= g_flickPulseBit;
+        if (now < g_zoomPulseUntilMs) pad.buttons |= XINPUT_GAMEPAD_RIGHT_THUMB;
     }
 
     // Left menu: short press pulses START on release, holding it past the

--- a/src/core/vr/openxr_input.cpp
+++ b/src/core/vr/openxr_input.cpp
@@ -26,6 +26,13 @@ constexpr float kGripRelease = 0.55f;
 // the game's per-tick edge detection cannot miss it.
 constexpr uint64_t kMenuLongMs = 500;
 constexpr uint64_t kStartPulseMs = 150;
+// Right-stick Y flick -> ammo-type cycle (session 19): press past kFlickPress,
+// re-arm inside +-kFlickRearm, pulse the dpad bit long enough for the game's
+// per-tick edge detection, cooldown so a held stick cannot machine-gun cycle.
+constexpr float kFlickPress = 0.65f;
+constexpr float kFlickRearm = 0.30f;
+constexpr uint64_t kFlickPulseMs = 150;
+constexpr uint64_t kFlickCooldownMs = 300;
 
 XrActionSet g_actionSet = XR_NULL_HANDLE;
 
@@ -63,6 +70,10 @@ bool g_gripLatchedL = false;
 bool g_gripLatchedR = false;
 uint64_t g_menuDownMs = 0;
 uint64_t g_startPulseUntilMs = 0;
+bool g_flickArmed = true;
+uint16_t g_flickPulseBit = 0;
+uint64_t g_flickPulseUntilMs = 0;
+uint64_t g_flickCooldownMs = 0;
 
 // M6 hand poses. Located on the render thread in input_sync; read from the
 // GAME thread by the adapter's aim path, so publish through atomics-guarded
@@ -385,16 +396,52 @@ void input_sync(XrSession session, XrTime predictedDisplayTime) {
     if (g_gripLatchedL) pad.buttons |= XINPUT_GAMEPAD_LEFT_SHOULDER;
     if (g_gripLatchedR) pad.buttons |= XINPUT_GAMEPAD_RIGHT_SHOULDER;
 
-    if (read_bool(session, g_btnA)) pad.buttons |= XINPUT_GAMEPAD_A;
-    if (read_bool(session, g_btnB)) pad.buttons |= XINPUT_GAMEPAD_B;
+    // Session 19 controls audit: the game's own pad layout (User.ini XENON_*)
+    // is A=Use, B=MedHypo heal, X=Reload/Hack/EVE, Y=Jump. VR convention puts
+    // JUMP on the lower-right face button, so the face buttons re-route:
+    //   Touch A (right lower) -> XInput Y  = jump
+    //   Touch B (right upper) -> XInput A  = use / interact
+    //   Touch X (left  lower) -> XInput X  = reload / hack / EVE inject
+    //   Touch Y (left  upper) -> XInput B  = first-aid (med hypo)
+    if (read_bool(session, g_btnA)) pad.buttons |= XINPUT_GAMEPAD_Y;
+    if (read_bool(session, g_btnB)) pad.buttons |= XINPUT_GAMEPAD_A;
     if (read_bool(session, g_btnX)) pad.buttons |= XINPUT_GAMEPAD_X;
-    if (read_bool(session, g_btnY)) pad.buttons |= XINPUT_GAMEPAD_Y;
+    if (read_bool(session, g_btnY)) pad.buttons |= XINPUT_GAMEPAD_B;
     if (read_bool(session, g_stickClickL)) pad.buttons |= XINPUT_GAMEPAD_LEFT_THUMB;
     if (read_bool(session, g_stickClickR)) pad.buttons |= XINPUT_GAMEPAD_RIGHT_THUMB;
 
+    uint64_t now = GetTickCount64();
+
+    // Right-stick Y flicks -> ammo-type cycling (session 19): the game's
+    // DPAD_UP/DOWN CallHudFunction handlers cycle the equipped weapon's ammo
+    // (flat-proven), the composed right-stick Y is freed by the stick-pitch
+    // kill, and Touch has no dpad. Rising-edge detection with a re-arm band
+    // and a cooldown; suppressed while a grip is held (the radial menus read
+    // the stick for selection there). Uses the PRE-deadzone value - flicks
+    // must work regardless of the user's deadzone tuning.
+    {
+        float rawY = 0.0f, rawX = 0.0f;
+        read_vec2(session, g_look, &rawX, &rawY);
+        bool gripHeld = g_gripLatchedL || g_gripLatchedR;
+        if (!gripHeld && now >= g_flickCooldownMs) {
+            if (rawY >= kFlickPress && g_flickArmed) {
+                g_flickPulseBit = XINPUT_GAMEPAD_DPAD_UP;
+                g_flickPulseUntilMs = now + kFlickPulseMs;
+                g_flickCooldownMs = now + kFlickCooldownMs;
+                g_flickArmed = false;
+            } else if (rawY <= -kFlickPress && g_flickArmed) {
+                g_flickPulseBit = XINPUT_GAMEPAD_DPAD_DOWN;
+                g_flickPulseUntilMs = now + kFlickPulseMs;
+                g_flickCooldownMs = now + kFlickCooldownMs;
+                g_flickArmed = false;
+            }
+        }
+        if (rawY > -kFlickRearm && rawY < kFlickRearm) g_flickArmed = true;
+        if (now < g_flickPulseUntilMs) pad.buttons |= g_flickPulseBit;
+    }
+
     // Left menu: short press pulses START on release, holding it past the
     // threshold holds BACK until release.
-    uint64_t now = GetTickCount64();
     bool menuDown = read_bool(session, g_menu);
     if (menuDown) {
         if (g_menuDownMs == 0) g_menuDownMs = now;

--- a/src/core/vr/openxr_runtime.cpp
+++ b/src/core/vr/openxr_runtime.cpp
@@ -6,6 +6,7 @@
 
 #include "core/vr/openxr_runtime.h"
 
+#include "core/gfx/blit.h"
 #include "core/gfx/hud_capture.h"
 #include "core/util/log.h"
 
@@ -76,6 +77,23 @@ std::atomic<bool> g_enabled{true};        // kill switch: tears the session down
 std::atomic<float> g_screenDistM{1.75f};  // quad distance in meters
 std::atomic<float> g_screenWidthM{2.4f};  // quad width in meters
 std::atomic<bool> g_cameraMode{false};    // M3: drive the game camera from the HMD
+
+// Session 19 HUD floating quad: the gameswf HUD captured by core/gfx/
+// hud_capture is copied into its own swapchain and composited head-locked
+// (g_viewSpace) during stereo gameplay. Sliders persist via vrpreset.ini.
+XrSwapchain g_hudSwapchain = XR_NULL_HANDLE;
+std::vector<XrSwapchainImageD3D11KHR> g_hudImages;
+uint32_t g_hudSwapW = 0, g_hudSwapH = 0;
+int64_t g_swapFormat = 0; // the format create_swapchains picked (lazy HUD create)
+std::atomic<float> g_hudDistM{1.30f};
+std::atomic<float> g_hudWidthM{1.25f};
+std::atomic<float> g_hudUpM{-0.10f};
+std::atomic<uint32_t> g_hudFramesSubmitted{0};
+std::atomic<bool> g_loggedFirstHudQuad{false};
+
+// Cached backbuffer RTV for the post-capture window HUD composite.
+ID3D11RenderTargetView* g_backbufferRtv = nullptr;
+ID3D11Texture2D* g_backbufferForRtv = nullptr; // identity only, never deref'd
 
 // Bring-up retry (render thread only).
 uint64_t g_nextRetryMs = 0;
@@ -337,6 +355,15 @@ void destroy_laser() {
     }
 }
 
+void destroy_hud_swapchain() {
+    if (g_hudSwapchain != XR_NULL_HANDLE) {
+        xrDestroySwapchain(g_hudSwapchain);
+        g_hudSwapchain = XR_NULL_HANDLE;
+    }
+    g_hudImages.clear();
+    g_hudSwapW = g_hudSwapH = 0;
+}
+
 void destroy_swapchains() {
     for (int i = 0; i < 2; ++i) {
         if (g_swapchains[i] != XR_NULL_HANDLE) {
@@ -346,8 +373,83 @@ void destroy_swapchains() {
         g_images[i].clear();
     }
     destroy_laser();
+    destroy_hud_swapchain();
     g_swapW = g_swapH = 0;
     reset_aer(); // the held eye images died with the swapchains
+}
+
+// Lazy: sized to the HUD capture RT, format = the eye swapchains' pick
+// (CopyResource-compatible UNORM/sRGB family).
+void create_hud_swapchain(uint32_t w, uint32_t h) {
+    destroy_hud_swapchain();
+    if (!g_swapFormat || g_session == XR_NULL_HANDLE) return;
+    XrSwapchainCreateInfo sci{XR_TYPE_SWAPCHAIN_CREATE_INFO};
+    sci.usageFlags = XR_SWAPCHAIN_USAGE_SAMPLED_BIT | XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT;
+    sci.format = g_swapFormat;
+    sci.sampleCount = 1;
+    sci.width = w;
+    sci.height = h;
+    sci.faceCount = 1;
+    sci.arraySize = 1;
+    sci.mipCount = 1;
+    if (XR_FAILED(xrCreateSwapchain(g_session, &sci, &g_hudSwapchain))) {
+        BVR_LOG("xr: HUD swapchain creation failed");
+        g_hudSwapchain = XR_NULL_HANDLE;
+        return;
+    }
+    uint32_t count = 0;
+    xrEnumerateSwapchainImages(g_hudSwapchain, 0, &count, nullptr);
+    g_hudImages.assign(count, {XR_TYPE_SWAPCHAIN_IMAGE_D3D11_KHR});
+    if (XR_FAILED(xrEnumerateSwapchainImages(
+            g_hudSwapchain, count, &count,
+            reinterpret_cast<XrSwapchainImageBaseHeader*>(g_hudImages.data())))) {
+        BVR_LOG("xr: HUD swapchain image enumeration failed");
+        destroy_hud_swapchain();
+        return;
+    }
+    g_hudSwapW = w;
+    g_hudSwapH = h;
+    BVR_LOG("xr: HUD quad swapchain ready (%ux%u, %u images)", w, h, count);
+}
+
+// Post-capture window composite: draw the captured HUD back onto the
+// backbuffer so the FLAT window keeps its HUD while the compositor feed
+// stays clean. Runs at most once per present, always AFTER the eye capture
+// and AFTER the mirror's right-half re-blit. Uses the swapchain's own
+// device/context so it also works with no XR session (flat testing).
+void composite_hud(IDXGISwapChain* swapchain) {
+    if (!bvr::hud::redirected_this_interval()) return;
+    ID3D11Texture2D* bb = nullptr;
+    if (FAILED(swapchain->GetBuffer(0, IID_PPV_ARGS(&bb))) || !bb) return;
+    if (g_backbufferRtv && g_backbufferForRtv != bb) {
+        g_backbufferRtv->Release();
+        g_backbufferRtv = nullptr;
+    }
+    ID3D11Device* dev = nullptr;
+    swapchain->GetDevice(IID_PPV_ARGS(&dev));
+    if (!dev) {
+        bb->Release();
+        return;
+    }
+    if (!g_backbufferRtv) {
+        if (FAILED(dev->CreateRenderTargetView(bb, nullptr, &g_backbufferRtv))) {
+            dev->Release();
+            bb->Release();
+            return;
+        }
+        g_backbufferForRtv = bb;
+    }
+    D3D11_TEXTURE2D_DESC d{};
+    bb->GetDesc(&d);
+    ID3D11DeviceContext* ctx = nullptr;
+    dev->GetImmediateContext(&ctx);
+    if (ctx) {
+        ID3D11ShaderResourceView* srv = bvr::hud::srv(ctx); // alpha-repaired copy
+        if (srv) bvr::blit::alpha_premul(ctx, g_backbufferRtv, srv, d.Width, d.Height);
+        ctx->Release();
+    }
+    dev->Release();
+    bb->Release();
 }
 
 void teardown_session(const char* why) {
@@ -502,6 +604,7 @@ bool create_swapchains(IDXGISwapChain* swapchain) {
 
     g_swapW = desc.BufferDesc.Width;
     g_swapH = desc.BufferDesc.Height;
+    g_swapFormat = pick; // the HUD quad swapchain creates lazily with this
     BVR_LOG("xr: swapchain pair %ux%u format %lld (%u images each)", g_swapW, g_swapH,
             static_cast<long long>(pick), imageCount);
 
@@ -1051,6 +1154,7 @@ void on_present_end(IDXGISwapChain* swapchain) {
         // it). The game may still be presenting alternating stereo eyes -
         // keep draining the tag ring and keep the window pinned to one eye.
         mirror_present(swapchain, sr_pop_eye());
+        composite_hud(swapchain); // the window keeps its HUD even with no session
         return;
     }
     bool pairSecond = g_srPairOpen; // this present completes an open pair
@@ -1063,8 +1167,10 @@ void on_present_end(IDXGISwapChain* swapchain) {
         {XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW},
         {XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW}};
     XrCompositionLayerQuad laserQuads[kMaxLaserDots] = {};
-    // The game frame is layer 0; the aim laser adds one quad per dot on top.
-    const XrCompositionLayerBaseHeader* layers[1 + kMaxLaserDots] = {};
+    XrCompositionLayerQuad hudQuad{XR_TYPE_COMPOSITION_LAYER_QUAD};
+    // The game frame is layer 0; the aim laser adds one quad per dot on top,
+    // the HUD quad one more (worst case 10 of the 16 runtimes must accept).
+    const XrCompositionLayerBaseHeader* layers[1 + kMaxLaserDots + 1] = {};
     uint32_t layerCount = 0;
 
     // Claim the fov the game actually rendered with (adapter readback);
@@ -1167,6 +1273,7 @@ void on_present_end(IDXGISwapChain* swapchain) {
                         BVR_LOG("xr: pair pacing live (one waitFrame per eye "
                                 "pair)");
                     backbuffer->Release();
+                    composite_hud(swapchain); // capture done - window gets HUD
                     return;
                 }
 
@@ -1230,8 +1337,10 @@ void on_present_end(IDXGISwapChain* swapchain) {
 
     // Mirror, right half: the right eye's XR capture is done (or was skipped
     // this present) - pin the backbuffer to the held left image before the
-    // real Present displays it.
+    // real Present displays it. The window HUD composite comes after (the
+    // re-blit would overwrite it).
     if (srSign > 0) mirror_present(swapchain, srSign);
+    composite_hud(swapchain);
 
     // Aim laser on top of the game frame - projection mode only, since in quad
     // ("cinema screen") mode there is no world for it to point into.
@@ -1243,6 +1352,55 @@ void on_present_end(IDXGISwapChain* swapchain) {
         g_laserLayersSubmitted.store(dots, std::memory_order_relaxed);
     } else {
         g_laserLayersSubmitted.store(0, std::memory_order_relaxed);
+    }
+
+    // HUD floating quad (session 19): head-locked, fed from the gameswf
+    // capture. Submitted only in projection mode with fresh HUD content and
+    // a live view space.
+    if (layerCount && projectionMode && g_viewSpace != XR_NULL_HANDLE) {
+        ID3D11Texture2D* hudTex = bvr::hud::texture(g_context); // alpha-repaired
+        if (hudTex) {
+            D3D11_TEXTURE2D_DESC hd{};
+            hudTex->GetDesc(&hd);
+            if (g_hudSwapchain == XR_NULL_HANDLE || g_hudSwapW != hd.Width ||
+                g_hudSwapH != hd.Height)
+                create_hud_swapchain(hd.Width, hd.Height);
+            if (g_hudSwapchain != XR_NULL_HANDLE) {
+                uint32_t idx = 0;
+                XrSwapchainImageAcquireInfo ai{XR_TYPE_SWAPCHAIN_IMAGE_ACQUIRE_INFO};
+                if (XR_SUCCEEDED(xrAcquireSwapchainImage(g_hudSwapchain, &ai, &idx))) {
+                    XrSwapchainImageWaitInfo wi{XR_TYPE_SWAPCHAIN_IMAGE_WAIT_INFO};
+                    wi.timeout = XR_INFINITE_DURATION;
+                    if (XR_SUCCEEDED(xrWaitSwapchainImage(g_hudSwapchain, &wi)))
+                        g_context->CopyResource(g_hudImages[idx].texture, hudTex);
+                    XrSwapchainImageReleaseInfo ri{XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO};
+                    xrReleaseSwapchainImage(g_hudSwapchain, &ri);
+
+                    // The processed capture is premultiplied rgb + repaired
+                    // alpha - premultiplied compositor semantics (no
+                    // UNPREMULTIPLIED bit).
+                    hudQuad.layerFlags = XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT;
+                    hudQuad.space = g_viewSpace; // head-locked
+                    hudQuad.eyeVisibility = XR_EYE_VISIBILITY_BOTH;
+                    hudQuad.subImage.swapchain = g_hudSwapchain;
+                    hudQuad.subImage.imageRect = {
+                        {0, 0}, {static_cast<int32_t>(hd.Width), static_cast<int32_t>(hd.Height)}};
+                    hudQuad.pose.orientation.w = 1.0f;
+                    hudQuad.pose.position = {0.0f, g_hudUpM.load(std::memory_order_relaxed),
+                                             -g_hudDistM.load(std::memory_order_relaxed)};
+                    float w = g_hudWidthM.load(std::memory_order_relaxed);
+                    hudQuad.size = {w, w * static_cast<float>(hd.Height) /
+                                           static_cast<float>(hd.Width)};
+                    layers[layerCount++] =
+                        reinterpret_cast<const XrCompositionLayerBaseHeader*>(&hudQuad);
+                    g_hudFramesSubmitted.fetch_add(1, std::memory_order_relaxed);
+                    if (!g_loggedFirstHudQuad.exchange(true))
+                        BVR_LOG("xr: HUD quad live (%ux%u, %.2f m wide at %.2f m)",
+                                hd.Width, hd.Height, w,
+                                g_hudDistM.load(std::memory_order_relaxed));
+                }
+            }
+        }
     }
 
     XrFrameEndInfo fei{XR_TYPE_FRAME_END_INFO};
@@ -1273,6 +1431,11 @@ void on_resize() {
     // Recreated at the new backbuffer size on the next frame.
     destroy_swapchains();
     release_mirror();
+    if (g_backbufferRtv) {
+        g_backbufferRtv->Release();
+        g_backbufferRtv = nullptr;
+        g_backbufferForRtv = nullptr;
+    }
 }
 
 void draw_debug_ui() {
@@ -1370,6 +1533,21 @@ void draw_debug_ui() {
         if (ImGui::SliderFloat("Screen width (m)", &width, 0.5f, 6.0f))
             g_screenWidthM.store(width, std::memory_order_relaxed);
     }
+
+    // Session 19 HUD quad: capture toggle + head-locked placement.
+    bool hudOn = bvr::hud::enabled();
+    if (ImGui::Checkbox("VR HUD (gameswf on a floating quad)", &hudOn))
+        bvr::hud::set_enabled(hudOn);
+    float hd = g_hudDistM.load(std::memory_order_relaxed);
+    if (ImGui::SliderFloat("HUD distance (m)", &hd, 0.5f, 3.0f))
+        g_hudDistM.store(hd, std::memory_order_relaxed);
+    float hw = g_hudWidthM.load(std::memory_order_relaxed);
+    if (ImGui::SliderFloat("HUD width (m)", &hw, 0.3f, 3.0f))
+        g_hudWidthM.store(hw, std::memory_order_relaxed);
+    float hu = g_hudUpM.load(std::memory_order_relaxed);
+    if (ImGui::SliderFloat("HUD height offset (m)", &hu, -1.0f, 1.0f))
+        g_hudUpM.store(hu, std::memory_order_relaxed);
+    ImGui::Text("HUD quad frames %u", g_hudFramesSubmitted.load(std::memory_order_relaxed));
 }
 
 bool get_head_pose(HeadPose& out) {
@@ -1486,6 +1664,18 @@ void set_laser(const LaserConfig& cfg) {
     g_laserSizeDeg.store(cfg.sizeDeg, std::memory_order_relaxed);
 }
 
+void set_hud_quad(float distM, float widthM, float upM) {
+    g_hudDistM.store(distM, std::memory_order_relaxed);
+    g_hudWidthM.store(widthM, std::memory_order_relaxed);
+    g_hudUpM.store(upM, std::memory_order_relaxed);
+}
+
+void get_hud_quad(float* distM, float* widthM, float* upM) {
+    if (distM) *distM = g_hudDistM.load(std::memory_order_relaxed);
+    if (widthM) *widthM = g_hudWidthM.load(std::memory_order_relaxed);
+    if (upM) *upM = g_hudUpM.load(std::memory_order_relaxed);
+}
+
 void sr_push_eye(int eyeSign) {
     uint32_t head = g_srHead.load(std::memory_order_relaxed);
     uint32_t tail = g_srTail.load(std::memory_order_acquire);
@@ -1526,6 +1716,12 @@ void set_rendered_hfov(float) {}
 int current_eye_sign() { return 0; }
 void sr_push_eye(int) {}
 void set_laser(const LaserConfig&) {}
+void set_hud_quad(float, float, float) {}
+void get_hud_quad(float* d, float* w, float* u) {
+    if (d) *d = 0;
+    if (w) *w = 0;
+    if (u) *u = 0;
+}
 
 } // namespace bvr::vr
 

--- a/src/core/vr/openxr_runtime.cpp
+++ b/src/core/vr/openxr_runtime.cpp
@@ -6,6 +6,7 @@
 
 #include "core/vr/openxr_runtime.h"
 
+#include "core/gfx/hud_capture.h"
 #include "core/util/log.h"
 
 #ifdef BVR_WITH_OPENXR
@@ -1083,6 +1084,9 @@ void on_present_end(IDXGISwapChain* swapchain) {
     // convention AER validated in-headset (depth not inverted).
     int srSign = sr_pop_eye();
     bool srFrame = projectionMode && srSign != 0;
+    // HUD capture gate (session 19): the gameswf redirect runs only while
+    // stereo gameplay frames flow (menus stop the eye tags -> gate drops).
+    bvr::hud::set_gate(srFrame);
 
     // Mirror, left half: snapshot the LEFT eye before anything else runs
     // (read-only - the XR eye capture below is unaffected). The right half

--- a/src/core/vr/openxr_runtime.h
+++ b/src/core/vr/openxr_runtime.h
@@ -150,4 +150,9 @@ struct LaserConfig {
 // builds the layers from it at submit time.
 void set_laser(const LaserConfig& cfg);
 
+// Session 19 HUD floating quad placement (meters; head-locked). Persisted by
+// the VR preset; sliders in the VR overlay section.
+void set_hud_quad(float distM, float widthM, float upM);
+void get_hud_quad(float* distM, float* widthM, float* upM);
+
 } // namespace bvr::vr

--- a/src/game/bioshock1r/body.cpp
+++ b/src/game/bioshock1r/body.cpp
@@ -122,17 +122,6 @@ uint32_t to_rva(const void* p) {
     return static_cast<uint32_t>(static_cast<const uint8_t*>(p) - g_imageBase);
 }
 
-// The cutscene/vehicle guard, same predicate aim.cpp and hands.cpp use - but
-// WITHOUT their `viewActor == pc` escape hatch. That hatch exists so the aim
-// ray still works in the main-menu attract scene; a write to the body facing
-// emphatically must not fire there.
-bool is_gameplay_view(void* viewActor) {
-    if (!viewActor) return false;
-    void* vtbl = nullptr;
-    if (!read_ptr(viewActor, &vtbl)) return false;
-    return to_rva(vtbl) == patterns::kShockPlayerVtableRva;
-}
-
 const char* state_name(State s) {
     switch (s) {
         case kOff: return "off";
@@ -207,6 +196,19 @@ int32_t wanted_step(int32_t residualUnits, float dt) {
 }
 
 } // namespace
+
+// The cutscene/vehicle guard, same predicate aim.cpp and hands.cpp use - but
+// WITHOUT their `viewActor == pc` escape hatch. That hatch exists so the aim
+// ray still works in the main-menu attract scene; a write to the body facing
+// emphatically must not fire there. Public since session 19: the stick-pitch
+// kill and the harness's "in gameplay" log signal gate on the same strict
+// predicate.
+bool is_gameplay_view(void* viewActor) {
+    if (!viewActor) return false;
+    void* vtbl = nullptr;
+    if (!read_ptr(viewActor, &vtbl)) return false;
+    return to_rva(vtbl) == patterns::kShockPlayerVtableRva;
+}
 
 void init(const bvr::pattern_scan::ProcessImage& image) {
     g_imageBase = image.base;

--- a/src/game/bioshock1r/body.h
+++ b/src/game/bioshock1r/body.h
@@ -70,6 +70,13 @@ void draw_debug_ui();
 
 bool enabled();
 
+// STRICT gameplay-view predicate: the view actor is the player's ShockPlayer
+// (vtable match), with NO `viewActor == pc` escape hatch - so the main-menu
+// attract scene and cutscenes read false. This is the body-write guard, and
+// since session 19 also the gate for the stick-pitch kill and the source of
+// the "[b1r] view state" harness log signal.
+bool is_gameplay_view(void* viewActor);
+
 // Tuned values the VR preset persists to vrpreset.ini.
 float rate_per_sec();
 float deadzone_deg();

--- a/src/game/bioshock1r/bones.cpp
+++ b/src/game/bioshock1r/bones.cpp
@@ -73,6 +73,23 @@ struct CachedSleeve {
 };
 CachedSleeve g_cacheSleeve[8];
 int g_cacheSleeveCount = 0;
+
+// Session 19: the whole INACTIVE hand collapses too - the drive poses only
+// the active hand's cluster, so the other one stays engine-animated at the
+// eye anchor and reads as a ghost hand. Cache mirrors g_cacheSleeve so the
+// stereo second pass replays the same writes. writeScale is false for the
+// weapon-attach bone: it hides by translation, never by scale (see drive()).
+std::atomic<bool> g_hideInactive{true};
+struct CachedHidden {
+    int idx;
+    float p[3];
+    float s[3];
+    bool writeScale;
+};
+CachedHidden g_cacheHidden[32];
+int g_cacheHiddenCount = 0;
+int g_hiddenHand = -1; // whose cluster is collapsed right now (game thread)
+
 void* g_cacheSkelInst = nullptr;
 uint64_t g_cacheMs = 0;
 
@@ -438,6 +455,31 @@ void cluster_of(int hand, int* first, int* last, int* anchor) {
     }
 }
 
+// Restore a hidden hand's cluster + sleeve from the reference pose. g_ref is
+// a safe source: an engine re-evaluation rewrites the whole array (scales
+// included) and triggers the reference refresh in drive(), so the reference
+// can never hold our zeroed scales.
+void restore_hidden(int hand) {
+    if (hand < 0 || !g_bones || !g_refValid) return;
+    int first = 0, last = 0, anchor = 0;
+    cluster_of(hand, &first, &last, &anchor);
+    for (int i = first; i <= last && i < g_boneCount; ++i) {
+        if (i < 0) continue;
+        write_n(g_bones[i].p, g_ref[i].p, 12);
+        write_n(g_bones[i].q, g_ref[i].q, 16);
+        write_n(g_bones[i].s, g_ref[i].s, 12);
+    }
+    const int* sleeve = hand == 1 ? patterns::kBoneRSleeve : patterns::kBoneLSleeve;
+    const size_t sleeveCount = hand == 1 ? _countof(patterns::kBoneRSleeve)
+                                         : _countof(patterns::kBoneLSleeve);
+    for (size_t k = 0; k < sleeveCount; ++k) {
+        int idx = sleeve[k];
+        if (idx >= g_boneCount) continue;
+        write_n(g_bones[idx].p, g_ref[idx].p, 12);
+        write_n(g_bones[idx].s, g_ref[idx].s, 12);
+    }
+}
+
 } // namespace
 
 void init(const bvr::pattern_scan::ProcessImage& image) {
@@ -456,7 +498,19 @@ void on_world_change() {
     g_hasWritten[0] = g_hasWritten[1] = false;
     g_cacheSkelInst = nullptr;
     g_cacheMs = 0;
+    g_hiddenHand = -1; // the collapsed bones died with the old world
+    g_cacheHiddenCount = 0;
 }
+
+void set_hide_inactive(bool on) {
+    bool was = g_hideInactive.exchange(on, std::memory_order_relaxed);
+    if (was != on)
+        BVR_LOG("[bones] hideinactive %s (inactive hand %s)", on ? "ON" : "off",
+                on ? "collapses while the other drives"
+                   : "restores on the next driven frame");
+}
+
+bool hide_inactive() { return g_hideInactive.load(std::memory_order_relaxed); }
 
 bool telemetry_on() {
     return g_telemetry.load(std::memory_order_relaxed);
@@ -498,6 +552,17 @@ bool drive(const FrameContext& ctx, void* handsActor, const GamePose& gp, int ha
         if (!read_n(g_bones, g_ref, sizeof(Qts) * static_cast<size_t>(g_boneCount)))
             return false;
         g_refValid = true;
+    }
+
+    // Hide-inactive bookkeeping, BEFORE the rigid write: if the hand about to
+    // be driven is the one currently collapsed (hand switch), or the feature
+    // just turned off, restore it from the reference first - the rigid write
+    // below sets p/q but never touches .s, so a zero scale left behind would
+    // keep the incoming hand invisible.
+    bool hideInactive = g_hideInactive.load(std::memory_order_relaxed);
+    if (g_hiddenHand >= 0 && (!hideInactive || g_hiddenHand == hand)) {
+        restore_hidden(g_hiddenHand);
+        g_hiddenHand = -1;
     }
 
     // World target -> component space, composed against the ACTOR transform.
@@ -646,6 +711,43 @@ bool drive(const FrameContext& ctx, void* handsActor, const GamePose& gp, int ha
     }
     s_wasCollapsed = collapse;
 
+    // Collapse the whole INACTIVE hand: cluster + its sleeve (session 19).
+    // Zero scale hides the skin exactly like the sleeve collapse; positions
+    // pin at the driven target so residual geometry stays inside the fist.
+    // EXCEPTION - the weapon-attach bone hides by TRANSLATION, scale
+    // untouched: the engine's attach path inverse-decomposes chain scale
+    // (session 16: any wrist-chain scale blows the attached weapon up
+    // near-plane, and zero would be 1/0), so the equipped gun is parked far
+    // below the actor in component space and frustum-culled instead.
+    g_cacheHiddenCount = 0;
+    if (hideInactive) {
+        const int ih = 1 - hand;
+        int hFirst = 0, hLast = 0, hAnchor = 0;
+        cluster_of(ih, &hFirst, &hLast, &hAnchor);
+        static const float kZero[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+        static const float kFarBelow[3] = {0.0f, 0.0f, -5000.0f};
+        const int* hSleeve = ih == 1 ? patterns::kBoneRSleeve : patterns::kBoneLSleeve;
+        const size_t hSleeveCount = ih == 1 ? _countof(patterns::kBoneRSleeve)
+                                            : _countof(patterns::kBoneLSleeve);
+        auto hideBone = [&](int idx) {
+            if (idx < 0 || idx >= g_boneCount) return;
+            bool isAttach = ih == 1 && idx == patterns::kBoneWeaponAttach;
+            const float* p = isAttach ? kFarBelow : ptc;
+            write_n(g_bones[idx].p, p, 12);
+            if (!isAttach) write_n(g_bones[idx].s, kZero, 12);
+            if (g_cacheHiddenCount < static_cast<int>(_countof(g_cacheHidden))) {
+                CachedHidden& ch = g_cacheHidden[g_cacheHiddenCount++];
+                ch.idx = idx;
+                memcpy(ch.p, p, 12);
+                memcpy(ch.s, kZero, 12);
+                ch.writeScale = !isAttach;
+            }
+        };
+        for (int i = hFirst; i <= hLast; ++i) hideBone(i);
+        for (size_t k = 0; k < hSleeveCount; ++k) hideBone(hSleeve[k]);
+        g_hiddenHand = ih;
+    }
+
     if (!read_n(&g_bones[anchor], &g_lastWrittenAnchor[hand], sizeof(Qts))) return false;
     g_hasWritten[hand] = true;
     set_dirty(0); // render-side evaluate-if-dirty must not rebuild over us
@@ -676,6 +778,12 @@ void reapply() {
         write_n(g_bones[cs.idx].p, cs.p, 12);
         write_n(g_bones[cs.idx].s, cs.s, 12);
     }
+    for (int k = 0; k < g_cacheHiddenCount; ++k) {
+        const CachedHidden& ch = g_cacheHidden[k];
+        if (ch.idx >= g_boneCount) continue;
+        write_n(g_bones[ch.idx].p, ch.p, 12);
+        if (ch.writeScale) write_n(g_bones[ch.idx].s, ch.s, 12);
+    }
     set_dirty(0);
 }
 
@@ -692,11 +800,12 @@ void handle_command(const char* args) {
 
     if (strcmp(verb, "status") == 0) {
         BVR_LOG("[bones] inst=%p bones=%p count=%d writes=%u lastHand=%d refValid=%d "
-                "collapse=%d",
+                "collapse=%d hideinactive=%d hiddenHand=%d",
                 g_skelInst, static_cast<void*>(g_bones), g_boneCount,
                 g_writes.load(std::memory_order_relaxed),
                 g_lastHand.load(std::memory_order_relaxed), g_refValid ? 1 : 0,
-                g_collapse.load(std::memory_order_relaxed) ? 1 : 0);
+                g_collapse.load(std::memory_order_relaxed) ? 1 : 0,
+                g_hideInactive.load(std::memory_order_relaxed) ? 1 : 0, g_hiddenHand);
         int lockMode = g_renderLock.load(std::memory_order_relaxed);
         BVR_LOG("[bones] render lock: %s |delta|=%.2f UU gain=%.2f dgain=%.2f solves=%u "
                 "skips=%u",
@@ -833,6 +942,9 @@ void draw_debug_ui() {
     bool col = g_collapse.load(std::memory_order_relaxed);
     if (ImGui::Checkbox("Hide the driven arm (collapse sleeve bones)", &col))
         g_collapse.store(col, std::memory_order_relaxed);
+    bool hide = g_hideInactive.load(std::memory_order_relaxed);
+    if (ImGui::Checkbox("Hide the inactive hand", &hide))
+        set_hide_inactive(hide);
     int lockMode = g_renderLock.load(std::memory_order_relaxed);
     if (ImGui::RadioButton("lock off", &lockMode, 0) ||
         ImGui::RadioButton("lock ABS (true position)", &lockMode, 1) ||

--- a/src/game/bioshock1r/bones.h
+++ b/src/game/bioshock1r/bones.h
@@ -47,6 +47,14 @@ void reapply();
 // The old actors died with the old world; drop every cached pointer.
 void on_world_change();
 
+// Session 19: collapse the whole INACTIVE hand's cluster + sleeve while the
+// other hand drives (default ON; `vrhands hideinactive on|off`). The
+// weapon-attach bone hides by translation, never scale - the attach path
+// inverse-decomposes chain scale (session 16). Restores from the reference
+// on toggle-off and on hand switch, before the incoming hand is driven.
+void set_hide_inactive(bool on);
+bool hide_inactive();
+
 // Seam commands (game thread): status | list [n] | poke <idx> <dUU> |
 // freeze on|off | collapse on|off | ref | anchor <idx> | lcluster <lo> <hi> <anchor> |
 // log on|off (in-headset telemetry: head/controller/camera/actor/target/bone

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -925,6 +925,33 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
                     strictGameplay ? "GAMEPLAY (ShockPlayer view)" : "menu/cutscene");
         }
 
+        // Radial-wheel pitch guard (session 19 part 2): the stick-pitch kill
+        // lifts while a grip/bumper is held so the weapon wheel can read
+        // stick Y - but the wheel's binding state keeps the look axis bound
+        // too, so REAL pitch accumulates on the PC during the hold. Snapshot
+        // the PC pitch at bumper-down, write it back at release: the wheel
+        // selects, the body pitch returns exactly where it was. Same field
+        // the stick writes (PC rotation, pitch at +0x0), so the engine's own
+        // clamp semantics hold.
+        {
+            bool lb = false, rb = false;
+            bvr::input::last_composed_bumpers(&lb, &rb);
+            bool bumperHeld = lb || rb;
+            static bool s_wasHeld = false;
+            static int32_t s_savedPitch = 0;
+            static void* s_savedPc = nullptr;
+            int32_t* pcPitch = reinterpret_cast<int32_t*>(static_cast<uint8_t*>(self) +
+                                                          patterns::kActorViewDirOffset);
+            if (bumperHeld && !s_wasHeld && vrDrove && strictGameplay) {
+                s_savedPitch = *pcPitch;
+                s_savedPc = self;
+            } else if (!bumperHeld && s_wasHeld) {
+                if (s_savedPc == self) *pcPitch = s_savedPitch;
+                s_savedPc = nullptr; // never restore across a world change
+            }
+            s_wasHeld = bumperHeld;
+        }
+
         // THE HARD-INVARIANT INSTRUMENT (session 17). Run a FIXED XR pose
         // through the unmodified context and log where it lands. This is the
         // exact function the aim ray and the viewmodel both call, with the

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -6,6 +6,7 @@
 
 #include "core/debug/value_scan.h"
 #include "core/gfx/frame_inspector.h"
+#include "core/gfx/hud_capture.h"
 #include "core/input/xinput_bridge.h"
 #include "core/util/log.h"
 #include "game/bioshock1r/aim.h"
@@ -387,7 +388,12 @@ void apply_command(const char* cmd, const char* args) {
     } else if (strcmp(cmd, "membases") == 0) {
         bvr::value_scan::log_module_bases();
     } else if (strcmp(cmd, "dumpframe") == 0) {
-        bvr::frame_inspector::arm(strncmp(args, "full", 4) == 0 ? 2 : 1);
+        // dumpframe [full] [n] - n > 1 records consecutive present windows
+        // (both halves of a stereo pair; files suffixed _qN).
+        bool full = strncmp(args, "full", 4) == 0;
+        int count = 1;
+        sscanf_s(full ? args + 4 : args, " %d", &count);
+        bvr::frame_inspector::arm(full ? 2 : 1, count);
     } else if (strcmp(cmd, "vrinput") == 0) {
         input::handle_command(args); // M5 synthetic gamepad; logs its own echoes
     } else if (strcmp(cmd, "vraim") == 0) {
@@ -417,6 +423,25 @@ void apply_command(const char* cmd, const char* args) {
         bvr::vr::handle_pace_command(args); // M8 disconnect-stall guard
     } else if (strcmp(cmd, "vrmirror") == 0) {
         bvr::vr::handle_mirror_command(args); // M8 single-eye desktop mirror
+    } else if (strcmp(cmd, "vrhud") == 0) {
+        // Session 19 HUD capture: gameswf HUD redirected off the game frame
+        // (clean eyes) and shown as a floating quad in stereo.
+        if (strncmp(args, "force on", 8) == 0) {
+            bvr::hud::set_force(true);
+        } else if (strncmp(args, "force off", 9) == 0) {
+            bvr::hud::set_force(false);
+        } else if (strncmp(args, "on", 2) == 0) {
+            bvr::hud::set_enabled(true);
+        } else if (strncmp(args, "off", 3) == 0) {
+            bvr::hud::set_enabled(false);
+        } else {
+            unsigned hd = 0, rd = 0, lk = 0, iv = 0;
+            bvr::hud::get_counters(&hd, &rd, &lk, &iv);
+            BVR_LOG("[hud] status: %s force=%d | hudDraws=%u redirects=%u leaks=%u "
+                    "hudIntervals=%u (vrhud on|off|force on|force off|status)",
+                    bvr::hud::enabled() ? "ON" : "off", bvr::hud::force() ? 1 : 0, hd, rd,
+                    lk, iv);
+        }
     } else if (strcmp(cmd, "vrxhair") == 0) {
         // M8 part 2: the flat-screen crosshair. Default HIDDEN; "on" re-shows.
         if (strncmp(args, "on", 2) == 0) {

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -873,6 +873,20 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
         fc.pc = self;
         g_lastViewActor.store(fc.viewActor, std::memory_order_relaxed);
 
+        // Strict gameplay-view (body.cpp predicate, no menu-attract escape
+        // hatch), published to the input bridge as the stick-pitch-kill gate
+        // and logged on transition - the harness's generic "in gameplay"
+        // signal (boot.ps1 watches for this line; any save, any level).
+        bool strictGameplay = body::is_gameplay_view(fc.viewActor);
+        bvr::input::publish_vr_gameplay(vrDrove && strictGameplay);
+        static int s_lastViewState = -1;
+        int viewState = strictGameplay ? 1 : 0;
+        if (viewState != s_lastViewState) {
+            s_lastViewState = viewState;
+            BVR_LOG("[b1r] view state: %s",
+                    strictGameplay ? "GAMEPLAY (ShockPlayer view)" : "menu/cutscene");
+        }
+
         // THE HARD-INVARIANT INSTRUMENT (session 17). Run a FIXED XR pose
         // through the unmodified context and log where it lands. This is the
         // exact function the aim ray and the viewmodel both call, with the

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -495,6 +495,13 @@ void save_vr_preset() {
     fprintf(f, "bodyDeadzoneDeg=%.1f\n", body::deadzone_deg());
     fprintf(f, "crosshairVisible=%d\n",
             g_crosshairVisible.load(std::memory_order_relaxed) ? 1 : 0);
+    {
+        float hd = 0, hw = 0, hu = 0;
+        bvr::vr::get_hud_quad(&hd, &hw, &hu);
+        fprintf(f, "hudQuadDistM=%.2f\n", hd);
+        fprintf(f, "hudQuadWidthM=%.2f\n", hw);
+        fprintf(f, "hudQuadUpM=%.2f\n", hu);
+    }
     fclose(f);
     BVR_LOG("[b1r] VR preset values saved to vrpreset.ini");
     // The per-hand model offsets live in hands.ini; saving them here too makes
@@ -514,6 +521,8 @@ void load_vr_preset_values() {
     float plf = aim::pos_fwd_cm(0), plr = aim::pos_right_cm(0), plu = aim::pos_up_cm(0);
     float prf = aim::pos_fwd_cm(1), prr = aim::pos_right_cm(1), pru = aim::pos_up_cm(1);
     float bodyRate = body::rate_per_sec(), bodyDz = body::deadzone_deg();
+    float hudD = 0, hudW = 0, hudU = 0;
+    bvr::vr::get_hud_quad(&hudD, &hudW, &hudU);
     while (fgets(line, sizeof line, f)) {
         char key[48] = {};
         float v = 0.0f;
@@ -539,6 +548,9 @@ void load_vr_preset_values() {
         else if (strcmp(key, "bodyDeadzoneDeg") == 0) bodyDz = v;
         else if (strcmp(key, "crosshairVisible") == 0)
             g_crosshairVisible.store(v != 0.0f, std::memory_order_relaxed);
+        else if (strcmp(key, "hudQuadDistM") == 0) hudD = v;
+        else if (strcmp(key, "hudQuadWidthM") == 0) hudW = v;
+        else if (strcmp(key, "hudQuadUpM") == 0) hudU = v;
         else --n;
     }
     fclose(f);
@@ -547,6 +559,7 @@ void load_vr_preset_values() {
     aim::set_pos_offset(0, plf, plr, plu);
     aim::set_pos_offset(1, prf, prr, pru);
     body::set_tuning(bodyRate, bodyDz);
+    if (hudD > 0.0f && hudW > 0.0f) bvr::vr::set_hud_quad(hudD, hudW, hudU);
     if (n) BVR_LOG("[b1r] VR preset: %d value(s) loaded from vrpreset.ini", n);
 }
 

--- a/src/game/bioshock1r/hands.cpp
+++ b/src/game/bioshock1r/hands.cpp
@@ -747,6 +747,8 @@ void handle_command(const char* args) {
         bool on = strncmp(rest, "on", 2) == 0;
         g_writeRot.store(on, std::memory_order_relaxed);
         BVR_LOG("[hands] rotation write %s", on ? "ON" : "off (position only)");
+    } else if (strcmp(verb, "hideinactive") == 0) {
+        bones::set_hide_inactive(strncmp(rest, "on", 2) == 0);
     } else if (strcmp(verb, "save") == 0) {
         save_config();
     } else if (strcmp(verb, "reload") == 0) {
@@ -794,7 +796,8 @@ void handle_command(const char* args) {
         log_status();
     } else {
         BVR_LOG("[hands] unknown command '%s' (on|off|mode gun|hands|pose aim|grip|scale|"
-                "probe|hand|pos|rot|writerot|save|reload|test|simpose|testclear|status)",
+                "probe|hand|pos|rot|writerot|hideinactive|save|reload|test|simpose|"
+                "testclear|status)",
                 verb);
     }
 }

--- a/src/game/bioshock1r/hands.h
+++ b/src/game/bioshock1r/hands.h
@@ -54,6 +54,9 @@ void on_calcview(const FrameContext& ctx);
 //   rot [l|r] <pitch> <yaw> <roll>  mesh-alignment trim in degrees, composed in
 //                           the controller's LOCAL frame (holds at any
 //                           orientation); no side = BOTH hands
+//   hideinactive on|off     collapse the whole INACTIVE hand's cluster while
+//                           the other drives (default ON; the weapon-attach
+//                           bone hides by translation - see bones.h)
 //   save | reload           persist / re-read the offsets (per-hand keys in
 //                           hands.ini; a legacy suffix-less key loads to both)
 //   test <dYaw> <dPitch> [distUU] [holdMs]   camera-relative placement (proves

--- a/tools/boot.ps1
+++ b/tools/boot.ps1
@@ -1,0 +1,68 @@
+# Boot BioShock Remastered into GAMEPLAY on the newest save: launch via Steam,
+# dismiss the revert-Options 'Message' dialog with &No if it appears, foreground
+# the game window (the boot sequence pauses unfocused), then press A every
+# ~3.5 s through the menu until the mod logs the strict gameplay-view
+# transition. Save-agnostic since session 19: the detector is the
+# "[b1r] view state: GAMEPLAY" line (ShockPlayer vtable predicate, logged on
+# transition by camera.cpp), not a hardwired save location - needs the
+# session-19+ DLL installed. After detection a single B press closes the MAP
+# screen the A-press loop sometimes leaves open (known harness trap);
+# callers should still screenshot-verify before measuring.
+$repo = Split-Path -Parent $PSScriptRoot
+$log = "$env:LOCALAPPDATA\BioshockVR\bioshockvr.log"
+
+Add-Type @'
+using System; using System.Runtime.InteropServices; using System.Text;
+public static class W {
+  [DllImport("user32.dll")] public static extern IntPtr FindWindow(string cls, string title);
+  [DllImport("user32.dll")] public static extern IntPtr FindWindowEx(IntPtr parent, IntPtr after, string cls, string title);
+  [DllImport("user32.dll")] public static extern IntPtr SendMessage(IntPtr h, uint m, IntPtr w, IntPtr l);
+  [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr h);
+}
+'@
+
+Start-Process "steam://rungameid/409710"
+"launched via steam"
+
+# Phase 1: wait for the game process; dismiss any 'Message' dialog with &No.
+$game = $null
+for ($i = 0; $i -lt 120; $i++) {
+    $dlg = [W]::FindWindow("#32770", "Message")
+    if ($dlg -ne [IntPtr]::Zero) {
+        $no = [W]::FindWindowEx($dlg, [IntPtr]::Zero, "Button", "&No")
+        if ($no -ne [IntPtr]::Zero) {
+            [W]::SendMessage($no, 0x00F5, [IntPtr]::Zero, [IntPtr]::Zero) | Out-Null
+            "dismissed revert-Options dialog with No"
+        }
+    }
+    $p = Get-Process BioshockHD -ErrorAction SilentlyContinue
+    if ($p -and $p.MainWindowTitle -like "*Bioshock*") { $game = $p; break }
+    Start-Sleep -Milliseconds 1000
+}
+if (-not $game) { "FAIL: game window never appeared"; exit 1 }
+"game window up (pid $($game.Id)), foregrounding"
+[W]::SetForegroundWindow($game.MainWindowHandle) | Out-Null
+Start-Sleep -Seconds 3
+
+# Phase 2: A-press loop until the strict gameplay-view transition logs. The
+# line fires once per menu->gameplay transition, so search the whole log (it
+# is truncated at DLL attach, small, and the one-shot line would scroll out
+# of a fixed tail window between polls).
+for ($i = 0; $i -lt 70; $i++) {
+    $hit = Select-String -Path $log -Pattern "view state: GAMEPLAY" -SimpleMatch -Quiet -ErrorAction SilentlyContinue
+    if ($hit) {
+        "GAMEPLAY REACHED (after $i presses)"
+        # The A-press loop can leave the MAP screen open; B closes it (a stray
+        # B in gameplay is at most a jump on the test save).
+        Start-Sleep -Milliseconds 1500
+        & "$repo\tools\game-cmd.ps1" "vrinput test press B 250" | Out-Null
+        exit 0
+    }
+    $p = Get-Process BioshockHD -ErrorAction SilentlyContinue
+    if (-not $p) { "FAIL: game process died"; exit 1 }
+    [W]::SetForegroundWindow($p.MainWindowHandle) | Out-Null
+    & "$repo\tools\game-cmd.ps1" "vrinput test press A 250" | Out-Null
+    Start-Sleep -Milliseconds 3500
+}
+"FAIL: gameplay never reached (timed out)"
+exit 1


### PR DESCRIPTION
M8 completion (session 19): the HUD readable in VR, VR-standard bindings, the ghost hand gone, stick pitch killed. Everything flat-verified with numeric acceptance on clean boots under vrstereo; the in-headset checklist is in docs/STATUS.md (IN-HEADSET CHECKLIST - M8 completion, session 19). v0.2.0 tags on this merge after the headset pass.

## What is in
- **HUD on a floating quad**: gameswf HUD draws classified per present interval (corrected fingerprint - ENGINE_NOTES session 19) and redirected to an offscreen RT; the alpha-repaired copy feeds a head-locked quad (3 placement sliders, persisted) and a post-capture window composite. Both eyes come out clean (also fixes the old HUD-in-both-eyes defect); the pause menu lands on the quad; the flat window keeps its HUD. Flat: 119 draws/interval classified, leaks=0, removal + restore exact.
- **vrhands hideinactive (default on)**: the inactive hand's whole cluster collapses (weapon hides by attach-bone translation - scale would blow up the attach path); restores before the incoming hand drives. Flat: ghost-arm A/B 2.64 mean vs 0.75 floor, both switch directions, Electro Bolt FX parity with the collapse live, fire test clean.
- **vrinput pitchkill (default on)**: composed right-stick Y zeroed while the VR camera drives a strict gameplay view. Flat: pitch frozen through full-stick holds while yaw spins; off restores instantly.
- **VR-standard bindings**: Touch A=jump, B=use, Y=heal, X=reload (game layout ground truth from User.ini XENON_*), plus right-stick flick up/down = ammo-type cycling (dpad up/down flat-proven as the ammo cycle; flicks grip-suppressed for the radials).
- Harness: save-agnostic tools/boot.ps1 (view-state detector), dumpframe N consecutive windows, six new draw-lane census hooks.

## Verification
Five clean controlled boots; stereo heartbeat clean throughout (presents = 2x builds, guardskips 0); crash dumps 8 -> 8 all session; every command echo verified. Screenshots + diffs in the session scratchpad.

Deferred whole to session 20 by the user's call: aim-sync algebra unification + synccheck/record-replay framework + FName + muzzle probe + idle-sway kill (designs in STATUS, SESSION 20 PLAN).
