### PR TITLE
Session 20: one trim algebra, vrrec record+replay, FName/GNames, muzzle ray, idle-sway kill

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -397,3 +397,26 @@ runtime.
   the camera, so absorbing into the recenter would counter-rotate the view every frame,
   and the engine re-stamps it from the controller anyway - live-confirmed the pawn follows
   our PC write for free).
+
+- **2026-07-28 (session 20) - ONE trim algebra for ray, laser, and model; quat helpers
+  promoted to core.** The fire ray used to apply its calibration trim as rotator ADDS in
+  game space after the XR->game map, and the laser as yaw/pitch adds inside a spherical
+  decomposition - while the model composed its trim as a quaternion in the controller's
+  LOCAL frame. Three algebras for one physical quantity agree only at the pose the user
+  tuned at; the session-20 `vraim synccheck` sweep measured up to **28.21 deg** of
+  ray-vs-barrel divergence at rolled poses with identical trims fed to both chains
+  (ENGINE_NOTES session 20). Now all three run the model's compose - `q_ctrl (x) q_trim`
+  via `xr_local_trim_quat`, roll slot 0 for the ray/laser (roll is innermost and cannot
+  move a ray), roll dropped only at the ray's final rotator write - implemented ONCE as
+  pure functions in `frame_context.h` (`ray_pose_from_xr` = `model_pose_from_xr` + roll
+  drop), which production and synccheck share, so the sweep measures the shipping code
+  and the gate is `synccheck ~0 at every orientation`. The laser's origin-offset basis
+  also adopts the ray's zero-roll convention (right built from the ray's yaw ANGLE, so
+  it stays defined at any pitch - the old `d x worldUp` cross degenerated near vertical
+  and silently dropped the right/up offsets there). The quat helpers moved to
+  `core/util/xr_math.h` (`bvr::xrmath`) because core code (the laser) must not include
+  game headers; `ue_math.h` re-exports them so game code keeps its spelling. The model's
+  own full-roll position-offset basis is deliberately UNTOUCHED (live user tuning rides
+  it), and tuned trim values carry over: the old and new algebras agree exactly at the
+  neutral tuning pose. The legacy `vrhands aligntrim` euler coupling was deleted - wrong
+  algebra everywhere but the tuning pose, and nothing left for it to do.

--- a/docs/ENGINE_NOTES.md
+++ b/docs/ENGINE_NOTES.md
@@ -1639,3 +1639,33 @@ wired on this build; flat weapon switching stays an open harness gap (the
 bumpers open the session-19 radial, which needs real stick timing). The
 per-weapon d0 change is structurally guaranteed but goes to the in-headset
 checklist for the eyes-on proof.
+
+### Idle sway: measured, root-cause identified, killed in the drive (session 20 stage 6)
+
+**Measured flat first** (the muzzle ray's barrel-axis echo as the
+instrument): at idle under the live drive the reference pose's barrel
+direction oscillates 8.4-11.0 deg (z component 0.146-0.191) = **+-1.2 deg
+amplitude**, yaw +-0.6 deg; 1 Hz anchor telemetry vs a frozen snapshot
+peaks at **3.01 UU / 4.6 deg** on the wrist anchors.
+
+**Negative result (the SET-seam premise dissolves)**:
+`UpdateHandBobAnimationParameters` decompiled - it drives the WALK bob on
+animation channel 2 with weight = velocity/GroundSpeed, i.e. ZERO at
+standstill. `PlayHandBobAnimation` confirms channel 2 = the additive bob.
+The idle breathing is the authored base idle ANIMATION - there is no script
+property to zero, so nothing for the SET seam to set.
+
+**The kill (default ON, `vrhands swaykill on|off`)**: the sway reaches the
+VR rig through exactly one door - the drive's per-frame reference recapture
+- so the reference FREEZES against it: a fresh engine pose is adopted only
+when either wrist anchor moves past 6 UU / 12 deg (2x the measured idle
+envelope; equip/reload/fire move tens of UU), plus a 600 ms settle window
+past the last big frame so the eventual freeze holds the SETTLED pose, not
+a mid-animation one. Flat acceptance: kill ON = barrel axis bitwise
+IDENTICAL across 8 samples / 32 s; OFF = the wobble returns instantly; two
+fire pulls passed the threshold (reference re-adopted, settled 0.4 deg from
+the old snapshot) and re-froze 3/3. The weapon's own skeleton (pump,
+cylinder) animates untouched - it is a different SkeletonInstance. Side
+effect by construction: hand-cluster finger animation during reload freezes
+too (the drive was already overwriting it); the weapon's own reload
+animation still shows.

--- a/docs/ENGINE_NOTES.md
+++ b/docs/ENGINE_NOTES.md
@@ -1556,3 +1556,18 @@ simpose (writes counting, loc/rot exact for sim 0/0/0), fire test through
 the armed synthetic ray - substituted rot (1763, 20919) = camera (853,
 19099) + trim (5, 10 deg) * 182.04 units/deg exactly, subs=2, ammo 47->43,
 dumps 8->8.
+
+**Post-unification (same day): the algebra gate collapsed 28.21 -> 0.03 deg.**
+Ray + laser now run the model's exact compose (q_ctrl (x) q_trim via
+xr_local_trim_quat; `ray_pose_from_xr` = `model_pose_from_xr` + roll drop in
+frame_context.h; helpers promoted to core/util/xr_math.h so the laser -
+core code - shares them). Canonical sweep: <= 0.03 deg at EVERY pose (the
+int-rotator quantization floor, 1 unit = 0.0055 deg). The live-L sweep is
+the confirmation from the other side: 17.70 deg at EVERY orientation
+(constant = pure trim-value difference between the L ray trim and the L
+model trim; pre-fix it varied 0.20-17.70 with orientation = algebra error).
+The laser's origin basis now builds right from the ray's YAW angle (zero-roll
+convention, defined at any pitch); the old d x worldUp cross degenerated near
+vertical and silently dropped the right/up offset components. Legacy
+`vrhands aligntrim` deleted. Fire test on the unified build: calls=2 subs=2
+skips=0, substituted rot exact, dumps 8->8.

--- a/docs/ENGINE_NOTES.md
+++ b/docs/ENGINE_NOTES.md
@@ -1515,3 +1515,44 @@ the stick-pitch-kill gate, and logged on transition as
 generic "save is loaded" detector (tools/boot.ps1). The intro and main menu read
 menu/cutscene (viewActor==pc there); the transition to GAMEPLAY fires exactly at
 save load, any save, any level.
+
+## Session 20 - the two trim algebras: measured divergence baseline (synccheck)
+
+The session-18/19 root-cause claim ("the ray trims via rotator ADDS in game
+space, the model trims via a QUAT COMPOSED in the controller's local frame -
+they agree only at the tuning pose") is now MEASURED. Both pose->rot chains
+were refactored into pure functions in `frame_context.h`
+(`ray_pose_from_xr`, `model_pose_from_xr`) that production (aim.cpp,
+hands.cpp) and the new `vraim synccheck` sweep share, so the sweep measures
+the real shipping code. The sweep drives ~21 axis-angle controller
+orientations (identity, +-45/90 per axis, 180 roll, mixed axes) through both
+chains against the cached last FrameContext and prints the angle between the
+ray direction and the model barrel direction.
+
+**Baseline (2026-07-28, pre-unification build, clean boot, NG+ Medical
+Pavilion, vrpreset armed):** with a canonical 10/10 trim fed IDENTICALLY to
+both chains (so every degree of divergence is pure algebra difference):
+
+- identity pose and all pure-YAW poses: 0.00 deg (rotations about world up
+  commute with the yaw add - the algebras agree exactly there, which is why
+  eye-tuning at a neutral pose always "worked")
+- pitch poses: 4.14 deg at +45, 1.76 at -45, 11.58 at +90
+- ROLL poses (about the view axis): 10.70 deg at 45, 19.85 at 90,
+  **28.21 deg at 180 - the maximum of the whole sweep**
+- mixed axes: 2.33-13.70 deg
+- **MAX canonical divergence: 28.21 deg.** Roll is where the two algebras
+  differ most - an XR-local-euler sweep (no rolled poses) would have
+  under-reported the defect badly.
+
+Live-trim sweep on the user's tuning (ray L +0.2/+17.7, R 0/0; model trims
+all 0): liveR ~0.0 everywhere (zero trims = both chains degenerate to the
+same map), liveL up to 17.70 deg (the L ray trim has no model-side
+counterpart by construction of the tuning). Render-lock position delta
+quoted separately at 0.00 UU (position-only by construction - the lock never
+touches rotation).
+
+Verification that the refactor is behavior-preserving: model drive live via
+simpose (writes counting, loc/rot exact for sim 0/0/0), fire test through
+the armed synthetic ray - substituted rot (1763, 20919) = camera (853,
+19099) + trim (5, 10 deg) * 182.04 units/deg exactly, subs=2, ammo 47->43,
+dumps 8->8.

--- a/docs/ENGINE_NOTES.md
+++ b/docs/ENGINE_NOTES.md
@@ -1571,3 +1571,32 @@ convention, defined at any pitch); the old d x worldUp cross degenerated near
 vertical and silently dropped the right/up offset components. Legacy
 `vrhands aligntrim` deleted. Fire test on the unified build: calls=2 subs=2
 skips=0, substituted rot exact, dumps 8->8.
+
+### The name system: GNames located, index->string live (session 20 stage 4)
+
+The FName-chain event scan finds the FName constructor and used to throw it
+away; it is now captured (`EventScanResult::fnameCtor`, logged at boot:
+**RVA 0x70D660**). Capstone disassembly (scratchpad only - never committed):
+0x70D660 is a thin SEH wrapper that enters a name-system critical section
+(global at RVA 0x136CEB8) and calls the real worker at **RVA 0x70D3C0**. The
+worker: wcslen, digit-suffix split (`Name_123` -> base + number - FName is
+8 bytes {int32 index, int32 number}; the number stores at FName+4), a
+case-insensitive hash AND 0xFFF into a **4096-bucket hash table at RVA
+0x1370EC0** (chain via entry+0xC, wcsicmp against entry+0x10), and on the
+FindType==2 path indexes **GNames.Data at RVA 0x13904EC**
+(`TArray<FNameEntry*>`: Data, +4 Count, +8 Max) and ORs 0x4000000 into
+entry+4.
+
+**FNameEntry layout** (matches the package-file prior - UTF-16, 8-byte
+flags): +0x0 the entry's own index (used as a self-check by the resolver),
++0x4/+0x8 the 8-byte flags, +0xC hash-chain next, +0x10 UTF-16 text in
+place. Bonus find: a free-index STACK (Data/Count/Max ints at RVA
+0x13904F8/FC/0x1390500) - new names reuse recycled indices.
+
+`patterns::fname_text(index)` reads GNames with full validation (every
+dereference is_memory_valid + the entry self-index check); exposed as
+`vrhands fname <index>|weapon`. **Live gate passed**: index 0 -> 'None',
+1 -> 'ByteProperty' (the canonical Unreal table opening), GNames count
+54129, and the equipped weapon's attach-bone FName (weapon+0xF0) ->
+**'Launcher'** (idx 18075) - the AHands rig's weapon-attach socket name
+(bone 43 in index space).

--- a/docs/ENGINE_NOTES.md
+++ b/docs/ENGINE_NOTES.md
@@ -1600,3 +1600,42 @@ dereference is_memory_valid + the entry self-index check); exposed as
 54129, and the equipped weapon's attach-bone FName (weapon+0xF0) ->
 **'Launcher'** (idx 18075) - the AHands rig's weapon-attach socket name
 (bone 43 in index space).
+
+### Weapon skeletons, bone names, and the muzzle ray (session 20 stage 5)
+
+**Bone-name map**: SkeletonInstance +0x08 -> SharedSkeletonData; its +0xAC map
+(lookup fn 0x5F6500, capstone-disassembled) is a standard UE hash map -
++0x00 pairs base (16-byte pairs {chain next, FName index, FName number,
+value}), +0x0C int32 bucket array (-1 empty), +0x10 bucket count (power of
+two). Walking every bucket chain enumerates FName->boneIndex, which inverted
++ fname_text gives index->name for ANY skeletal actor (`vrbones skel
+[hands|weapon]`).
+
+**The shotgun's own skeleton is 3 bones**: SG_Body (x=10.1), SG_Pump
+(x=57.3), SG_Shell (x=25.0) - all identity-ish quats, so the weapon's
+component +X is the barrel axis, and there is NO explicit muzzle bone. The
+muzzle ray therefore derives from the HANDS rig (bones 43->44 of the
+per-weapon reference pose), as the plan's on-file alternative anticipated.
+
+**Muzzle-ray derivation** (vraim muzzle on|off, default OFF): bones::drive
+writes every cluster quat as qtc (x) q_ref with qtc = inv(q_actor) (x)
+q_target, so the rendered world direction of (bone44ref - bone43ref) is
+q_target (x) d0 - the actor frame cancels, the head never enters
+(actor-frame rendering, session 12 part 3). d0 = normalize(p44ref - p43ref)
+is recomputed per frame from the live reference, so it is per-weapon (the
+reference IS the per-weapon animation) and follows any authored sway.
+**Flat-measured on the shotgun**: d0 = (0.98, ~0.01, 0.15-0.19) - the
+rendered barrel sits ~9-11 deg ABOVE the attach frame's forward and visibly
+wanders inside that band with the idle sway (the misalignment users
+hand-trim today, now followed automatically). Muzzle off -> ray rot
+(0, camYaw); on -> (+1971, +41) units = +10.8/+0.2 deg = asin(d0.z) exactly.
+Fire test with the muzzle ray live: calls=3 subs=3 skips=0, dumps 8->8. The
+laser rides the same d0 XR-side (LaserConfig.muzzle; model trim incl. ROLL -
+roll moves an off-axis vector).
+
+**Negative result**: `exec NextWeapon` through the viewport chain FAULTS
+(eip exe+0x4C2353, SEH caught) - UE2 stock console weapon switching is not
+wired on this build; flat weapon switching stays an open harness gap (the
+bumpers open the session-19 radial, which needs real stick timing). The
+per-weapon d0 change is structurally guaranteed but goes to the in-headset
+checklist for the eyes-on proof.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -464,7 +464,10 @@ fixed or the release waits:**
 
 ## M9 - Comfort + UI/config + release polish (~2–3 sessions)
 
-**Two-hand track (user's call 2026-07-28, sequenced AFTER the session-20 aim work):**
+**Two-hand track (user's call 2026-07-28, sequenced AFTER the session-20 aim work -
+which SHIPPED 2026-07-28 on branch s20-aim-sync: one trim algebra (28.21 -> 0.03 deg),
+vrrec record+replay, FName/GNames + named skeleton dumps, the muzzle ray, the idle-sway
+kill. Both prerequisites below are now MET.):**
 - [ ] **Off-hand tracking** (`vrhands offhand track|hide`, default hide until judged by
       eye): drive the INACTIVE hand's cluster from its controller instead of collapsing
       it - the same rigid drive run on both clusters per frame. Reload/idle anims on the

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,7 +2,102 @@
 
 > Handoff file. Rewrite "Current state" and "Next steps" every session; append to the session log.
 
-## Current state (2026-07-28, session 19 - M8 COMPLETE, v0.2.0 PUBLISHED: HUD on a floating quad, VR bindings, inactive hand hidden, stick pitch killed)
+## Current state (2026-07-28, session 20 - THE AIM-SYNC SESSION: one trim algebra, vrrec record+replay, FName/GNames, the muzzle ray, the idle-sway kill - ALL SIX STAGES FLAT-GREEN on branch s20-aim-sync)
+
+**Branch `s20-aim-sync` (from main at v0.2.0). Every stage below passed its
+numeric flat gate on clean boots; the in-headset checklist below is the open
+gate, and v0.3.0 publishes only after it + the user's explicit go. The
+session-19 plan's stage designs (4.1-4.6) were followed as written - nothing
+re-derived - with two design corrections forced by measurement (the SET-seam
+sway premise dissolved; the fopen_s share-mode trap resurfaced 19 sessions
+after session 1 fixed the same bug in the logger).**
+
+**1. The root cause is MEASURED, then KILLED (stages 1-2, the headline).**
+`vraim synccheck` sweeps 21 axis-angle controller orientations (roll
+included) through BOTH pose->rot chains as PURE functions
+(frame_context.h - production and the test share the code). Pre-fix
+baseline with a canonical 10/10 trim fed identically to both chains: 0.00
+deg at identity/pure-yaw poses, ~4-12 on pitch, 10.70/19.85/**28.21 deg at
+45/90/180 roll** - roll is where the two algebras differed most, exactly
+where eye-tuning never looked. Post-unification (ray + laser adopt the
+model's `q_ctrl (x) q_trim` compose via the promoted core/util/xr_math.h;
+`ray_pose_from_xr` = `model_pose_from_xr` + roll drop; the laser's origin
+basis now angle-built zero-roll, degeneracy bail gone; legacy `aligntrim`
+DELETED): canonical max **0.03 deg** (the int-rotator floor) at every pose,
+and the live-L divergence reads a CONSTANT 17.70 deg at every orientation =
+pure trim-value difference, orientation-independent - the definition of one
+algebra. Tuned trims carry over by construction. Fire test exact, laser
+echo unchanged, dumps 8->8.
+
+**2. vrrec record+replay (stage 3) - frame-for-frame EXACT.** One tap in
+CalcView's tail records what the game consumed (head, the four
+funnel poses, the published pad, predictedDisplayTime); replay feeds a
+dedicated head lane in the camera gate + sim slots ON the
+input_get_hand_pose funnel (ray, model, laser all read one world) + the pad
+publish, with recenter state + worldScale serialized in the header and
+restored on play. Acceptance: a neutral-stick simhead sweep (7112 frames)
+replayed with **712/712 marks bitwise identical** - |dloc| 0.000000 UU,
+rot/cam delta 0 units, head pose exact, pad exact - including the swept
+segments (20-deg head yaw replayed to the unit). Traps found and settled:
+the seam's trailing newline read as a file name (errno 22); fopen_s opens
+non-sharable (fresh recordings held by the indexer - _wfsopen _SH_DENYNO);
+`vrbody`'s probe moves gameYaw/recenterYaw between record and play, so
+comparisons run `vrbody off` or settled (documented in TESTING.md).
+`vrrec hand` arms a static funnel pose - the flat record path.
+
+**3. FName index->string (stage 4).** The event scan's discarded FName-ctor
+address is now captured (RVA 0x70D660 -> worker 0x70D3C0); capstone
+disassembly yielded GNames (TArray<FNameEntry*> Data at RVA 0x13904EC),
+the 4096-bucket name hash (0x1370EC0), and the entry layout that matches
+the package prior (+0 self-index, +4/+8 the 8-byte flags, +0xC chain,
++0x10 UTF-16 text). `patterns::fname_text()` validates every dereference +
+the self-index. Gate: index 0 -> 'None', 1 -> 'ByteProperty' (the canonical
+table opening), and the weapon's attach-bone FName (weapon+0xF0) ->
+**'Launcher'** (GNames count 54129).
+
+**4. The muzzle ray (stage 5; `vraim muzzle on|off`, DEFAULT OFF pending
+your verdict).** `vrbones skel weapon` dumps ANY actor's skeleton WITH
+names (the SharedSkeletonData +0xAC FName->index map, layout from the
+0x5F6500 lookup disasm, walked in reverse): the shotgun is 3 bones
+(SG_Body/SG_Pump/SG_Shell, +X = barrel, NO muzzle bone) - so the ray
+derives from the HANDS rig as the plan's on-file alternative: rendered
+world barrel = q_target (x) d0 with d0 = normalize(bone44ref - bone43ref)
+(the actor frame cancels - derivation in ENGINE_NOTES). d0 is per-weapon
+BY CONSTRUCTION (the reference pose IS the per-weapon animation - the
+flat-measured shotgun value: the barrel sits **~9-11 deg ABOVE the attach
+forward**, the exact misalignment hand-trimmed by eye until now). Flat:
+muzzle off ray rot (0, camYaw) -> on (+1971, +41) units = asin(d0.z) to
+the unit; fire subs 3/3 with the muzzle ray live; the laser rides the same
+d0 XR-side (model trim incl. ROLL - it moves an off-axis vector). Open
+flat gap, honestly: a per-weapon d0 CHANGE was not demonstrated flat
+(bumpers open the radial, which needs real stick timing; `exec NextWeapon`
+FAULTS - SEH caught, negative result logged) - it is structural + on your
+checklist.
+
+**5. The idle-sway kill (stage 6; `vrhands swaykill on|off`, DEFAULT ON).**
+Measured FIRST: at idle the reference barrel direction breathes **+-1.2
+deg** (8.4-11.0 deg band, the muzzle echo as instrument); anchor deltas
+peak 3.01 UU / 4.6 deg. The SET-seam premise DISSOLVED on decompilation:
+UpdateHandBobAnimationParameters is the WALK bob (channel 2, weight =
+velocity/GroundSpeed = zero at standstill) - the idle breathing is the
+authored base idle animation, no script property to zero. The kill lives
+where the sway enters the VR rig: the drive's reference recapture now
+FREEZES unless either wrist anchor moves past 6 UU / 12 deg (2x the
+measured envelope) with a 600 ms settle window so post-animation freezes
+hold the SETTLED pose. Flat: kill ON = barrel axis bitwise identical 8/8
+over 32 s; OFF = wobble back instantly; two fire pulls passed the
+threshold and re-froze 3/3 (settled 0.4 deg from the old snapshot). The
+weapon's own skeleton (pump/cylinder) animates untouched.
+
+**Promoted-build clean-boot smoke (the stage-6 build):** preset chain in
+order, stereo heartbeat clean (mode=1T, presents = 2x builds, guardskips
+0), fire test subs exact, crash dumps 8->8 across every boot of the
+session, vrpreset.ini + hands.ini untouched (live values loaded and echoed
+correctly all session). Off-hand tracking (the stretch) was NOT started -
+it stays queued in M9, now unblocked (one algebra + per-weapon identity
+both exist).
+
+## Previous state (2026-07-28, session 19 - M8 COMPLETE, v0.2.0 PUBLISHED: HUD on a floating quad, VR bindings, inactive hand hidden, stick pitch killed)
 
 **v0.2.0 IS PUBLISHED** (tag on main at PR #4's merge,
 https://github.com/mohamad-balouza/bioshock-vr/releases/tag/v0.2.0) after the
@@ -1252,70 +1347,32 @@ https://github.com/mohamad-balouza/bioshock-vr. Em dashes banned repo-wide.
 
 ## Next steps
 
-0. **THE IN-HEADSET CHECKLIST BELOW, then v0.2.0** (tag on merged main,
-   `build.ps1 -Release`, zip both RelWithDebInfo DLLs + README.txt, notes
-   leading with what moved off the v0.1.0 known-issues list: HUD readability,
-   bindings, the ghost hand, stick pitch). PR is open; merge + publish only
-   on the user's explicit go.
+0. **THE IN-HEADSET CHECKLIST BELOW (session 20), then v0.3.0**: after the
+   user's pass + explicit go - merge PR, tag v0.3.0 on merged main,
+   `build.ps1 -Release`, zip both RelWithDebInfo DLLs + README.txt (README
+   gets the new commands in the same pass: vraim muzzle, vrhands swaykill,
+   vrrec, vrbones skel, vrhands fname, vraim synccheck), notes leading with
+   the aim-sync fix (28.21 deg -> 0.03) + the sway kill.
 
-1. **SESSION 20 PLAN - aim/laser/model sync + the flat testing framework
-   (session-19 plan item 4, deferred whole by the user's call; the full
-   design incl. the design-check agent's refinements is in the session-19
-   plan file `~/.claude/plans/continue-the-bioshock-vr-project-frolicking-
-   hinton.md`, stages 4.1-4.6):**
+1. **Post-verdict decisions the checklist feeds**: does `vraim muzzle`
+   become the DEFAULT (and ride vrpreset.ini)? Does swaykill stay
+   default-ON? If muzzle wins per-weapon judgment for some weapons only,
+   build per-weapon profiles keyed by class name (the FName machinery
+   exists - fname_text of the weapon's class).
 
-   (a) `synccheck` FIRST (the failing baseline): refactor the ray and model
-   pose->rot chains into pure functions, cache the last FrameContext, sweep
-   ~20 axis-angle orientations INCLUDING roll, print max ray-vs-barrel
-   divergence for live AND canonical (10/10) trims. Expect nonzero pre-fix.
-   (b) Unify the trim algebra: ray + laser adopt the model's local-frame
-   quat compose (q_ctrl x q_trim, trim built by xr_local_trim_quat, roll
-   dropped only at the final rotator write); laser origin basis adopts the
-   ray's zero-roll convention (kill its near-vertical degeneracy bail);
-   DELETE the legacy aligntrim euler path; promote quat helpers to a core
-   math header. Gate: synccheck collapses to ~0 at every orientation; the
-   user's tuned trim values carry over (they agree at the tuning pose).
-   The model's own full-roll offset basis stays UNTOUCHED (live tuning).
-   (c) Record+replay (`vrrec start|stop|play|status`): ONE tap in
-   camera.cpp's CalcView tail (works flat AND in-headset - an
-   on_present_begin tap cannot record flat), heads via a replayHead lane
-   (simHead is angles-only), hands via NEW sim slots at the
-   input_get_hand_pose funnel, pad via publish_xr_state; RECENTER STATE +
-   worldScale serialized in the file header or every comparison fails;
-   frame-for-frame replay; `[rec] mark` lines every 10th frame; refuse
-   play while a session lives. Gate: neutral-stick record/replay with
-   |dloc| < 0.01 UU, |drot| <= 2 units, pad exact.
-   (d) FName index->string: capture the FName-ctor address
-   find_fname_index_global already computes AND DISCARDS (:129-134),
-   disassemble to GNames (capstone), licensee layout prior = UTF-16
-   POSITIVE count 8-byte flags; fallback = the GetHighBone{Name,Index}
-   native oracle via find_native_function.
-   (e) Muzzle-bone probe: bones::locate() is already generic - run it on
-   the cached g_weaponActor (produced every frame, currently unused), dump
-   bone names via (d), derive the ray from the muzzle bone's rendered
-   transform (compose weapon component space through the attach at hands
-   bone 43). Fallback: per-weapon manual profiles keyed by class name.
-   Cheap alternative on file: hands-rig bone 44 = "muzzle-ish tip" at
-   x=+71.
-   (f) Idle-sway investigation + kill (user 2026-07-27: clearly visible
-   in-headset, likely less than flat - "worth it to put our minds at
-   ease"): MEASURE the surviving amplitude flat first (shot series, lock
-   on/off), decompile UpdateHandBobAnimationParameters + Hands
-   defaultproperties (dump.ps1, ~40% fail rate), then zero the bob params
-   via the SET seam (re-assert like vrxhair); toggle + armed by PRESET 1.
+2. **SESSION 20 leftovers, small**: demonstrate a per-weapon d0 change flat
+   (needs a flat weapon-switch lane - the radial wants real stick timing;
+   `exec NextWeapon` faults, negative result logged); wire
+   find_weapon_actor's caching form per frame if stage-5 features grow.
 
-   ANSWERED by the session-19 headset run: the wrench works with the pitch
-   kill alone - the HMD-pitch body drive is NOT needed and is dropped. Watch
-   only: map-pan-under-pause if the user ever reports the right stick dead
-   there (the pitchkill gate is strict-view, which stays true while paused).
+3. **Off-hand tracking + two-handed weapons (ROADMAP M9)** - now UNBLOCKED:
+   both prerequisites (one trim algebra; per-weapon identity via
+   FName/skeletons) shipped this session. Then the wrench swing gesture and
+   the first-boot-restart fix (M9 polish).
 
-   FOLLOW-ONS QUEUED BEHIND THIS WORK (user's call 2026-07-28, detailed in
-   ROADMAP M9): off-hand tracking (`vrhands offhand track` - drive the
-   inactive cluster from its controller instead of collapsing it; do after
-   (b) so both hands ride one algebra) and TWO-HANDED weapon handling
-   (foregrip engage + rear-to-front-hand aim line; hard prerequisites are
-   (b) and (d)/(e) - per-weapon identity and foregrip offsets). Neither
-   blocks v0.2.0.
+4. **vrrec follow-on**: record a real in-headset run (checklist item 8) and
+   replay it flat next session - the first true flat reproduction of a
+   headset defect report.
 
 2. **DONE 2026-07-27: v0.1.0 IS PUBLISHED** - tag on main at PR #3's merge,
    release zip (both RelWithDebInfo DLLs + README.txt) at
@@ -1389,7 +1446,51 @@ Carried-over backlog (numbering kept from session 17):
 13. **Parked in M9** (user's call 2026-07-24): IPD slider verification, small
     head-motion bobbing, the vrstereo off/re-arm state bug, HUD-in-both-eyes.
 
-### IN-HEADSET CHECKLIST - M8 completion (session 19)
+### IN-HEADSET CHECKLIST - aim sync + testing framework (session 20)
+
+Setup as always: Quest 3 + Virtual Desktop (VDXR), launch from Steam, CONTINUE
+(the NG+ Medical Pavilion all-weapons anchor), press **VR PRESET 1**. Nothing
+in the camera/recenter/body path changed - head decoupling and body-follow
+must feel identical to v0.2.0; any difference there is a regression, say so
+first. Live A/Bs: `vraim muzzle on|off`, `vrhands swaykill on|off`.
+
+1. **Non-regression sweep (60 s, do first).** Park the hand, look around
+   wide, stick-walk, turn past 90 both ways, two right-trigger pulls + an
+   Electro Bolt, open the pause menu once. Anything session 19 did not do:
+   stop and report.
+2. **THE ALGEBRA FIX (the headline). Laser vs barrel at MANY orientations,
+   ESPECIALLY WRIST ROLL.** Weapon up, laser on: roll your wrist +-90, tilt
+   up/down/diagonal, point across your body - the laser must stay glued to
+   the barrel line at EVERY orientation now (pre-fix it drifted up to ~28
+   deg at rolled poses - the "agrees only where I tuned it" defect). Same
+   check on the plasmid hand: whatever offset the L laser has vs the hand,
+   it should now be CONSTANT at every orientation (if you want it tighter,
+   `vraim cal l <pitch> <yaw>` now holds everywhere, not just at one pose).
+3. **THE MUZZLE RAY** (arm `vraim muzzle on`): bullets + laser now leave
+   along the RENDERED barrel. Judge vs `vraim muzzle off` (the trimmed
+   controller ray you have today). Then SWITCH WEAPONS through the wheel -
+   pistol, MG, shotgun, crossbow - each should auto-align its laser to its
+   own barrel with ZERO manual trim (this is the per-weapon proof the flat
+   harness could not do). Report per weapon which mode aims truer.
+4. **THE SWAY KILL** (on by default): raise a weapon, stand still, watch
+   the barrel/laser - the breathing should be GONE. `vrhands swaykill off`
+   = the old sway for comparison. Then verify animations still LIVE: fire,
+   reload, switch weapons, swing the wrench - all should play through
+   normally and the hand must settle correctly afterwards (a hand frozen
+   mid-pose after an animation = the settle window failed, report it).
+5. **Quick controls regression** (adjacent code, unchanged paths): wheel
+   select incl. up/down with pitch restore, ammo click-hold select, A/B/X/Y
+   as v0.2.0.
+6. **(optional but valuable, 60 s) Record a real run**: `vrrec start`, play
+   normally - walk, look, fire, switch - then `vrrec stop`. That file lets
+   me replay your exact run flat next session (first true flat reproduction
+   of headset behavior). Nothing to judge; just do it once mid-session.
+7. **The 4 GB-scan field watch**: if the model EVER stops following after a
+   level transition, grab the log ("AHands scan" lines).
+8. **Anything off**: `vraim muzzle off` / `vrhands swaykill off` first - if
+   the symptom survives both, it predates this session.
+
+### PREVIOUS CHECKLIST - M8 completion (session 19) - PASSED (v0.2.0 shipped on it)
 
 Setup as always: Quest 3 + Virtual Desktop (VDXR), launch from Steam, load the
 newest save (CONTINUE = the NG+ Medical Pavilion all-weapons anchor), press
@@ -1638,6 +1739,33 @@ and it resumes.
   (install.ps1 backs theirs up automatically).
 
 ## Session log (newest first)
+
+### 2026-07-28 - Session 20 (the aim-sync session: all six stages flat-green)
+
+- Worked the session-19 plan stages 4.1-4.6 as designed, each flat-gated:
+  synccheck baseline (canonical algebra divergence 28.21 deg max, roll-
+  dominant) -> trim-algebra unification (0.03 deg max = the int-rotator
+  floor; quat helpers promoted to core/util/xr_math.h; aligntrim deleted)
+  -> vrrec record+replay (712/712 marks bitwise exact incl. swept head
+  segments) -> FName/GNames (ctor 0x70D660 captured, GNames 0x13904EC,
+  'None'/'ByteProperty'/'Launcher' resolved) -> muzzle ray (vraim muzzle;
+  shotgun barrel measured ~9-11 deg above the attach forward; laser rides
+  the same d0) -> idle-sway kill (vrhands swaykill; +-1.2 deg measured,
+  frozen bitwise 8/8, animations pass a 2x-envelope threshold with a 600 ms
+  settle window).
+- Design corrections forced by measurement: the SET-seam sway premise
+  dissolved (the bob function is the velocity-weighted WALK bob; idle
+  breathing is the authored idle anim - no property to zero), so the kill
+  moved to the drive's reference recapture; fopen_s share-mode trap hit
+  AGAIN (session 1 fixed the same bug in the logger) - recordings open via
+  _wfsopen _SH_DENYNO.
+- Negative results logged: `exec NextWeapon` faults (SEH caught); flat
+  weapon switching through the radial remains a harness gap; vrbody state
+  poisons record/replay comparisons (documented rule: vrbody off or
+  settled).
+- Stretch (off-hand tracking) not started - queued in M9, now unblocked.
+- Branch s20-aim-sync, six commits, PR opened; v0.3.0 waits on the
+  in-headset checklist + explicit go.
 
 ### 2026-07-28 - Session 19 close (v0.2.0 PUBLISHED)
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -231,6 +231,19 @@ evidence, and both need a headset.
   `%LOCALAPPDATA%\BioshockVR\framedump_HHMMSS.txt` for the next full Present-to-Present
   frame: per-draw RTs/formats, viewports, VS b0 readback (full mode), callstack RVAs, and
   a draws-per-RT + stack-histogram summary. Never commit dumps (game-derived).
+- **Record/replay (session 20)**: `vrrec start|stop|play [file]|hand [p y r|off]|status`
+  records the per-frame input state (head pose, the four hand-funnel poses, the XR pad)
+  once per game tick at the CalcView tail and replays it frame for frame through the
+  production paths - files in `%LOCALAPPDATA%\BioshockVR\recordings\*.bvrrec`, recenter
+  state + worldScale in the header (restored on play). `vrrec hand` arms a static
+  synthetic pose on all four funnel slots (model+ray+laser follow it - the flat record
+  path). `[rec] REC/PLAY mark` lines every 10th frame print head pose, driven camera,
+  and the aim-R ray through the shared pure chain - a record log and a replay log are
+  comparable number for number (session-20 acceptance: 712/712 marks bitwise EXACT).
+  Rules: `play` refuses while an XR session lives; RECENTER BEFORE `start`, never
+  during; record comparisons with `vrbody off` (or long-settled) - the yaw transfer's
+  probe moves gameYaw/recenterYaw between record and replay time and offsets every
+  camera mark by the transferred amount (measured: the 1.1 deg arm probe = 200 units).
 - **Reentry probe (DR-5)**: `reentry hook [build|submit|drain|flush]` / `reentry unhook`
   (MinHook the game-thread scene BUILD root (default - the SequentialReentry seam), the
   frame submit, the render-thread drain, or the flush - command-gated, default runs stay

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,6 +59,8 @@ add_library(bioshockvr SHARED
     game/bioshock1r/input_drive.h
     game/bioshock1r/patterns.cpp
     game/bioshock1r/patterns.h
+    game/bioshock1r/recorder.cpp
+    game/bioshock1r/recorder.h
     game/bioshock1r/scenedraw.cpp
     game/bioshock1r/scenedraw.h
     game/bioshock1r/ue_math.h

--- a/src/core/hooks/pattern_scan.cpp
+++ b/src/core/hooks/pattern_scan.cpp
@@ -118,7 +118,8 @@ std::vector<const uint8_t*> find_references(const ProcessImage& img, const void*
     return out;
 }
 
-const uint8_t* find_fname_index_global(const ProcessImage& img, const uint8_t* stringXref) {
+const uint8_t* find_fname_index_global(const ProcessImage& img, const uint8_t* stringXref,
+                                       const uint8_t** ctorOut) {
     constexpr size_t kForwardWindow = 96;
     const uint8_t* imageEnd = img.base + img.size;
     const uint8_t* windowEnd = stringXref + kForwardWindow;
@@ -132,6 +133,14 @@ const uint8_t* find_fname_index_global(const ProcessImage& img, const uint8_t* s
         }
     }
     if (!call) return nullptr;
+    if (ctorOut) {
+        // Resolve the rel32: target = end-of-instruction + displacement. This
+        // is the FName constructor itself - previously computed and thrown
+        // away; session 20 keeps it (GNames falls out of its disassembly).
+        int32_t rel;
+        memcpy(&rel, call + 1, sizeof rel);
+        *ctorOut = call + 5 + rel;
+    }
 
     for (const uint8_t* p = call + 5; p + 6 <= windowEnd; ++p) {
         if (p[0] == 0x89 && p[1] == 0x0D) { // MOV [imm32], ECX - index store
@@ -172,9 +181,11 @@ bool find_event_function(const ProcessImage& img, const char* eventName, EventSc
         out.stringXrefs += stringXrefs.size();
 
         for (const uint8_t* sx : stringXrefs) {
-            const uint8_t* global = find_fname_index_global(img, sx);
+            const uint8_t* ctor = nullptr;
+            const uint8_t* global = find_fname_index_global(img, sx, &ctor);
             if (!global) continue;
             out.fnameIndexGlobal = global;
+            out.fnameCtor = ctor;
 
             std::vector<const uint8_t*> globalXrefs = find_references(img, global);
             out.globalXrefs = globalXrefs.size();

--- a/src/core/hooks/pattern_scan.h
+++ b/src/core/hooks/pattern_scan.h
@@ -40,8 +40,11 @@ std::vector<const uint8_t*> find_references(const ProcessImage& img, const void*
 // From a code xref to an FName's init string: forward-scan (<=96 bytes) for
 // the E8 CALL into the FName constructor, then past that 5-byte CALL for the
 // 89 0D (mov [imm32], ecx) store that caches the returned name index. Returns
-// the address of that global, or null.
-const uint8_t* find_fname_index_global(const ProcessImage& img, const uint8_t* stringXref);
+// the address of that global, or null. `ctorOut` (optional) receives the
+// resolved CALL target - the FName constructor itself, the entry point of the
+// engine's whole name system (session 20: disassembling it yields GNames).
+const uint8_t* find_fname_index_global(const ProcessImage& img, const uint8_t* stringXref,
+                                       const uint8_t** ctorOut = nullptr);
 
 // Backward-scan (<=512 bytes) from an xref for the MSVC function prologue
 // CC CC CC 55 8B EC. Returns the address of the 55 (push ebp), or null.
@@ -52,6 +55,7 @@ struct EventScanResult {
     size_t stringMatches = 0;            // wide-string occurrences of the name
     size_t stringXrefs = 0;              // code refs to those strings
     const uint8_t* fnameIndexGlobal = nullptr;
+    const uint8_t* fnameCtor = nullptr;  // the FName constructor (session 20)
     size_t globalXrefs = 0;              // refs to the FName index global
     size_t candidates = 0;               // refs surviving the init-site filter
     void* function = nullptr;            // resolved event function entry point

--- a/src/core/input/xinput_bridge.cpp
+++ b/src/core/input/xinput_bridge.cpp
@@ -492,6 +492,12 @@ void publish_xr_state(const Gamepad& pad, bool active) {
     g_xrLastMs = GetTickCount64();
 }
 
+void last_xr_pad(Gamepad* pad, bool* active) {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    if (pad) *pad = g_xrPad;
+    if (active) *active = g_xrActive;
+}
+
 void publish_vr_gameplay(bool on) {
     g_vrGameplay.store(on, std::memory_order_relaxed);
     g_vrGameplayLastMs.store(GetTickCount64(), std::memory_order_relaxed);

--- a/src/core/input/xinput_bridge.h
+++ b/src/core/input/xinput_bridge.h
@@ -32,6 +32,11 @@ bool enabled();
 // focused); the slot also self-expires if publishing stops entirely.
 void publish_xr_state(const Gamepad& pad, bool active);
 
+// The last pad published above + its active flag - what the composer will
+// merge this frame. The session-20 recorder taps it per CalcView so a replay
+// can re-publish the exact pad stream.
+void last_xr_pad(Gamepad* pad, bool* active);
+
 // The game layer publishes "the VR camera is driving a REAL gameplay view"
 // once per frame (CalcView; strict predicate - menus/cutscenes publish
 // false). While true and pitchkill is on, the composed right-stick Y is

--- a/src/core/util/xr_math.h
+++ b/src/core/util/xr_math.h
@@ -1,0 +1,66 @@
+#pragma once
+// Quaternion helpers on XR conventions (right +X, up +Y, forward -Z, meters,
+// right-handed) - PURE math, no engine semantics, which is why this lives in
+// core: the laser (core/vr) and the game adapters must compose trims with the
+// SAME algebra or the beam and the barrel disagree everywhere but the tuning
+// pose (session 20, the aim-sync unification). Promoted from
+// game/bioshock1r/ue_math.h, which re-exports these for its own callers.
+
+#include <cmath>
+
+namespace bvr::xrmath {
+
+// Rotate v by the quaternion (xyzw).
+inline void quat_rotate(float qx, float qy, float qz, float qw, const float v[3],
+                        float out[3]) {
+    float t[3] = {2.0f * (qy * v[2] - qz * v[1]), 2.0f * (qz * v[0] - qx * v[2]),
+                  2.0f * (qx * v[1] - qy * v[0])};
+    out[0] = v[0] + qw * t[0] + (qy * t[2] - qz * t[1]);
+    out[1] = v[1] + qw * t[1] + (qz * t[0] - qx * t[2]);
+    out[2] = v[2] + qw * t[2] + (qx * t[1] - qy * t[0]);
+}
+
+// Hamilton product a (x) b, xyzw order: rotating by the result applies b
+// FIRST, then a. `pose (x) trim` therefore applies the trim in the POSE'S OWN
+// local frame - which is what a mesh-alignment offset must be. Adding euler
+// angles after conversion only behaves at one controller orientation; the M7
+// in-headset test proved that the hard way (the "pivot that breaks
+// everything"), and the session-20 synccheck baseline measured it at up to
+// 28.21 deg of ray-vs-barrel divergence.
+inline void quat_mul(const float a[4], const float b[4], float out[4]) {
+    out[0] = a[3] * b[0] + a[0] * b[3] + a[1] * b[2] - a[2] * b[1];
+    out[1] = a[3] * b[1] - a[0] * b[2] + a[1] * b[3] + a[2] * b[0];
+    out[2] = a[3] * b[2] + a[0] * b[1] - a[1] * b[0] + a[2] * b[3];
+    out[3] = a[3] * b[3] - a[0] * b[0] - a[1] * b[1] - a[2] * b[2];
+}
+
+inline void quat_axis_angle(float ax, float ay, float az, float rad, float out[4]) {
+    float s = sinf(rad * 0.5f);
+    out[0] = ax * s;
+    out[1] = ay * s;
+    out[2] = az * s;
+    out[3] = cosf(rad * 0.5f);
+}
+
+inline void quat_conj(const float q[4], float out[4]) {
+    out[0] = -q[0];
+    out[1] = -q[1];
+    out[2] = -q[2];
+    out[3] = q[3];
+}
+
+// Local-frame trim quaternion from user-facing angles, XR axes, signs chosen
+// to match the UE conventions the sliders claim: +pitch tilts up, +yaw turns
+// right, +roll tilts clockwise (right). Applied as pose (x) trim. The roll
+// axis is INNERMOST (qy * (qp * qr)), so a roll trim can never change where a
+// ray points - which is why the aim trim stays pitch/yaw-only.
+inline void xr_local_trim_quat(float pitchRad, float yawRad, float rollRad, float out[4]) {
+    float qy[4], qp[4], qr[4], t[4];
+    quat_axis_angle(0.0f, 1.0f, 0.0f, -yawRad, qy);  // +Y is up; -angle = right
+    quat_axis_angle(1.0f, 0.0f, 0.0f, pitchRad, qp); // +X is right; + = up
+    quat_axis_angle(0.0f, 0.0f, -1.0f, rollRad, qr); // -Z is forward; + = clockwise
+    quat_mul(qp, qr, t);
+    quat_mul(qy, t, out);
+}
+
+} // namespace bvr::xrmath

--- a/src/core/vr/openxr_input.cpp
+++ b/src/core/vr/openxr_input.cpp
@@ -89,6 +89,16 @@ struct HandSlot {
 HandSlot g_hands[2]; // grip pose: 0 = left, 1 = right
 HandSlot g_aims[2];  // aim pose, same indexing
 
+// Session 20 vrrec: sim overlay ON the funnel. While armed, EVERY consumer of
+// input_get_hand_pose (fire ray, viewmodel, laser) reads the injected poses
+// instead of the runtime's - replay only works if all three see one
+// consistent world. Written from the game thread (replay tick / drive
+// command), read game+render side - the same atomics discipline as the live
+// slots.
+std::atomic<bool> g_simHandsActive{false};
+HandSlot g_simHands[2];
+HandSlot g_simAims[2];
+
 // Telemetry for the overlay (render thread writes, overlay reads same thread).
 std::atomic<uint32_t> g_syncOk{0};
 std::atomic<uint32_t> g_syncNotFocused{0};
@@ -474,11 +484,33 @@ void input_sync(XrSession session, XrTime predictedDisplayTime) {
 
 bool input_get_hand_pose(int hand, bool aimPose, float* pos3, float* quat4) {
     if (hand < 0 || hand > 1 || !pos3 || !quat4) return false;
-    const HandSlot& s = aimPose ? g_aims[hand] : g_hands[hand];
+    const bool sim = g_simHandsActive.load(std::memory_order_relaxed);
+    const HandSlot& s = sim ? (aimPose ? g_simAims[hand] : g_simHands[hand])
+                            : (aimPose ? g_aims[hand] : g_hands[hand]);
     if (!s.valid.load(std::memory_order_relaxed)) return false;
     pos3[0] = s.px; pos3[1] = s.py; pos3[2] = s.pz;
     quat4[0] = s.qx; quat4[1] = s.qy; quat4[2] = s.qz; quat4[3] = s.qw;
     return true;
+}
+
+void input_set_sim_hand(int hand, bool aimPose, bool valid, const float pos3[3],
+                        const float quat4[4]) {
+    if (hand < 0 || hand > 1) return;
+    HandSlot& s = aimPose ? g_simAims[hand] : g_simHands[hand];
+    if (pos3) { s.px = pos3[0]; s.py = pos3[1]; s.pz = pos3[2]; }
+    if (quat4) { s.qx = quat4[0]; s.qy = quat4[1]; s.qz = quat4[2]; s.qw = quat4[3]; }
+    s.valid.store(valid, std::memory_order_relaxed);
+    // Arming ANY slot flips the whole funnel to sim - unset slots read
+    // invalid, which is what a faithful replay of an untracked hand wants.
+    g_simHandsActive.store(true, std::memory_order_relaxed);
+}
+
+void input_clear_sim_hands() {
+    g_simHandsActive.store(false, std::memory_order_relaxed);
+    for (int h = 0; h < 2; ++h) {
+        g_simHands[h].valid.store(false, std::memory_order_relaxed);
+        g_simAims[h].valid.store(false, std::memory_order_relaxed);
+    }
 }
 
 void input_draw_debug_ui() {

--- a/src/core/vr/openxr_input.h
+++ b/src/core/vr/openxr_input.h
@@ -46,4 +46,11 @@ void input_draw_debug_ui();
 // Unreal units.
 bool input_get_hand_pose(int hand, bool aimPose, float* pos3, float* quat4);
 
+// Session 20 vrrec: sim overlay on the funnel above. While any slot is armed,
+// input_get_hand_pose serves the injected poses to ALL consumers (ray, model,
+// laser); clear restores the live slots. Game-thread writers.
+void input_set_sim_hand(int hand, bool aimPose, bool valid, const float pos3[3],
+                        const float quat4[4]);
+void input_clear_sim_hands();
+
 } // namespace bvr::vr

--- a/src/core/vr/openxr_runtime.cpp
+++ b/src/core/vr/openxr_runtime.cpp
@@ -9,6 +9,7 @@
 #include "core/gfx/blit.h"
 #include "core/gfx/hud_capture.h"
 #include "core/util/log.h"
+#include "core/util/xr_math.h"
 
 #ifdef BVR_WITH_OPENXR
 
@@ -1030,56 +1031,40 @@ uint32_t build_laser_layers(XrCompositionLayerQuad* quads) {
     float pos[3], quat[4];
     if (!input_get_hand_pose(hand, true, pos, quat)) return 0; // AIM pose = the fire ray
 
-    // Controller forward (-Z in XR), then the SAME pitch/yaw trim the fire ray
-    // applies, expressed the same way: yaw about world up, pitch about the
-    // horizon. If these two ever disagree the laser stops being a calibration
-    // tool and becomes a lie.
-    const float fwd[3] = {0.0f, 0.0f, -1.0f};
-    float d[3];
-    {
-        float qx = quat[0], qy = quat[1], qz = quat[2], qw = quat[3];
-        float t[3] = {2.0f * (qy * fwd[2] - qz * fwd[1]), 2.0f * (qz * fwd[0] - qx * fwd[2]),
-                      2.0f * (qx * fwd[1] - qy * fwd[0])};
-        d[0] = fwd[0] + qw * t[0] + (qy * t[2] - qz * t[1]);
-        d[1] = fwd[1] + qw * t[1] + (qz * t[0] - qx * t[2]);
-        d[2] = fwd[2] + qw * t[2] + (qx * t[1] - qy * t[0]);
-    }
+    // Session 20 unification: the laser composes its pitch/yaw trim as a
+    // quaternion in the controller's LOCAL frame - the model's and the fire
+    // ray's EXACT algebra (core/util/xr_math.h). The old spherical
+    // decomposition added the trim in world angles, which matched the other
+    // two only at the tuning pose. If these ever disagree again the laser
+    // stops being a calibration tool and becomes a lie.
     constexpr float kDegToRad = 3.14159265f / 180.0f;
-    float yaw = atan2f(d[0], -d[2]) + g_laserYawTrim.load(std::memory_order_relaxed) * kDegToRad;
-    float pitch = asinf(fmaxf(-1.0f, fminf(1.0f, d[1]))) +
-                  g_laserPitchTrim.load(std::memory_order_relaxed) * kDegToRad;
-    float cp = cosf(pitch);
-    d[0] = cp * sinf(yaw);
-    d[1] = sinf(pitch);
-    d[2] = -cp * cosf(yaw);
+    const float fwd[3] = {0.0f, 0.0f, -1.0f};
+    float trim[4], q2[4], d[3];
+    bvr::xrmath::xr_local_trim_quat(
+        g_laserPitchTrim.load(std::memory_order_relaxed) * kDegToRad,
+        g_laserYawTrim.load(std::memory_order_relaxed) * kDegToRad, 0.0f, trim);
+    bvr::xrmath::quat_mul(quat, trim, q2);
+    bvr::xrmath::quat_rotate(q2[0], q2[1], q2[2], q2[3], fwd, d);
 
-    // Ray ORIGIN offset (cm -> m) in the TRIMMED ray's zero-roll frame - the
-    // same offset the game-side ray build applies in UU (aim.cpp), so the
-    // beam and the fire origin move together by construction. right =
-    // d x worldUp (horizontal right of the ray), up completes the frame;
-    // near-vertical rays get the forward component only (degenerate cross).
+    // Ray ORIGIN offset (cm -> m) in the trimmed ray's ZERO-ROLL frame, built
+    // from the ray's YAW angle exactly like the game-side build (aim.cpp
+    // ue_rot_basis at roll 0) so the beam and the fire origin move together
+    // by construction. Angle-built right stays defined at ANY pitch - the old
+    // d x worldUp cross degenerated near vertical and silently dropped the
+    // right/up offset components there.
     {
         float ofM = g_laserPosFwdCm.load(std::memory_order_relaxed) * 0.01f;
         float orM = g_laserPosRightCm.load(std::memory_order_relaxed) * 0.01f;
         float ouM = g_laserPosUpCm.load(std::memory_order_relaxed) * 0.01f;
         if (ofM != 0.0f || orM != 0.0f || ouM != 0.0f) {
-            pos[0] += d[0] * ofM;
-            pos[1] += d[1] * ofM;
-            pos[2] += d[2] * ofM;
-            float right[3] = {d[1] * 0.0f - d[2] * 1.0f, d[2] * 0.0f - d[0] * 0.0f,
-                              d[0] * 1.0f - d[1] * 0.0f}; // d x (0,1,0)
-            float rl = sqrtf(right[0] * right[0] + right[1] * right[1] + right[2] * right[2]);
-            if (rl > 1e-3f) {
-                right[0] /= rl;
-                right[1] /= rl;
-                right[2] /= rl;
-                float up2[3] = {right[1] * d[2] - right[2] * d[1],
-                                right[2] * d[0] - right[0] * d[2],
-                                right[0] * d[1] - right[1] * d[0]}; // right x d
-                pos[0] += right[0] * orM + up2[0] * ouM;
-                pos[1] += right[1] * orM + up2[1] * ouM;
-                pos[2] += right[2] * orM + up2[2] * ouM;
-            }
+            float yaw = atan2f(d[0], -d[2]);
+            float right[3] = {cosf(yaw), 0.0f, sinf(yaw)};
+            float up2[3] = {right[1] * d[2] - right[2] * d[1],
+                            right[2] * d[0] - right[0] * d[2],
+                            right[0] * d[1] - right[1] * d[0]}; // right x d
+            pos[0] += d[0] * ofM + right[0] * orM + up2[0] * ouM;
+            pos[1] += d[1] * ofM + right[1] * orM + up2[1] * ouM;
+            pos[2] += d[2] * ofM + right[2] * orM + up2[2] * ouM;
         }
     }
 

--- a/src/core/vr/openxr_runtime.cpp
+++ b/src/core/vr/openxr_runtime.cpp
@@ -1549,6 +1549,23 @@ bool get_hand_pose(int hand, bool aimPose, HeadPose& out) {
     return true;
 }
 
+void set_sim_hand_pose(int hand, bool aimPose, bool valid, const float pos3[3],
+                       const float quat4[4]) {
+    input_set_sim_hand(hand, aimPose, valid, pos3, quat4);
+}
+
+void clear_sim_hand_poses() {
+    input_clear_sim_hands();
+}
+
+bool session_live() {
+    return g_session != XR_NULL_HANDLE;
+}
+
+int64_t last_predicted_time() {
+    return static_cast<int64_t>(g_frameState.predictedDisplayTime);
+}
+
 bool vr_camera_mode() {
     return g_cameraMode.load(std::memory_order_relaxed) &&
            g_sessionBegun.load(std::memory_order_relaxed) &&
@@ -1690,6 +1707,10 @@ void on_resize() {}
 void draw_debug_ui() {}
 bool get_head_pose(HeadPose&) { return false; }
 bool get_hand_pose(int, bool, HeadPose&) { return false; }
+void set_sim_hand_pose(int, bool, bool, const float[3], const float[4]) {}
+void clear_sim_hand_poses() {}
+bool session_live() { return false; }
+int64_t last_predicted_time() { return 0; }
 bool vr_camera_mode() { return false; }
 void set_camera_mode(bool) {}
 void set_enabled(bool) {}

--- a/src/core/vr/openxr_runtime.cpp
+++ b/src/core/vr/openxr_runtime.cpp
@@ -70,6 +70,11 @@ std::atomic<float> g_laserPitchTrim{0.0f}, g_laserYawTrim{0.0f};
 std::atomic<float> g_laserPosFwdCm{0.0f}, g_laserPosRightCm{0.0f}, g_laserPosUpCm{0.0f};
 std::atomic<int> g_laserDots{6};
 std::atomic<float> g_laserNearM{0.30f}, g_laserFarM{6.0f}, g_laserSizeDeg{0.7f};
+// Session 20 muzzle ray (see LaserConfig): beam along the rendered barrel.
+std::atomic<bool> g_laserMuzzle{false};
+std::atomic<float> g_laserMuzzleD0[3] = {0.0f, 0.0f, -1.0f};
+std::atomic<float> g_laserModelPitchTrim{0.0f}, g_laserModelYawTrim{0.0f},
+    g_laserModelRollTrim{0.0f};
 std::atomic<uint32_t> g_laserLayersSubmitted{0};
 std::atomic<bool> g_loggedFirstLaser{false};
 
@@ -1040,11 +1045,26 @@ uint32_t build_laser_layers(XrCompositionLayerQuad* quads) {
     constexpr float kDegToRad = 3.14159265f / 180.0f;
     const float fwd[3] = {0.0f, 0.0f, -1.0f};
     float trim[4], q2[4], d[3];
-    bvr::xrmath::xr_local_trim_quat(
-        g_laserPitchTrim.load(std::memory_order_relaxed) * kDegToRad,
-        g_laserYawTrim.load(std::memory_order_relaxed) * kDegToRad, 0.0f, trim);
-    bvr::xrmath::quat_mul(quat, trim, q2);
-    bvr::xrmath::quat_rotate(q2[0], q2[1], q2[2], q2[3], fwd, d);
+    if (g_laserMuzzle.load(std::memory_order_relaxed)) {
+        // Muzzle ray: the beam follows the RENDERED barrel - the MODEL's trim
+        // (roll included: it moves an off-axis vector) applied to the barrel
+        // axis the game side derived from the driven rig this frame.
+        const float d0[3] = {g_laserMuzzleD0[0].load(std::memory_order_relaxed),
+                             g_laserMuzzleD0[1].load(std::memory_order_relaxed),
+                             g_laserMuzzleD0[2].load(std::memory_order_relaxed)};
+        bvr::xrmath::xr_local_trim_quat(
+            g_laserModelPitchTrim.load(std::memory_order_relaxed) * kDegToRad,
+            g_laserModelYawTrim.load(std::memory_order_relaxed) * kDegToRad,
+            g_laserModelRollTrim.load(std::memory_order_relaxed) * kDegToRad, trim);
+        bvr::xrmath::quat_mul(quat, trim, q2);
+        bvr::xrmath::quat_rotate(q2[0], q2[1], q2[2], q2[3], d0, d);
+    } else {
+        bvr::xrmath::xr_local_trim_quat(
+            g_laserPitchTrim.load(std::memory_order_relaxed) * kDegToRad,
+            g_laserYawTrim.load(std::memory_order_relaxed) * kDegToRad, 0.0f, trim);
+        bvr::xrmath::quat_mul(quat, trim, q2);
+        bvr::xrmath::quat_rotate(q2[0], q2[1], q2[2], q2[3], fwd, d);
+    }
 
     // Ray ORIGIN offset (cm -> m) in the trimmed ray's ZERO-ROLL frame, built
     // from the ray's YAW angle exactly like the game-side build (aim.cpp
@@ -1664,6 +1684,12 @@ void set_laser(const LaserConfig& cfg) {
     g_laserNearM.store(cfg.nearM, std::memory_order_relaxed);
     g_laserFarM.store(cfg.farM, std::memory_order_relaxed);
     g_laserSizeDeg.store(cfg.sizeDeg, std::memory_order_relaxed);
+    g_laserMuzzle.store(cfg.muzzle, std::memory_order_relaxed);
+    for (int i = 0; i < 3; ++i)
+        g_laserMuzzleD0[i].store(cfg.muzzleD0[i], std::memory_order_relaxed);
+    g_laserModelPitchTrim.store(cfg.modelPitchTrimDeg, std::memory_order_relaxed);
+    g_laserModelYawTrim.store(cfg.modelYawTrimDeg, std::memory_order_relaxed);
+    g_laserModelRollTrim.store(cfg.modelRollTrimDeg, std::memory_order_relaxed);
 }
 
 void set_hud_quad(float distM, float widthM, float upM) {

--- a/src/core/vr/openxr_runtime.h
+++ b/src/core/vr/openxr_runtime.h
@@ -164,6 +164,16 @@ struct LaserConfig {
     float nearM = 0.30f;       // first dot, meters from the controller
     float farM = 6.0f;         // last dot
     float sizeDeg = 0.7f;      // angular diameter, so the beam reads evenly
+    // Session 20 muzzle ray: when on, the beam leaves along the RENDERED
+    // barrel instead of the trimmed controller forward - direction =
+    // (q_ctrl (x) model trim) applied to the barrel axis d0 (XR frame; the
+    // game side derives d0 from the driven rig's reference pose each frame).
+    // Roll matters for an off-axis vector, so the model ROLL trim rides too.
+    bool muzzle = false;
+    float muzzleD0[3] = {0.0f, 0.0f, -1.0f};
+    float modelPitchTrimDeg = 0.0f;
+    float modelYawTrimDeg = 0.0f;
+    float modelRollTrimDeg = 0.0f;
 };
 
 // Publish the laser state (game thread, once per frame). The render thread

--- a/src/core/vr/openxr_runtime.h
+++ b/src/core/vr/openxr_runtime.h
@@ -8,6 +8,8 @@
 // D3D11 hooks install; everything else runs on the game's render thread
 // inside the Present/ResizeBuffers detours.
 
+#include <cstdint>
+
 struct IDXGISwapChain;
 
 namespace bvr::vr {
@@ -52,6 +54,24 @@ bool get_head_pose(HeadPose& out);
 // `aimPose` true = the runtime's pointing ray (aiming), false = the grip pose
 // (hand/weapon placement).
 bool get_hand_pose(int hand, bool aimPose, HeadPose& out);
+
+// --- Session 20: vrrec record+replay support ---------------------------------
+// Sim overlay on the hand-pose funnel: while armed, every consumer of
+// get_hand_pose/input_get_hand_pose (fire ray, viewmodel, laser) reads the
+// injected poses. The recorder writes one set per replayed frame; a flat
+// drive command can arm a static set for recording without a headset.
+void set_sim_hand_pose(int hand, bool aimPose, bool valid, const float pos3[3],
+                       const float quat4[4]);
+void clear_sim_hand_poses();
+
+// True while an XR session object exists (any state). `vrrec play` refuses
+// while this holds - a live session and a replay would be two writers on the
+// same funnel.
+bool session_live();
+
+// The last xrWaitFrame's predictedDisplayTime (0 with no session) - recorded
+// as per-frame metadata.
+int64_t last_predicted_time();
 
 // True when the user enabled VR camera mode AND a session is running; the
 // adapter drives the game camera from the HMD only while this holds. Frame

--- a/src/game/bioshock1r/aim.cpp
+++ b/src/game/bioshock1r/aim.cpp
@@ -53,6 +53,14 @@ std::atomic<int> g_pendingEnable{-1}; // -1 none, 0 off, 1 on
 // of taste (grip angle, wrist posture) - the user's first in-headset run wanted
 // the ray a little lower than the raw pose gave.
 std::atomic<bool> g_useAimPose{true};
+// Session 20 muzzle ray (default OFF until the in-headset verdict): the RIGHT
+// hand's ray leaves along the RENDERED barrel - direction = the model's
+// target rotation applied to the rig's reference barrel axis
+// (bones::barrel_ref_axis) - instead of the trimmed controller forward.
+// Per-weapon automatic (the reference pose is the per-weapon animation), no
+// manual trim. The left/plasmid hand keeps the pointing ray: there is no
+// barrel to follow.
+std::atomic<bool> g_muzzleRay{false};
 // Per-hand since session 16 part 3 (user request): each controller's wrist
 // posture wants its own trim. 0 = left (plasmid), 1 = right (weapon).
 std::atomic<float> g_pitchOffsetDeg[2] = {0.0f, 0.0f};
@@ -858,9 +866,29 @@ void on_calcview(const FrameContext& ctx) {
         GamePose gp = ray_pose_from_xr(ctx, pos, quat,
                                        g_pitchOffsetDeg[i].load(std::memory_order_relaxed),
                                        g_yawOffsetDeg[i].load(std::memory_order_relaxed));
-
         out.origin = gp.loc;
         out.rot = gp.rot;
+
+        // Muzzle ray (session 20, right hand only): the bullet leaves along
+        // the RENDERED barrel. The model's target rotation is recomputed here
+        // through the same pure function hands.cpp uses this frame (same ctx,
+        // same funnel pose, same trims - no staleness, no coupling), then
+        // applied to the reference barrel axis. Falls back to the trimmed
+        // controller ray whenever the rig has no reference yet.
+        if (i == 1 && g_muzzleRay.load(std::memory_order_relaxed)) {
+            float d0[3];
+            if (bvr::b1r::bones::barrel_ref_axis(d0)) {
+                GamePose mgp = model_pose_from_xr(ctx, pos, quat,
+                                                  hands::model_trim_pitch_deg(1),
+                                                  hands::model_trim_yaw_deg(1),
+                                                  hands::model_trim_roll_deg(1));
+                float qt[4], dirW[3];
+                ue_rot_to_quat(mgp.rot, qt);
+                quat_rotate(qt[0], qt[1], qt[2], qt[3], d0, dirW);
+                out.rot = ue_dir_to_rot(dirW); // pitch/yaw; roll stays 0
+            }
+        }
+
         apply_origin_offset(i, out, ctx.worldScale);
         out.valid = true;
     }
@@ -881,6 +909,20 @@ void on_calcview(const FrameContext& ctx) {
     lc.nearM = g_laserNearM.load(std::memory_order_relaxed);
     lc.farM = g_laserFarM.load(std::memory_order_relaxed);
     lc.sizeDeg = g_laserSizeDeg.load(std::memory_order_relaxed);
+    // Muzzle ray (session 20): the beam must follow the bullet. d0 converts
+    // UE (fwd,right,up) -> XR (right,up,-fwd): (y, z, -x).
+    if (lc.hand == 1 && g_muzzleRay.load(std::memory_order_relaxed)) {
+        float d0[3];
+        if (bvr::b1r::bones::barrel_ref_axis(d0)) {
+            lc.muzzle = true;
+            lc.muzzleD0[0] = d0[1];
+            lc.muzzleD0[1] = d0[2];
+            lc.muzzleD0[2] = -d0[0];
+            lc.modelPitchTrimDeg = hands::model_trim_pitch_deg(1);
+            lc.modelYawTrimDeg = hands::model_trim_yaw_deg(1);
+            lc.modelRollTrimDeg = hands::model_trim_roll_deg(1);
+        }
+    }
     bvr::vr::set_laser(lc);
 }
 
@@ -1136,6 +1178,17 @@ void handle_command(const char* args) {
         g_test[idx].deadline = GetTickCount64() + static_cast<uint64_t>(hold);
         BVR_LOG("[aim] test aim %s: yaw %+.1f pitch %+.1f for %d ms", idx ? "RIGHT" : "LEFT",
                 yaw, pitch, hold);
+    } else if (strcmp(verb, "muzzle") == 0) {
+        bool on = strncmp(rest, "on", 2) == 0;
+        g_muzzleRay.store(on, std::memory_order_relaxed);
+        float d0[3];
+        bool haveRef = bvr::b1r::bones::barrel_ref_axis(d0);
+        BVR_LOG("[aim] muzzle ray %s - right-hand ray %s (barrel axis %s: %.3f %.3f %.3f)",
+                on ? "ON" : "off",
+                on ? "follows the RENDERED barrel (per-weapon, no manual trim)"
+                   : "back to the trimmed controller forward",
+                haveRef ? "from the live reference" : "UNAVAILABLE yet",
+                haveRef ? d0[0] : 0.0f, haveRef ? d0[1] : 0.0f, haveRef ? d0[2] : 0.0f);
     } else if (strcmp(verb, "synccheck") == 0) {
         run_synccheck();
     } else if (strcmp(verb, "status") == 0) {

--- a/src/game/bioshock1r/aim.cpp
+++ b/src/game/bioshock1r/aim.cpp
@@ -16,6 +16,7 @@
 #include "core/input/xinput_bridge.h"
 #include "core/util/log.h"
 #include "core/vr/openxr_runtime.h"
+#include "game/bioshock1r/bones.h"
 #include "game/bioshock1r/hands.h"
 #include "game/bioshock1r/ue_math.h"
 
@@ -772,9 +773,17 @@ void apply_origin_offset(int i, Ray& out, float worldScale) {
     out.origin.z += fwd[2] * of + right[2] * orr + up[2] * ou;
 }
 
+// Last published FrameContext, cached for `vraim synccheck` (session 20): the
+// sweep needs a real frame's transform to map through, outside the frame.
+// Written and read on the game thread only (commands run there too).
+static FrameContext g_lastCtx{};
+static bool g_haveCtx = false;
+
 void on_calcview(const FrameContext& ctx) {
     uint64_t now = GetTickCount64();
     g_rayStampMs = now;
+    g_lastCtx = ctx;
+    g_haveCtx = true;
 
     // Apply an overlay request from THIS thread (see g_pendingEnable).
     int pending = g_pendingEnable.exchange(-1, std::memory_order_relaxed);
@@ -844,16 +853,14 @@ void on_calcview(const FrameContext& ctx) {
 
         const float pos[3] = {hp.px, hp.py, hp.pz};
         const float quat[4] = {hp.qx, hp.qy, hp.qz, hp.qw};
-        GamePose gp = xr_pose_to_game(ctx, pos, quat);
+        // The trimmed chain is a pure function in frame_context.h, shared
+        // with `vraim synccheck` (roll forced 0 there - the camera owns roll).
+        GamePose gp = ray_pose_from_xr(ctx, pos, quat,
+                                       g_pitchOffsetDeg[i].load(std::memory_order_relaxed),
+                                       g_yawOffsetDeg[i].load(std::memory_order_relaxed));
 
         out.origin = gp.loc;
-        out.rot.yaw = gp.rot.yaw + static_cast<int32_t>(
-                                       g_yawOffsetDeg[i].load(std::memory_order_relaxed) *
-                                       kRotUnitsPerDegree);
-        out.rot.pitch = gp.rot.pitch + static_cast<int32_t>(
-                                           g_pitchOffsetDeg[i].load(std::memory_order_relaxed) *
-                                           kRotUnitsPerDegree);
-        out.rot.roll = 0; // aim carries no roll; the camera owns roll
+        out.rot = gp.rot;
         apply_origin_offset(i, out, ctx.worldScale);
         out.valid = true;
     }
@@ -875,6 +882,91 @@ void on_calcview(const FrameContext& ctx) {
     lc.farM = g_laserFarM.load(std::memory_order_relaxed);
     lc.sizeDeg = g_laserSizeDeg.load(std::memory_order_relaxed);
     bvr::vr::set_laser(lc);
+}
+
+// ---- synccheck (session 20): ray-vs-barrel divergence sweep -----------------
+// Sweeps axis-angle controller orientations - INCLUDING rolled poses, where
+// the two algebras differ most - through BOTH pure pose->rot chains
+// (frame_context.h) against the cached last FrameContext, and prints the angle
+// between the ray direction and the model barrel direction per pose. Two trim
+// sets per pose: the LIVE trims (what the user's tuning experiences) and a
+// canonical 10/10 trim fed IDENTICALLY to both chains, so any canonical
+// divergence is pure algebra difference - the deterministic gate. Position is
+// deliberately NOT part of the gate: the render lock shifts position only
+// (bones.cpp - never rotation, quoted separately below) and the two
+// origin-offset bases are tuned against each other by design.
+static void run_synccheck() {
+    if (!g_haveCtx) {
+        BVR_LOG("[sync] no FrameContext cached yet - enter gameplay first");
+        return;
+    }
+    const FrameContext ctx = g_lastCtx;
+    const float pos[3] = {0.15f, -0.20f, -0.35f}; // the sim lane's hand spot
+
+    struct AxisAngle { float x, y, z, deg; };
+    static const AxisAngle kPoses[] = {
+        {0, 0, 1, 0},                                       // identity
+        {1, 0, 0, 45},  {1, 0, 0, -45}, {1, 0, 0, 90},      // pitch-ish (XR +X)
+        {0, 1, 0, 45},  {0, 1, 0, -45}, {0, 1, 0, 90},      // yaw-ish (XR +Y)
+        {0, 0, 1, 45},  {0, 0, 1, -45}, {0, 0, 1, 90},      // ROLL (view axis)
+        {0, 0, 1, 180},
+        {1, 1, 0, 60},  {1, 0, 1, 60},  {0, 1, 1, 60},      // mixed axes
+        {1, -1, 0, 60}, {1, 0, -1, 60}, {0, 1, -1, 60},
+        {1, 1, 1, 60},  {1, 1, 1, 120}, {1, -1, 1, 90}, {-1, 1, 1, 90},
+    };
+    constexpr int kPoseCount = static_cast<int>(sizeof kPoses / sizeof kPoses[0]);
+
+    // Angle between the two chains' forward directions for one trim set.
+    auto diverge = [&](const float q[4], float rayPitch, float rayYaw, float mPitch,
+                       float mYaw, float mRoll) {
+        GamePose rp = ray_pose_from_xr(ctx, pos, q, rayPitch, rayYaw);
+        GamePose mp = model_pose_from_xr(ctx, pos, q, mPitch, mYaw, mRoll);
+        float dr[3], dm[3];
+        ue_rot_to_dir(rp.rot, dr);
+        ue_rot_to_dir(mp.rot, dm);
+        float dot = dr[0] * dm[0] + dr[1] * dm[1] + dr[2] * dm[2];
+        if (dot > 1.0f) dot = 1.0f;
+        if (dot < -1.0f) dot = -1.0f;
+        return acosf(dot) * kRadToDeg;
+    };
+
+    const float rayP[2] = {g_pitchOffsetDeg[0].load(std::memory_order_relaxed),
+                           g_pitchOffsetDeg[1].load(std::memory_order_relaxed)};
+    const float rayY[2] = {g_yawOffsetDeg[0].load(std::memory_order_relaxed),
+                           g_yawOffsetDeg[1].load(std::memory_order_relaxed)};
+    BVR_LOG("[sync] sweep of %d poses | ray trim L(%+.1f,%+.1f) R(%+.1f,%+.1f) | "
+            "model trim L(%+.1f,%+.1f,%+.1f) R(%+.1f,%+.1f,%+.1f) | canon 10/10 both chains",
+            kPoseCount, rayP[0], rayY[0], rayP[1], rayY[1], hands::model_trim_pitch_deg(0),
+            hands::model_trim_yaw_deg(0), hands::model_trim_roll_deg(0),
+            hands::model_trim_pitch_deg(1), hands::model_trim_yaw_deg(1),
+            hands::model_trim_roll_deg(1));
+
+    float maxL = 0.0f, maxR = 0.0f, maxC = 0.0f;
+    for (int p = 0; p < kPoseCount; ++p) {
+        const AxisAngle& aa = kPoses[p];
+        float len = sqrtf(aa.x * aa.x + aa.y * aa.y + aa.z * aa.z);
+        float q[4];
+        quat_axis_angle(aa.x / len, aa.y / len, aa.z / len, aa.deg / kRadToDeg, q);
+
+        float dL = diverge(q, rayP[0], rayY[0], hands::model_trim_pitch_deg(0),
+                           hands::model_trim_yaw_deg(0), hands::model_trim_roll_deg(0));
+        float dR = diverge(q, rayP[1], rayY[1], hands::model_trim_pitch_deg(1),
+                           hands::model_trim_yaw_deg(1), hands::model_trim_roll_deg(1));
+        float dC = diverge(q, 10.0f, 10.0f, 10.0f, 10.0f, 0.0f);
+        if (dL > maxL) maxL = dL;
+        if (dR > maxR) maxR = dR;
+        if (dC > maxC) maxC = dC;
+        BVR_LOG("[sync] %2d axis(%+.0f,%+.0f,%+.0f) %+4.0f deg | liveL %6.2f liveR %6.2f "
+                "canon %6.2f deg",
+                p, aa.x, aa.y, aa.z, aa.deg, dL, dR, dC);
+    }
+    BVR_LOG("[sync] MAX divergence: liveL %.2f liveR %.2f CANON %.2f deg over %d poses "
+            "(canon is the algebra gate: identical trims in, so nonzero = the two "
+            "algebras disagree)",
+            maxL, maxR, maxC, kPoseCount);
+    BVR_LOG("[sync] position (separate story): render-lock delta last frame %.2f UU - "
+            "position-only by construction, never rotation",
+            bvr::b1r::bones::lock_delta_mag());
 }
 
 void handle_command(const char* args) {
@@ -1044,11 +1136,13 @@ void handle_command(const char* args) {
         g_test[idx].deadline = GetTickCount64() + static_cast<uint64_t>(hold);
         BVR_LOG("[aim] test aim %s: yaw %+.1f pitch %+.1f for %d ms", idx ? "RIGHT" : "LEFT",
                 yaw, pitch, hold);
+    } else if (strcmp(verb, "synccheck") == 0) {
+        run_synccheck();
     } else if (strcmp(verb, "status") == 0) {
         log_status();
     } else {
         BVR_LOG("[aim] unknown command '%s' "
-                "(on|off|probe|dump|origin|seam|test|scan|scanimpl|scanoff|status)",
+                "(on|off|probe|dump|origin|seam|test|synccheck|scan|scanimpl|scanoff|status)",
                 verb);
     }
 }

--- a/src/game/bioshock1r/aim.h
+++ b/src/game/bioshock1r/aim.h
@@ -51,6 +51,12 @@ void on_calcview(const FrameContext& ctx);
 //   seam <weapon|ability> on|off
 //   scan <Class> <Func> [n] / scanoff   hook ANY name-based native read-only
 //                           (fire-flow investigation without a rebuild)
+//   synccheck               sweep ~20 controller orientations (incl. roll)
+//                           through the ray AND model pose->rot chains and
+//                           print the ray-vs-barrel divergence per pose, for
+//                           the live trims and a canonical 10/10 trim
+//                           (session 20; the pure chains live in
+//                           frame_context.h)
 void handle_command(const char* args);
 
 // Overlay section (render thread).

--- a/src/game/bioshock1r/aim.h
+++ b/src/game/bioshock1r/aim.h
@@ -57,6 +57,10 @@ void on_calcview(const FrameContext& ctx);
 //                           the live trims and a canonical 10/10 trim
 //                           (session 20; the pure chains live in
 //                           frame_context.h)
+//   muzzle on|off           right-hand ray + laser follow the RENDERED barrel
+//                           (bones 43->44 of the per-weapon reference pose) -
+//                           per-weapon automatic, no manual trim; default off
+//                           until the in-headset verdict (session 20)
 void handle_command(const char* args);
 
 // Overlay section (render thread).

--- a/src/game/bioshock1r/bones.cpp
+++ b/src/game/bioshock1r/bones.cpp
@@ -75,6 +75,27 @@ struct CachedSleeve {
 CachedSleeve g_cacheSleeve[8];
 int g_cacheSleeveCount = 0;
 
+// Session 20 idle-sway kill (default ON; `vrhands swaykill on|off`): freeze
+// the drive's reference pose against the idle animation's breathing. A fresh
+// engine pose is adopted only when either wrist anchor moved past the
+// thresholds - real animations (equip/reload/melee) pass through and
+// re-freeze when they settle; the measured idle wobble (+-1.2 deg barrel
+// direction, sub-UU positions) stays out. Acts only on the DRIVEN rig; the
+// weapon's own skeleton (pump, cylinder) animates untouched.
+std::atomic<bool> g_swayKill{true};
+// 2x the MEASURED idle envelope vs a frozen snapshot (session 20, 1 Hz sway
+// telemetry: dpos peaks 3.01 UU, dang peaks 4.6 deg) - real animations move
+// the anchors tens of UU / tens of degrees, so the gap is wide on both sides.
+constexpr float kSwayPosThreshUu = 6.0f;
+constexpr float kSwayAngThreshDeg = 12.0f;
+// After a real animation, keep tracking this long past the LAST threshold
+// crossing so the freeze lands on the SETTLED pose, not the last big frame.
+constexpr uint64_t kSwaySettleMs = 600;
+uint64_t g_lastBigDeltaMs = 0;
+// Telemetry (1 Hz while frozen): the probe deltas the threshold judges, so
+// the thresholds are set from measured idle amplitude, not guesses.
+uint64_t g_lastSwayTlmMs = 0;
+
 // Session 19: the whole INACTIVE hand collapses too - the drive poses only
 // the active hand's cluster, so the other one stays engine-animated at the
 // eye anchor and reads as a ghost hand. Cache mirrors g_cacheSleeve so the
@@ -569,6 +590,19 @@ void on_world_change() {
     g_cacheHiddenCount = 0;
 }
 
+void set_sway_kill(bool on) {
+    bool was = g_swayKill.exchange(on, std::memory_order_relaxed);
+    if (was && !on) g_refValid = false; // release the frozen pose immediately
+    BVR_LOG("[bones] idle-sway kill %s (%s)", on ? "ON" : "off",
+            on ? "reference frozen against idle breathing; real animations pass the "
+                 "threshold and re-freeze when settled"
+               : "reference tracks every engine evaluation - sway visible again");
+}
+
+bool sway_kill() {
+    return g_swayKill.load(std::memory_order_relaxed);
+}
+
 void set_hide_inactive(bool on) {
     bool was = g_hideInactive.exchange(on, std::memory_order_relaxed);
     if (was != on)
@@ -642,9 +676,53 @@ bool drive(const FrameContext& ctx, void* handsActor, const GamePose& gp, int ha
     bool engineEvaluated =
         !g_hasWritten[hand] || memcmp(&cur, &g_lastWrittenAnchor[hand], sizeof cur) != 0;
     if (engineEvaluated || !g_refValid) {
-        if (!read_n(g_bones, g_ref, sizeof(Qts) * static_cast<size_t>(g_boneCount)))
+        // Session 20 sway kill: the idle breathing is the authored idle
+        // ANIMATION (channel 0/1 - no script parameter to zero, measured),
+        // and it reaches the VR rig only through this recapture. With the
+        // kill armed, a fresh engine pose replaces the reference ONLY when
+        // it differs by a REAL animation's magnitude (equip/reload/melee -
+        // they track live and re-freeze when they settle); idle wobble
+        // (measured +-1.2 deg / sub-UU on the anchor) stays frozen out.
+        Qts fresh[kMaxBones];
+        if (!read_n(g_bones, fresh, sizeof(Qts) * static_cast<size_t>(g_boneCount)))
             return false;
-        g_refValid = true;
+        bool adopt = true;
+        if (g_refValid && g_swayKill.load(std::memory_order_relaxed)) {
+            adopt = false;
+            uint64_t nowMs = GetTickCount64();
+            float maxPos = 0.0f, maxAng = 0.0f;
+            static const int kProbe[2] = {patterns::kBoneLWrist, patterns::kBoneWeaponAttach};
+            for (int k = 0; k < 2; ++k) {
+                int b = kProbe[k];
+                if (b >= g_boneCount) continue;
+                float dp[3] = {fresh[b].p[0] - g_ref[b].p[0], fresh[b].p[1] - g_ref[b].p[1],
+                               fresh[b].p[2] - g_ref[b].p[2]};
+                float dot = fresh[b].q[0] * g_ref[b].q[0] + fresh[b].q[1] * g_ref[b].q[1] +
+                            fresh[b].q[2] * g_ref[b].q[2] + fresh[b].q[3] * g_ref[b].q[3];
+                if (dot < 0.0f) dot = -dot;
+                if (dot > 1.0f) dot = 1.0f;
+                float angDeg = 2.0f * acosf(dot) * kRadToDeg;
+                float posUu = sqrtf(dp[0] * dp[0] + dp[1] * dp[1] + dp[2] * dp[2]);
+                if (posUu > maxPos) maxPos = posUu;
+                if (angDeg > maxAng) maxAng = angDeg;
+            }
+            if (maxPos > kSwayPosThreshUu || maxAng > kSwayAngThreshDeg)
+                g_lastBigDeltaMs = nowMs;
+            // Track through the animation AND a settle window past its last
+            // big frame, so the eventual freeze holds the SETTLED pose.
+            adopt = (nowMs - g_lastBigDeltaMs) < kSwaySettleMs;
+            if (g_telemetry.load(std::memory_order_relaxed) &&
+                nowMs - g_lastSwayTlmMs >= 1000) {
+                g_lastSwayTlmMs = nowMs;
+                BVR_LOG("[tlm] sway probe: dpos=%.2f UU dang=%.2f deg (thresh %.1f/%.1f) %s",
+                        maxPos, maxAng, kSwayPosThreshUu, kSwayAngThreshDeg,
+                        adopt ? "TRACKING" : "frozen");
+            }
+        }
+        if (adopt || !g_refValid) {
+            memcpy(g_ref, fresh, sizeof(Qts) * static_cast<size_t>(g_boneCount));
+            g_refValid = true;
+        }
     }
 
     // Hide-inactive bookkeeping, BEFORE the rigid write: if the hand about to

--- a/src/game/bioshock1r/bones.cpp
+++ b/src/game/bioshock1r/bones.cpp
@@ -516,6 +516,10 @@ bool telemetry_on() {
     return g_telemetry.load(std::memory_order_relaxed);
 }
 
+float lock_delta_mag() {
+    return g_lockDeltaMag.load(std::memory_order_relaxed);
+}
+
 bool drive(const FrameContext& ctx, void* handsActor, const GamePose& gp, int hand) {
     // Telemetry window: opened here (the once-per-frame pass-1 path) so every
     // module's lines for one sample land together in the log.

--- a/src/game/bioshock1r/bones.cpp
+++ b/src/game/bioshock1r/bones.cpp
@@ -20,6 +20,7 @@
 #include "core/gfx/frame_inspector.h"
 #include "core/util/log.h"
 #include "game/bioshock1r/camera.h"
+#include "game/bioshock1r/hands.h"
 #include "game/bioshock1r/patterns.h"
 
 #include <windows.h>
@@ -167,38 +168,104 @@ uint32_t to_rva(const void* p) {
 // actor -> SkeletonInstance, fully revalidated (vtable, plausible count,
 // readable array). The instance is recreated on mesh relinks, so never trust
 // yesterday's pointer.
-bool locate(void* handsActor) {
+//
+// Session 20: the resolution itself is BY VALUE and slot-free (`resolve_skel`)
+// so any actor's skeleton can be inspected - the weapon carries its own, which
+// is what the muzzle probe needs. `locate()` keeps the module's single cached
+// slot for the drive, which only ever poses the AHands rig.
+struct Skel {
+    void* inst = nullptr;
+    Qts* bones = nullptr;
+    int count = 0;
+};
+
+bool resolve_skel(void* actor, Skel& out) {
+    out = {};
+    if (!actor) return false;
     void* si = nullptr;
-    if (!read_n(static_cast<uint8_t*>(handsActor) + patterns::kActorSkelInstOffset, &si,
-                sizeof si) ||
-        !si) {
-        g_skelInst = nullptr;
+    if (!read_n(static_cast<uint8_t*>(actor) + patterns::kActorSkelInstOffset, &si, sizeof si) ||
+        !si)
         return false;
-    }
     void* vtbl = nullptr;
-    if (!read_n(si, &vtbl, sizeof vtbl) || to_rva(vtbl) != patterns::kSkeletonInstanceVtableRva) {
-        g_skelInst = nullptr;
+    if (!read_n(si, &vtbl, sizeof vtbl) || to_rva(vtbl) != patterns::kSkeletonInstanceVtableRva)
         return false;
-    }
     struct {
         Qts* bones;
         int count;
     } a{};
     if (!read_n(static_cast<uint8_t*>(si) + patterns::kSkelInstBonesOffset, &a, sizeof a) ||
-        !a.bones || a.count < 8 || a.count > kMaxBones) {
+        !a.bones || a.count < 1 || a.count > kMaxBones)
+        return false;
+    out.inst = si;
+    out.bones = a.bones;
+    out.count = a.count;
+    return true;
+}
+
+// Bone index -> name, via the SharedSkeletonData FName->index map walked in
+// reverse (patterns.h "Session 20: bone NAMES"). Returns how many names were
+// filled; entries stay null when a bone has no map entry.
+int resolve_bone_names(const Skel& sk, const wchar_t** names, int cap) {
+    for (int i = 0; i < cap; ++i) names[i] = nullptr;
+    if (!sk.inst) return 0;
+    void* shared = nullptr;
+    if (!read_n(static_cast<uint8_t*>(sk.inst) + patterns::kSkelInstSharedOffset, &shared,
+                sizeof shared) ||
+        !shared)
+        return 0;
+    const uint8_t* map = static_cast<const uint8_t*>(shared) + patterns::kSharedBoneNameMapOffset;
+    struct {
+        const uint8_t* pairs;
+    } p{};
+    const int32_t* buckets = nullptr;
+    int32_t bucketCount = 0;
+    if (!read_n(map + patterns::kNameMapPairsOffset, &p, sizeof p) ||
+        !read_n(map + patterns::kNameMapBucketsOffset, &buckets, sizeof buckets) ||
+        !read_n(map + patterns::kNameMapBucketCountOffset, &bucketCount, sizeof bucketCount))
+        return 0;
+    if (!p.pairs || !buckets || bucketCount <= 0 || bucketCount > 65536) return 0;
+
+    int filled = 0;
+    for (int b = 0; b < bucketCount; ++b) {
+        int32_t idx = -1;
+        if (!read_n(buckets + b, &idx, sizeof idx)) break;
+        // Chain walk, bounded by the table size so a corrupt link cannot spin.
+        for (int guard = 0; idx >= 0 && guard <= cap * 4; ++guard) {
+            struct {
+                int32_t next, nameIdx, nameNum, value;
+            } pair{};
+            if (!read_n(p.pairs + static_cast<size_t>(idx) * patterns::kNameMapPairStride, &pair,
+                        sizeof pair))
+                break;
+            if (pair.value >= 0 && pair.value < cap && !names[pair.value]) {
+                const wchar_t* t = patterns::fname_text(pair.nameIdx);
+                if (t) {
+                    names[pair.value] = t;
+                    ++filled;
+                }
+            }
+            idx = pair.next;
+        }
+    }
+    return filled;
+}
+
+bool locate(void* handsActor) {
+    Skel sk{};
+    if (!resolve_skel(handsActor, sk) || sk.count < 8) {
         g_skelInst = nullptr;
         return false;
     }
-    if (si != g_skelInst || a.bones != g_bones || a.count != g_boneCount) {
-        BVR_LOG("[bones] skeleton: inst=%p bones=%p count=%d%s", si,
-                static_cast<void*>(a.bones), a.count,
-                a.count == patterns::kHandsRigBoneCount ? "" : " (UNEXPECTED count)");
+    if (sk.inst != g_skelInst || sk.bones != g_bones || sk.count != g_boneCount) {
+        BVR_LOG("[bones] skeleton: inst=%p bones=%p count=%d%s", sk.inst,
+                static_cast<void*>(sk.bones), sk.count,
+                sk.count == patterns::kHandsRigBoneCount ? "" : " (UNEXPECTED count)");
         g_refValid = false; // new array = new reference
         g_hasWritten[0] = g_hasWritten[1] = false;
     }
-    g_skelInst = si;
-    g_bones = a.bones;
-    g_boneCount = a.count;
+    g_skelInst = sk.inst;
+    g_bones = sk.bones;
+    g_boneCount = sk.count;
     return true;
 }
 
@@ -520,6 +587,28 @@ float lock_delta_mag() {
     return g_lockDeltaMag.load(std::memory_order_relaxed);
 }
 
+bool barrel_ref_axis(float d0[3]) {
+    // The rendered barrel axis in the DRIVE TARGET's local frame (UE
+    // fwd/right/up). Derivation: drive() writes every cluster quat as
+    // qtc (x) q_ref with qtc = inv(q_actor) (x) q_target and positions as a
+    // rigid rotation of the reference about the anchor, so the rendered
+    // world direction of (bone44ref - bone43ref) is q_target (x) d0 - the
+    // actor frame cancels. d0 tracks the reference pose, which IS the
+    // per-weapon animation (bone 44 = "muzzle-ish tip", patterns.h), so the
+    // muzzle ray is per-weapon automatic and follows any authored sway the
+    // engine still plays.
+    if (!g_refValid || g_boneCount <= patterns::kBoneRClusterLast) return false;
+    const float* pa = g_ref[patterns::kBoneWeaponAttach].p;
+    const float* pm = g_ref[patterns::kBoneRClusterLast].p; // bone 44
+    float d[3] = {pm[0] - pa[0], pm[1] - pa[1], pm[2] - pa[2]};
+    float len = sqrtf(d[0] * d[0] + d[1] * d[1] + d[2] * d[2]);
+    if (len < 1.0f) return false; // degenerate reference (collapsed rig)
+    d0[0] = d[0] / len;
+    d0[1] = d[1] / len;
+    d0[2] = d[2] / len;
+    return true;
+}
+
 bool drive(const FrameContext& ctx, void* handsActor, const GamePose& gp, int hand) {
     // Telemetry window: opened here (the once-per-frame pass-1 path) so every
     // module's lines for one sample land together in the log.
@@ -839,6 +928,37 @@ void handle_command(const char* args) {
                     "scale(%.2f %.2f %.2f)",
                     i, b.p[0], b.p[1], b.p[2], b.q[0], b.q[1], b.q[2], b.q[3], b.s[0], b.s[1],
                     b.s[2]);
+        }
+    } else if (strcmp(verb, "skel") == 0) {
+        // Session 20 muzzle probe: dump ANY actor's skeleton WITH bone names.
+        // "skel hands" (default) = the AHands rig; "skel weapon" = the
+        // equipped weapon's own skeleton, where the muzzle bone lives.
+        bool wantWeapon = strncmp(rest, "weapon", 6) == 0;
+        void* actor = wantWeapon ? hands::weapon_actor() : hands::hands_actor();
+        if (!actor) {
+            BVR_LOG("[bones] skel: no live %s actor (arm the drive; fire once for the "
+                    "weapon)",
+                    wantWeapon ? "weapon" : "hands");
+            return;
+        }
+        Skel sk{};
+        if (!resolve_skel(actor, sk)) {
+            BVR_LOG("[bones] skel: %s actor %p has no SkeletonInstance at +0x%X (or the "
+                    "vtable did not validate)",
+                    wantWeapon ? "weapon" : "hands", actor, patterns::kActorSkelInstOffset);
+            return;
+        }
+        const wchar_t* names[kMaxBones];
+        int named = resolve_bone_names(sk, names, sk.count);
+        BVR_LOG("[bones] skel %s: actor=%p inst=%p bones=%p count=%d (%d named)",
+                wantWeapon ? "WEAPON" : "HANDS", actor, sk.inst, static_cast<void*>(sk.bones),
+                sk.count, named);
+        for (int i = 0; i < sk.count; ++i) {
+            Qts b{};
+            if (!read_n(&sk.bones[i], &b, sizeof b)) break;
+            BVR_LOG("[bones]  %2d %-24S pos(%8.2f %8.2f %8.2f) quat(%6.3f %6.3f %6.3f %6.3f)",
+                    i, names[i] ? names[i] : L"<unnamed>", b.p[0], b.p[1], b.p[2], b.q[0],
+                    b.q[1], b.q[2], b.q[3]);
         }
     } else if (strcmp(verb, "poke") == 0) {
         int idx = -1;

--- a/src/game/bioshock1r/bones.h
+++ b/src/game/bioshock1r/bones.h
@@ -66,6 +66,11 @@ void handle_command(const char* args);
 // ~5 Hz; the log timestamps correlate the lines of one sample).
 bool telemetry_on();
 
+// |render-lock position delta| applied last frame, UU. POSITION-only by
+// construction (the lock never touches rotation) - `vraim synccheck` quotes it
+// so the position story stays separate from the rotation-divergence gate.
+float lock_delta_mag();
+
 // Overlay section (render thread only).
 void draw_debug_ui();
 

--- a/src/game/bioshock1r/bones.h
+++ b/src/game/bioshock1r/bones.h
@@ -55,6 +55,13 @@ void on_world_change();
 void set_hide_inactive(bool on);
 bool hide_inactive();
 
+// Session 20: freeze the drive's reference against the idle animation's
+// breathing (default ON; `vrhands swaykill on|off`). Real animations pass an
+// anchor-delta threshold and re-freeze when they settle. Measured baseline:
+// +-1.2 deg of barrel-direction wobble at idle without it.
+void set_sway_kill(bool on);
+bool sway_kill();
+
 // Seam commands (game thread): status | list [n] | skel [hands|weapon] |
 // poke <idx> <dUU> |
 // freeze on|off | collapse on|off | ref | anchor <idx> | lcluster <lo> <hi> <anchor> |

--- a/src/game/bioshock1r/bones.h
+++ b/src/game/bioshock1r/bones.h
@@ -55,7 +55,8 @@ void on_world_change();
 void set_hide_inactive(bool on);
 bool hide_inactive();
 
-// Seam commands (game thread): status | list [n] | poke <idx> <dUU> |
+// Seam commands (game thread): status | list [n] | skel [hands|weapon] |
+// poke <idx> <dUU> |
 // freeze on|off | collapse on|off | ref | anchor <idx> | lcluster <lo> <hi> <anchor> |
 // log on|off (in-headset telemetry: head/controller/camera/actor/target/bone
 // samples at ~5 Hz so a headset session can be diagnosed from the log)
@@ -70,6 +71,12 @@ bool telemetry_on();
 // construction (the lock never touches rotation) - `vraim synccheck` quotes it
 // so the position story stays separate from the rotation-divergence gate.
 float lock_delta_mag();
+
+// Session 20 muzzle ray: the rendered barrel axis (hands-rig bones 43->44 in
+// the current reference pose), expressed in the drive target's local frame -
+// world barrel dir = target rotation (x) d0 (see the impl derivation). False
+// until a reference pose exists. Game thread.
+bool barrel_ref_axis(float d0[3]);
 
 // Overlay section (render thread only).
 void draw_debug_ui();

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -17,6 +17,7 @@
 #include "game/bioshock1r/hands.h"
 #include "game/bioshock1r/input_drive.h"
 #include "game/bioshock1r/patterns.h"
+#include "game/bioshock1r/recorder.h"
 #include "game/bioshock1r/scenedraw.h"
 #include "game/bioshock1r/ue_math.h"
 
@@ -404,6 +405,8 @@ void apply_command(const char* cmd, const char* args) {
         bones::handle_command(args); // M7-v2 skeleton probes; logs its own echoes
     } else if (strcmp(cmd, "vrbody") == 0) {
         body::handle_command(args); // M7.5 yaw transfer; logs its own echoes
+    } else if (strcmp(cmd, "vrrec") == 0) {
+        recorder::handle_command(args); // session 20 record+replay; logs its own echoes
     } else if (strcmp(cmd, "exec") == 0) {
         console_exec::run_viewport(args); // engine console command, viewport chain
     } else if (strcmp(cmd, "execc") == 0) {
@@ -732,8 +735,15 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
     int32_t residualUnits = 0;
     int32_t gameYawUnitsRaw = rot ? rot->yaw : 0; // the engine's own body yaw
     bvr::vr::HeadPose hp{};
-    bool simHead = now < g_simHead.deadline;
-    if (simHead) {
+    bool driveHead = false;
+    bool liveHead = false;
+    if (recorder::playing()) {
+        // Session 20 replay lane: the recorded head (position + quat) drives
+        // the camera; a frame recorded with no drive faithfully leaves the
+        // camera alone. The sim and live lanes are locked out while playing -
+        // and so is the auto-recenter (play restored the recorded reference).
+        driveHead = recorder::replay_head(hp);
+    } else if (now < g_simHead.deadline) {
         // Synthetic head pose, XR convention (same quat builder simpose uses
         // for the hand). Position stays at the recenter origin - rotation is
         // what every head-coupling report has been about.
@@ -745,9 +755,12 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
         hp.qy = q[1];
         hp.qz = q[2];
         hp.qw = q[3];
+        driveHead = true;
+    } else if (bvr::vr::vr_camera_mode() && bvr::vr::get_head_pose(hp)) {
+        driveHead = true;
+        liveHead = true;
     }
-    if (loc && rot &&
-        (simHead || (bvr::vr::vr_camera_mode() && bvr::vr::get_head_pose(hp)))) {
+    if (loc && rot && driveHead) {
         UeAngles a = hmd_angles(hp);
         if (g_recenterRequested.exchange(false, std::memory_order_relaxed) || !g_haveRecenter) {
             g_recenterPose = hp;
@@ -976,6 +989,12 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
             }
         }
 
+        // Session 20 vrrec: record (or replay) this frame's input state -
+        // BEFORE aim/hands consume it, so a replayed frame feeds all three
+        // funnel consumers one consistent world. Once per game tick by
+        // construction (the stereo second pass skips this whole body).
+        recorder::on_tick(fc, hp, vrDrove, liveHead);
+
         aim::on_calcview(fc);
         // The viewmodel write goes LAST in the frame: the engine placed the
         // hands during its own tick, so ours has to be the one that survives.
@@ -1125,6 +1144,24 @@ bool fg_fov_match_active() {
 
 bool hook_live() {
     return g_hookLive.load(std::memory_order_relaxed);
+}
+
+void get_recenter_state(bvr::vr::HeadPose* pose, int32_t* yawUnits, float* worldScale) {
+    if (pose) *pose = g_recenterPose;
+    if (yawUnits) *yawUnits = g_recenterYawUnits;
+    if (worldScale) *worldScale = g_worldScale.load(std::memory_order_relaxed);
+}
+
+void set_recenter_state(const bvr::vr::HeadPose& pose, int32_t yawUnits, float worldScale) {
+    g_recenterPose = pose;
+    g_recenterYawUnits = yawUnits;
+    g_worldScale.store(worldScale, std::memory_order_relaxed);
+    g_haveRecenter = true;
+    // A pending auto-recenter would re-reference the mapping onto the first
+    // replayed head pose, throwing away the state just restored.
+    g_recenterRequested.store(false, std::memory_order_relaxed);
+    BVR_LOG("[b1r] recenter state SET (yaw %d units, worldScale %.1f) - vrrec play restore",
+            yawUnits, worldScale);
 }
 
 void set_fov_override(float hfovDeg) {

--- a/src/game/bioshock1r/camera.h
+++ b/src/game/bioshock1r/camera.h
@@ -2,6 +2,10 @@
 // PlayerCalcView hook for BioShock 1 Remastered: per-frame camera telemetry,
 // debug location/rotation offsets, wobble test, and the live FOV override.
 
+#include "core/vr/openxr_runtime.h"
+
+#include <cstdint>
+
 namespace bvr::b1r::camera {
 
 // MinHook hook on eventPlayerCalcView; enables itself. False = flat mode.
@@ -15,6 +19,13 @@ bool hook_live();
 bool fg_fov_match_active();
 
 void set_fov_override(float hfovDeg); // <= 0 disables; game value restored
+
+// Session 20 vrrec: the recenter reference + world scale are the xr->game
+// mapping's hidden state. The recorder snapshots them into a recording's
+// header and restores them on play; set_ also suppresses the pending
+// auto-recenter so the first replayed frame cannot re-reference itself.
+void get_recenter_state(bvr::vr::HeadPose* pose, int32_t* yawUnits, float* worldScale);
+void set_recenter_state(const bvr::vr::HeadPose& pose, int32_t yawUnits, float worldScale);
 
 // Full ImGui section: hook status, telemetry, and all debug controls.
 // Called from the overlay through IGameAdapter::drawDebugUi().

--- a/src/game/bioshock1r/frame_context.h
+++ b/src/game/bioshock1r/frame_context.h
@@ -63,4 +63,37 @@ inline GamePose xr_pose_to_game(const FrameContext& ctx, const float pos[3],
     return out;
 }
 
+// ---- The two trimmed pose->rot chains, as PURE functions (session 20) -------
+// Production (hands.cpp / aim.cpp) and the `vraim synccheck` sweep call the
+// SAME code, so the sweep measures the real thing. Until the session-20
+// unification lands the two apply their trims with DIFFERENT algebras - the
+// model composes a quaternion in the controller's LOCAL frame, the ray adds
+// rotator angles in game space after the map - and therefore agree only near
+// the pose the user tuned at. That divergence is exactly what synccheck
+// exists to expose (and what stage 2 collapses).
+
+// Model chain (hands.cpp): trim quat composed in the controller's local frame,
+// then mapped. Holds at every controller orientation.
+inline GamePose model_pose_from_xr(const FrameContext& ctx, const float pos[3],
+                                   const float quat[4], float trimPitchDeg,
+                                   float trimYawDeg, float trimRollDeg) {
+    float trim[4], q2[4];
+    xr_local_trim_quat(trimPitchDeg / kRadToDeg, trimYawDeg / kRadToDeg,
+                       trimRollDeg / kRadToDeg, trim);
+    quat_mul(quat, trim, q2);
+    return xr_pose_to_game(ctx, pos, q2);
+}
+
+// Ray chain (aim.cpp): map first, then add the trim as game-space rotator
+// angles. Roll is forced 0 - aim carries no roll; the camera owns roll.
+inline GamePose ray_pose_from_xr(const FrameContext& ctx, const float pos[3],
+                                 const float quat[4], float trimPitchDeg,
+                                 float trimYawDeg) {
+    GamePose out = xr_pose_to_game(ctx, pos, quat);
+    out.rot.pitch += static_cast<int32_t>(trimPitchDeg * kRotUnitsPerDegree);
+    out.rot.yaw += static_cast<int32_t>(trimYawDeg * kRotUnitsPerDegree);
+    out.rot.roll = 0;
+    return out;
+}
+
 } // namespace bvr::b1r

--- a/src/game/bioshock1r/frame_context.h
+++ b/src/game/bioshock1r/frame_context.h
@@ -65,12 +65,14 @@ inline GamePose xr_pose_to_game(const FrameContext& ctx, const float pos[3],
 
 // ---- The two trimmed pose->rot chains, as PURE functions (session 20) -------
 // Production (hands.cpp / aim.cpp) and the `vraim synccheck` sweep call the
-// SAME code, so the sweep measures the real thing. Until the session-20
-// unification lands the two apply their trims with DIFFERENT algebras - the
-// model composes a quaternion in the controller's LOCAL frame, the ray adds
-// rotator angles in game space after the map - and therefore agree only near
-// the pose the user tuned at. That divergence is exactly what synccheck
-// exists to expose (and what stage 2 collapses).
+// SAME code, so the sweep measures the real thing. Since the session-20
+// unification both chains compose the trim as a quaternion in the
+// controller's LOCAL frame (the model's algebra - the only one that holds at
+// every controller orientation); the ray then drops roll at the final
+// rotator write. The pre-unification ray added rotator angles in game space
+// after the map, which agreed with the model only at the tuning pose
+// (measured: up to 28.21 deg divergence at rolled poses, ENGINE_NOTES
+// session 20).
 
 // Model chain (hands.cpp): trim quat composed in the controller's local frame,
 // then mapped. Holds at every controller orientation.
@@ -84,14 +86,15 @@ inline GamePose model_pose_from_xr(const FrameContext& ctx, const float pos[3],
     return xr_pose_to_game(ctx, pos, q2);
 }
 
-// Ray chain (aim.cpp): map first, then add the trim as game-space rotator
-// angles. Roll is forced 0 - aim carries no roll; the camera owns roll.
+// Ray chain (aim.cpp): the model's EXACT compose with the roll trim slot 0
+// (roll is innermost in xr_local_trim_quat, so it could not move the ray
+// anyway), roll dropped only at the final rotator write - aim carries no
+// roll; the camera owns roll. Tuned pitch/yaw trim values carry over from
+// the old rotator-add algebra: the two agree exactly at the neutral pose.
 inline GamePose ray_pose_from_xr(const FrameContext& ctx, const float pos[3],
                                  const float quat[4], float trimPitchDeg,
                                  float trimYawDeg) {
-    GamePose out = xr_pose_to_game(ctx, pos, quat);
-    out.rot.pitch += static_cast<int32_t>(trimPitchDeg * kRotUnitsPerDegree);
-    out.rot.yaw += static_cast<int32_t>(trimYawDeg * kRotUnitsPerDegree);
+    GamePose out = model_pose_from_xr(ctx, pos, quat, trimPitchDeg, trimYawDeg, 0.0f);
     out.rot.roll = 0;
     return out;
 }

--- a/src/game/bioshock1r/hands.cpp
+++ b/src/game/bioshock1r/hands.cpp
@@ -776,6 +776,11 @@ void handle_command(const char* args) {
                 BVR_LOG("[hands] usage: vrhands fname <index>|weapon");
             }
         }
+    } else if (strcmp(verb, "swaykill") == 0) {
+        if (strncmp(rest, "status", 6) == 0)
+            BVR_LOG("[hands] swaykill %s", bones::sway_kill() ? "ON" : "off");
+        else
+            bones::set_sway_kill(strncmp(rest, "on", 2) == 0);
     } else if (strcmp(verb, "hideinactive") == 0) {
         bones::set_hide_inactive(strncmp(rest, "on", 2) == 0);
     } else if (strcmp(verb, "save") == 0) {

--- a/src/game/bioshock1r/hands.cpp
+++ b/src/game/bioshock1r/hands.cpp
@@ -738,6 +738,34 @@ void handle_command(const char* args) {
         bool on = strncmp(rest, "on", 2) == 0;
         g_writeRot.store(on, std::memory_order_relaxed);
         BVR_LOG("[hands] rotation write %s", on ? "ON" : "off (position only)");
+    } else if (strcmp(verb, "fname") == 0) {
+        // Session 20: the name-system gate. `fname <idx>` resolves any name
+        // index; `fname weapon` reads the cached weapon actor's attach-bone
+        // FName (+0xF0 {index, number}) - the stage-4 acceptance.
+        if (strncmp(rest, "weapon", 6) == 0) {
+            void* w = weapon_valid(g_weaponActor) ? g_weaponActor
+                                                  : bvr::b1r::aim::learned_weapon_object();
+            if (!weapon_valid(w)) {
+                BVR_LOG("[hands] fname: no live weapon actor (fire once so the aim seam "
+                        "learns it)");
+                return;
+            }
+            const int32_t* nm = reinterpret_cast<const int32_t*>(
+                static_cast<uint8_t*>(w) + patterns::kActorAttachBoneNameOffset);
+            const wchar_t* t = patterns::fname_text(nm[0]);
+            BVR_LOG("[hands] weapon attach-bone FName idx=%d num=%d -> '%S' "
+                    "(GNames count %d)",
+                    nm[0], nm[1], t ? t : L"<unresolved>", patterns::fname_count());
+        } else {
+            int idx = 0;
+            if (sscanf_s(rest, "%d", &idx) == 1) {
+                const wchar_t* t = patterns::fname_text(idx);
+                BVR_LOG("[hands] fname %d -> '%S' (GNames count %d)", idx,
+                        t ? t : L"<unresolved>", patterns::fname_count());
+            } else {
+                BVR_LOG("[hands] usage: vrhands fname <index>|weapon");
+            }
+        }
     } else if (strcmp(verb, "hideinactive") == 0) {
         bones::set_hide_inactive(strncmp(rest, "on", 2) == 0);
     } else if (strcmp(verb, "save") == 0) {

--- a/src/game/bioshock1r/hands.cpp
+++ b/src/game/bioshock1r/hands.cpp
@@ -50,13 +50,6 @@ std::atomic<int> g_mode{2};           // 0 = gun (inert), 1 = hands (actor pin,
 std::atomic<bool> g_useAimPose{true}; // aim pose = the ray the laser/bullet use
 std::atomic<int> g_handMode{2};       // 0 left, 1 right, 2 auto
 std::atomic<int> g_autoHand{1};       // the latched auto choice
-// Session 18 part 3 (user report): OFF by default - the aim CALIBRATION trim
-// used to be applied to the model too, so re-trimming the ray dragged the
-// already-tuned model with it. Now the model is raw aim pose + its own trim,
-// and the ray is raw aim pose + aim trim + origin offset; each is tuned
-// against the other. `vrhands aligntrim on` restores the old coupling.
-std::atomic<bool> g_alignAimTrim{false};
-
 // Model offsets, PER HAND (0 left / 1 right, same convention as aim.cpp): the
 // pistol and the plasmid hand sit differently in the mesh, so one shared set
 // meant tuning the weapon also moved the plasmid hand. Position is in
@@ -603,16 +596,11 @@ void on_calcview(const FrameContext& ctx) {
                                 g_rotPitchDeg[hand].load(std::memory_order_relaxed),
                                 g_rotYawDeg[hand].load(std::memory_order_relaxed),
                                 g_rotRollDeg[hand].load(std::memory_order_relaxed));
-
-        // The aim calibration trim is NOT applied to the model by default
-        // (see g_alignAimTrim above) - re-trimming the ray must not move the
-        // tuned model.
-        if (g_alignAimTrim.load(std::memory_order_relaxed)) {
-            gp.rot.pitch += static_cast<int32_t>(bvr::b1r::aim::trim_pitch_deg(hand) *
-                                                 kRotUnitsPerDegree);
-            gp.rot.yaw += static_cast<int32_t>(bvr::b1r::aim::trim_yaw_deg(hand) *
-                                               kRotUnitsPerDegree);
-        }
+        // The aim calibration trim is deliberately NOT applied to the model
+        // (session 18 part 3): re-trimming the ray must not move the tuned
+        // model. The legacy `aligntrim` euler coupling was DELETED in session
+        // 20 - euler adds after conversion were the wrong algebra everywhere
+        // but the tuning pose, and the unification left nothing for it to do.
     }
 
     // Position offset rides the final (trimmed) frame: "2 cm forward" means
@@ -746,12 +734,6 @@ void handle_command(const char* args) {
         } else {
             BVR_LOG("[hands] usage: vrhands rot [l|r] <pitchDeg> <yawDeg> <rollDeg>");
         }
-    } else if (strcmp(verb, "aligntrim") == 0) {
-        bool on = strncmp(rest, "on", 2) == 0;
-        g_alignAimTrim.store(on, std::memory_order_relaxed);
-        BVR_LOG("[hands] aim-trim coupling %s (%s)", on ? "ON" : "off",
-                on ? "model follows the aim calibration trim - pre-part-3 behavior"
-                   : "model independent of the aim trim (default)");
     } else if (strcmp(verb, "writerot") == 0) {
         bool on = strncmp(rest, "on", 2) == 0;
         g_writeRot.store(on, std::memory_order_relaxed);

--- a/src/game/bioshock1r/hands.cpp
+++ b/src/game/bioshock1r/hands.cpp
@@ -445,6 +445,16 @@ int active_hand() {
     return g_autoHand.load(std::memory_order_relaxed);
 }
 
+void* hands_actor() {
+    return g_handsActor;
+}
+
+void* weapon_actor() {
+    void* w = weapon_valid(g_weaponActor) ? g_weaponActor
+                                          : bvr::b1r::aim::learned_weapon_object();
+    return weapon_valid(w) ? w : nullptr;
+}
+
 // Live mesh-alignment trim, read by `vraim synccheck` so its model chain runs
 // on the REAL tuned values (session 20).
 float model_trim_pitch_deg(int hand) {

--- a/src/game/bioshock1r/hands.cpp
+++ b/src/game/bioshock1r/hands.cpp
@@ -452,6 +452,18 @@ int active_hand() {
     return g_autoHand.load(std::memory_order_relaxed);
 }
 
+// Live mesh-alignment trim, read by `vraim synccheck` so its model chain runs
+// on the REAL tuned values (session 20).
+float model_trim_pitch_deg(int hand) {
+    return g_rotPitchDeg[hand & 1].load(std::memory_order_relaxed);
+}
+float model_trim_yaw_deg(int hand) {
+    return g_rotYawDeg[hand & 1].load(std::memory_order_relaxed);
+}
+float model_trim_roll_deg(int hand) {
+    return g_rotRollDeg[hand & 1].load(std::memory_order_relaxed);
+}
+
 void init(const bvr::pattern_scan::ProcessImage& image) {
     g_imageBase = image.base;
     load_config();
@@ -585,15 +597,12 @@ void on_calcview(const FrameContext& ctx) {
         }
 
         // Mesh-alignment trim (per hand), composed in the controller's local
-        // frame so it holds at EVERY controller orientation.
-        float trim[4], q2[4];
-        xr_local_trim_quat(g_rotPitchDeg[hand].load(std::memory_order_relaxed) / kRadToDeg,
-                           g_rotYawDeg[hand].load(std::memory_order_relaxed) / kRadToDeg,
-                           g_rotRollDeg[hand].load(std::memory_order_relaxed) / kRadToDeg,
-                           trim);
-        quat_mul(quat, trim, q2);
-
-        gp = xr_pose_to_game(mapCtx, pos, q2);
+        // frame so it holds at EVERY controller orientation. The chain is a
+        // pure function in frame_context.h, shared with `vraim synccheck`.
+        gp = model_pose_from_xr(mapCtx, pos, quat,
+                                g_rotPitchDeg[hand].load(std::memory_order_relaxed),
+                                g_rotYawDeg[hand].load(std::memory_order_relaxed),
+                                g_rotRollDeg[hand].load(std::memory_order_relaxed));
 
         // The aim calibration trim is NOT applied to the model by default
         // (see g_alignAimTrim above) - re-trimming the ray must not move the

--- a/src/game/bioshock1r/hands.h
+++ b/src/game/bioshock1r/hands.h
@@ -57,6 +57,9 @@ void on_calcview(const FrameContext& ctx);
 //   hideinactive on|off     collapse the whole INACTIVE hand's cluster while
 //                           the other drives (default ON; the weapon-attach
 //                           bone hides by translation - see bones.h)
+//   fname <index>|weapon    resolve a name index to its string via GNames
+//                           (session 20); `weapon` reads the cached weapon
+//                           actor's attach-bone FName
 //   save | reload           persist / re-read the offsets (per-hand keys in
 //                           hands.ini; a legacy suffix-less key loads to both)
 //   test <dYaw> <dPitch> [distUU] [holdMs]   camera-relative placement (proves

--- a/src/game/bioshock1r/hands.h
+++ b/src/game/bioshock1r/hands.h
@@ -72,6 +72,12 @@ void handle_command(const char* args);
 // the beam leaves the hand that is actually holding the weapon.
 int active_hand();
 
+// Live mesh-alignment trim (degrees, per hand) - read by `vraim synccheck` so
+// its model chain sweeps the REAL tuned values (session 20).
+float model_trim_pitch_deg(int hand);
+float model_trim_yaw_deg(int hand);
+float model_trim_roll_deg(int hand);
+
 // Persist the per-hand model offsets to hands.ini (same as `vrhands save`).
 // Called by `vrpreset save` too, so the one in-headset save button covers the
 // model sliders along with the preset's own values.

--- a/src/game/bioshock1r/hands.h
+++ b/src/game/bioshock1r/hands.h
@@ -60,6 +60,9 @@ void on_calcview(const FrameContext& ctx);
 //   fname <index>|weapon    resolve a name index to its string via GNames
 //                           (session 20); `weapon` reads the cached weapon
 //                           actor's attach-bone FName
+//   swaykill on|off|status  freeze the drive's reference against the idle
+//                           animation's breathing (default ON; session 20 -
+//                           real animations pass the threshold)
 //   save | reload           persist / re-read the offsets (per-hand keys in
 //                           hands.ini; a legacy suffix-less key loads to both)
 //   test <dYaw> <dPitch> [distUU] [holdMs]   camera-relative placement (proves

--- a/src/game/bioshock1r/hands.h
+++ b/src/game/bioshock1r/hands.h
@@ -81,6 +81,12 @@ float model_trim_pitch_deg(int hand);
 float model_trim_yaw_deg(int hand);
 float model_trim_roll_deg(int hand);
 
+// The live actors this module tracks (null until found/learned). The session-20
+// muzzle probe inspects the WEAPON's own skeleton, which is produced here every
+// frame; game thread only, revalidated by the caller's own reads.
+void* hands_actor();
+void* weapon_actor();
+
 // Persist the per-hand model offsets to hands.ini (same as `vrhands save`).
 // Called by `vrpreset save` too, so the one in-headset save button covers the
 // model sliders along with the preset's own values.

--- a/src/game/bioshock1r/patterns.cpp
+++ b/src/game/bioshock1r/patterns.cpp
@@ -147,6 +147,12 @@ bool resolve(const bvr::pattern_scan::ProcessImage& image, Symbols& out) {
         BVR_LOG("[b1r] fname index global: %p (%zu xref(s), %zu candidate(s) after init-site filter)",
                 scan.fnameIndexGlobal, scan.globalXrefs, scan.candidates);
     }
+    if (scan.fnameCtor) {
+        // Session 20: the FName constructor, kept for the name-system work
+        // (GNames derivation in ENGINE_NOTES; resolver below).
+        BVR_LOG("[b1r] fname ctor = %p (RVA 0x%X)", scan.fnameCtor,
+                static_cast<unsigned>(scan.fnameCtor - image.base));
+    }
 
     if (!ok) {
         const char* stage = scan.stringMatches == 0     ? "wide string not found"
@@ -223,6 +229,31 @@ void resolve_aim_natives(const bvr::pattern_scan::ProcessImage& image, Symbols& 
         BVR_LOG("[b1r] UAttackAbility::GetPerfectFireStart impl prologue mismatch at RVA 0x%X"
                 " - plasmid aim unavailable", kAbilityFireStartImplRva);
     }
+}
+
+const wchar_t* fname_text(int32_t index) {
+    using bvr::pattern_scan::is_memory_valid;
+    if (!g_imageBase || index < 0) return nullptr;
+    const uint8_t* arrayBase = g_imageBase + kGNamesDataRva;
+    if (!is_memory_valid(arrayBase, 8)) return nullptr;
+    const uint8_t* const* data = *reinterpret_cast<const uint8_t* const* const*>(arrayBase);
+    int32_t count = *reinterpret_cast<const int32_t*>(arrayBase + 4);
+    if (!data || index >= count) return nullptr;
+    if (!is_memory_valid(data + index, sizeof(void*))) return nullptr;
+    const uint8_t* entry = data[index];
+    if (!entry || !is_memory_valid(entry, kFNameEntryTextOffset + 2)) return nullptr;
+    // Entries self-identify: +0 is the entry's own index. A mismatch means
+    // the layout assumption broke (or the slot is recycled garbage) - refuse.
+    if (*reinterpret_cast<const int32_t*>(entry) != index) return nullptr;
+    return reinterpret_cast<const wchar_t*>(entry + kFNameEntryTextOffset);
+}
+
+int32_t fname_count() {
+    using bvr::pattern_scan::is_memory_valid;
+    if (!g_imageBase) return 0;
+    const uint8_t* arrayBase = g_imageBase + kGNamesDataRva;
+    if (!is_memory_valid(arrayBase, 8)) return 0;
+    return *reinterpret_cast<const int32_t*>(arrayBase + 4);
 }
 
 } // namespace bvr::b1r::patterns

--- a/src/game/bioshock1r/patterns.h
+++ b/src/game/bioshock1r/patterns.h
@@ -519,6 +519,27 @@ inline constexpr float kFgInvTanV = 2.3094011f; // 1/0.4330127
 inline constexpr float kFgViewYawBiasDeg = 1.7f;
 inline constexpr float kFgViewPitchBiasDeg = 1.1f;
 
+// ---- Name system (session 20) ----------------------------------------------
+// Derived by capstone disassembly of the FName constructor the event scan
+// already finds (thin SEH/lock wrapper at RVA 0x70D660 -> worker 0x70D3C0);
+// full chain in ENGINE_NOTES "Session 20". GNames is a TArray<FNameEntry*>
+// indexed by name index:
+//   [kGNamesDataRva] = FNameEntry** Data, +4 = int32 Count, +8 = int32 Max
+// FNameEntry: +0x0 int32 index (self), +0x4/+0x8 the 8-byte flags (the
+// FindType==2 path ORs 0x4000000 into +0x4), +0xC FNameEntry* hash next,
+// +0x10 UTF-16 text in place. An FName field is 8 bytes {index, number}.
+// The 4096-bucket string->index hash lives at kFNameHashRva (bonus oracle).
+inline constexpr uint32_t kGNamesDataRva = 0x13904EC;
+inline constexpr uint32_t kFNameHashRva = 0x1370EC0;
+inline constexpr uint32_t kFNameEntryHashNextOffset = 0xC;
+inline constexpr uint32_t kFNameEntryTextOffset = 0x10;
+
+// UTF-16 text of a name index, or null (unresolved base / out of range /
+// unreadable entry - every dereference is validated, fail-soft). Game thread.
+const wchar_t* fname_text(int32_t index);
+// GNames.Count (0 if unavailable) - for status lines.
+int32_t fname_count();
+
 struct Symbols {
     // void __thiscall(APlayerController* this, AActor** viewActor,
     //                 FVector* camLoc, FRotator* camRot)

--- a/src/game/bioshock1r/patterns.h
+++ b/src/game/bioshock1r/patterns.h
@@ -410,6 +410,18 @@ inline constexpr uint32_t kSkelInstBoneCountOffset = 0x4C;  // int (AHands rig: 
 inline constexpr uint32_t kSkelInstBonesBOffset = 0x54;     // hkQsTransform* array B
 inline constexpr uint32_t kSkelInstBoneCountBOffset = 0x58;
 inline constexpr uint32_t kSkelInstDirtyOffset = 0x88;   // evaluate-if-dirty flag (byte)
+// Session 20: bone NAMES. SkeletonInstance +0x08 -> SharedSkeletonData, whose
+// +0xAC map is FName -> bone index (lookup fn 0x5F6500, disassembled): a
+// standard UE hash map - +0x00 pairs base (16-byte pairs: +0 chain next,
+// +4 FName index, +8 FName number, +0xC value), +0x0C bucket array (int32,
+// -1 = empty), +0x10 bucket count (power of two). Walking every bucket chain
+// enumerates the whole table, which inverts to bone index -> name.
+inline constexpr uint32_t kSkelInstSharedOffset = 0x08;
+inline constexpr uint32_t kSharedBoneNameMapOffset = 0xAC;
+inline constexpr uint32_t kNameMapPairsOffset = 0x00;
+inline constexpr uint32_t kNameMapBucketsOffset = 0x0C;
+inline constexpr uint32_t kNameMapBucketCountOffset = 0x10;
+inline constexpr uint32_t kNameMapPairStride = 16;
 // The attach bone FName is stored ON the attached actor (weapon +0xF0/+0xF4)
 // by AActor::AttachToBone; attachment itself is bone-name + SetBase (actor
 // vtable +0x1A0). Equip-time only - nothing re-asserts it per tick.

--- a/src/game/bioshock1r/recorder.cpp
+++ b/src/game/bioshock1r/recorder.cpp
@@ -1,0 +1,403 @@
+// Session 20 vrrec: record + replay the per-frame input state. Design notes in
+// recorder.h; the acceptance contract is in docs/TESTING.md ("record/replay").
+//
+// Threading: every entry point here runs on the GAME thread (the CalcView tap
+// and the command seam share it), so the module needs no locks of its own.
+// The funnel sim slots and the pad publish are the cross-thread edges, and
+// they carry their own atomics.
+
+#include "game/bioshock1r/recorder.h"
+
+#include "core/input/xinput_bridge.h"
+#include "core/util/log.h"
+#include "game/bioshock1r/aim.h"
+#include "game/bioshock1r/camera.h"
+#include "game/bioshock1r/ue_math.h"
+
+#include <windows.h>
+
+#include <cstdio>
+#include <cstring>
+#include <share.h>
+#include <string>
+#include <vector>
+
+namespace bvr::b1r::recorder {
+namespace {
+
+#pragma pack(push, 1)
+struct RecPose {
+    float px = 0.0f, py = 0.0f, pz = 0.0f;
+    float qx = 0.0f, qy = 0.0f, qz = 0.0f, qw = 1.0f;
+    uint8_t valid = 0;
+};
+struct RecHeader {
+    char magic[4] = {'B', 'V', 'R', 'R'};
+    uint32_t version = 1;
+    uint32_t count = 0;
+    uint8_t sourceVr = 0; // 1 = recorded with a real headset driving
+    RecPose recenter{};   // valid flag unused; pose + the yaw units below
+    int32_t recenterYawUnits = 0;
+    float worldScale = 100.0f;
+};
+struct RecEntry {
+    RecPose head{};     // what the camera drive consumed (valid = vrDrove)
+    RecPose hands[4]{}; // [grip L, grip R, aim L, aim R] from the funnel
+    uint16_t buttons = 0;
+    uint8_t lt = 0, rt = 0;
+    int16_t lx = 0, ly = 0, rx = 0, ry = 0;
+    uint8_t padActive = 0;
+    int64_t predictedTime = 0;
+};
+#pragma pack(pop)
+
+enum class Mode { Idle, Recording, Playing };
+Mode g_mode = Mode::Idle;
+std::vector<RecEntry> g_entries;
+RecHeader g_header{};
+uint32_t g_cursor = 0;   // next entry to replay
+uint32_t g_marks = 0;    // mark lines emitted this run (record or play)
+char g_fileA[MAX_PATH] = {}; // last file written/loaded, for status lines
+// Runaway backstop, not a target: ~2 h at 150 CalcView/s. Never trimmed
+// silently - hitting it logs and stops the recording.
+constexpr size_t kMaxEntries = 1000000;
+
+// The flat drive pose (`vrrec hand`): one static pose on all four funnel
+// slots, at the sim lane's fixed hand spot.
+bool g_handArmed = false;
+
+std::wstring recordings_dir() {
+    std::wstring dir = bvr::log::data_dir();
+    dir += L"\\recordings";
+    CreateDirectoryW(dir.c_str(), nullptr);
+    return dir;
+}
+
+void wide_to_narrow(const wchar_t* w, char* out, size_t cap) {
+    WideCharToMultiByte(CP_UTF8, 0, w, -1, out, static_cast<int>(cap), nullptr, nullptr);
+}
+
+// Newest = lexicographically greatest rec_*.bvrrec (names are timestamped).
+bool newest_file(std::wstring& out) {
+    std::wstring pat = recordings_dir() + L"\\rec_*.bvrrec";
+    WIN32_FIND_DATAW fd{};
+    HANDLE h = FindFirstFileW(pat.c_str(), &fd);
+    if (h == INVALID_HANDLE_VALUE) return false;
+    std::wstring best;
+    do {
+        if (best.empty() || wcscmp(fd.cFileName, best.c_str()) > 0) best = fd.cFileName;
+    } while (FindNextFileW(h, &fd));
+    FindClose(h);
+    out = recordings_dir() + L"\\" + best;
+    return true;
+}
+
+void mark_line(const char* tag, uint32_t idx, const RecEntry& e, const FrameContext& fc) {
+    // The aim-R pose through the SAME pure chain the fire ray uses
+    // (frame_context.h) with the live R trim - so a record log and a replay
+    // log are comparable number for number.
+    // The head QUAT and the driven camera (fc.camPitch/camYaw) are the lines'
+    // head-replay evidence: under simhead the head POSITION is always the
+    // recenter origin, and the aim ray is deliberately head-invariant (the M7
+    // decoupling), so without these a broken head replay would not show.
+    const RecPose& aimR = e.hands[3];
+    if (aimR.valid) {
+        const float p[3] = {aimR.px, aimR.py, aimR.pz};
+        const float q[4] = {aimR.qx, aimR.qy, aimR.qz, aimR.qw};
+        GamePose gp = ray_pose_from_xr(fc, p, q, bvr::b1r::aim::trim_pitch_deg(1),
+                                       bvr::b1r::aim::trim_yaw_deg(1));
+        BVR_LOG("[rec] %s mark %u head=(%.4f %.4f %.4f | %.4f %.4f %.4f %.4f) "
+                "cam=(%d %d) aimR loc=(%.3f %.3f %.3f) rot=(%d %d) "
+                "pad=%04X %u %u %d %d %d %d",
+                tag, idx, e.head.px, e.head.py, e.head.pz, e.head.qx, e.head.qy, e.head.qz,
+                e.head.qw, fc.camPitch, fc.camYaw, gp.loc.x, gp.loc.y, gp.loc.z,
+                gp.rot.pitch, gp.rot.yaw, e.buttons, e.lt, e.rt, e.lx, e.ly, e.rx, e.ry);
+    } else {
+        BVR_LOG("[rec] %s mark %u head=(%.4f %.4f %.4f | %.4f %.4f %.4f %.4f) "
+                "cam=(%d %d) aimR INVALID pad=%04X %u %u %d %d %d %d",
+                tag, idx, e.head.px, e.head.py, e.head.pz, e.head.qx, e.head.qy, e.head.qz,
+                e.head.qw, fc.camPitch, fc.camYaw, e.buttons, e.lt, e.rt, e.lx, e.ly, e.rx,
+                e.ry);
+    }
+}
+
+void capture_pose(int hand, bool aim, RecPose& out) {
+    bvr::vr::HeadPose hp{};
+    if (bvr::vr::get_hand_pose(hand, aim, hp)) {
+        out = {hp.px, hp.py, hp.pz, hp.qx, hp.qy, hp.qz, hp.qw, 1};
+    } else {
+        out = {};
+    }
+}
+
+void feed_sim_slots(const RecEntry& e) {
+    for (int i = 0; i < 4; ++i) {
+        const RecPose& rp = e.hands[i];
+        const float p[3] = {rp.px, rp.py, rp.pz};
+        const float q[4] = {rp.qx, rp.qy, rp.qz, rp.qw};
+        bvr::vr::set_sim_hand_pose(i & 1, i >= 2, rp.valid != 0, p, q);
+    }
+}
+
+void publish_entry_pad(const RecEntry& e) {
+    bvr::input::Gamepad pad{};
+    pad.buttons = e.buttons;
+    pad.lt = e.lt;
+    pad.rt = e.rt;
+    pad.lx = e.lx;
+    pad.ly = e.ly;
+    pad.rx = e.rx;
+    pad.ry = e.ry;
+    bvr::input::publish_xr_state(pad, e.padActive != 0);
+}
+
+void end_replay(const char* why) {
+    bvr::vr::clear_sim_hand_poses();
+    bvr::input::publish_xr_state({}, false);
+    g_mode = Mode::Idle;
+    BVR_LOG("[rec] play %s: %u/%u frames, %u marks", why, g_cursor,
+            static_cast<uint32_t>(g_entries.size()), g_marks);
+}
+
+void write_file() {
+    SYSTEMTIME st{};
+    GetLocalTime(&st);
+    wchar_t name[64];
+    swprintf_s(name, L"rec_%04u%02u%02u_%02u%02u%02u.bvrrec", st.wYear, st.wMonth, st.wDay,
+               st.wHour, st.wMinute, st.wSecond);
+    std::wstring path = recordings_dir() + L"\\" + name;
+    FILE* f = nullptr;
+    if (_wfopen_s(&f, path.c_str(), L"wb") != 0 || !f) {
+        BVR_LOG("[rec] FAILED to open recording file for write");
+        return;
+    }
+    g_header.count = static_cast<uint32_t>(g_entries.size());
+    fwrite(&g_header, sizeof g_header, 1, f);
+    if (!g_entries.empty()) fwrite(g_entries.data(), sizeof(RecEntry), g_entries.size(), f);
+    fclose(f);
+    wide_to_narrow(path.c_str(), g_fileA, sizeof g_fileA);
+    BVR_LOG("[rec] stop: %u frames (%u marks) -> %s", g_header.count, g_marks, g_fileA);
+}
+
+bool read_file(const std::wstring& path) {
+    // _wfsopen with _SH_DENYNO: the fopen_s family opens files NON-SHARABLE,
+    // and a freshly written recording is routinely still held by the search
+    // indexer / AV scan - the shared open reads through that.
+    FILE* f = _wfsopen(path.c_str(), L"rb", _SH_DENYNO);
+    if (!f) {
+        BVR_LOG("[rec] FAILED to open recording for read (errno %d)", errno);
+        return false;
+    }
+    RecHeader h{};
+    if (fread(&h, sizeof h, 1, f) != 1 || memcmp(h.magic, "BVRR", 4) != 0 || h.version != 1) {
+        fclose(f);
+        BVR_LOG("[rec] not a BVRR v1 recording");
+        return false;
+    }
+    g_entries.assign(h.count, {});
+    if (h.count && fread(g_entries.data(), sizeof(RecEntry), h.count, f) != h.count) {
+        fclose(f);
+        g_entries.clear();
+        BVR_LOG("[rec] recording truncated (header says %u frames)", h.count);
+        return false;
+    }
+    fclose(f);
+    g_header = h;
+    wide_to_narrow(path.c_str(), g_fileA, sizeof g_fileA);
+    return true;
+}
+
+} // namespace
+
+bool playing() {
+    return g_mode == Mode::Playing;
+}
+
+bool replay_head(bvr::vr::HeadPose& hp) {
+    if (g_mode != Mode::Playing || g_cursor >= g_entries.size()) return false;
+    const RecPose& h = g_entries[g_cursor].head;
+    if (!h.valid) return false;
+    hp = {h.px, h.py, h.pz, h.qx, h.qy, h.qz, h.qw};
+    return true;
+}
+
+void on_tick(const FrameContext& fc, const bvr::vr::HeadPose& consumedHead, bool vrDrove,
+             bool liveHead) {
+    if (g_mode == Mode::Recording) {
+        if (g_entries.size() >= kMaxEntries) {
+            BVR_LOG("[rec] entry cap %u hit - stopping the recording",
+                    static_cast<uint32_t>(kMaxEntries));
+            write_file();
+            g_mode = Mode::Idle;
+            return;
+        }
+        RecEntry e{};
+        e.head = {consumedHead.px, consumedHead.py, consumedHead.pz, consumedHead.qx,
+                  consumedHead.qy, consumedHead.qz, consumedHead.qw,
+                  static_cast<uint8_t>(vrDrove ? 1 : 0)};
+        capture_pose(0, false, e.hands[0]);
+        capture_pose(1, false, e.hands[1]);
+        capture_pose(0, true, e.hands[2]);
+        capture_pose(1, true, e.hands[3]);
+        if (vrDrove && liveHead) g_header.sourceVr = 1;
+        bvr::input::Gamepad pad{};
+        bool active = false;
+        bvr::input::last_xr_pad(&pad, &active);
+        e.buttons = pad.buttons;
+        e.lt = pad.lt;
+        e.rt = pad.rt;
+        e.lx = pad.lx;
+        e.ly = pad.ly;
+        e.rx = pad.rx;
+        e.ry = pad.ry;
+        e.padActive = active ? 1 : 0;
+        e.predictedTime = bvr::vr::last_predicted_time();
+        uint32_t idx = static_cast<uint32_t>(g_entries.size());
+        g_entries.push_back(e);
+        if (idx % 10 == 0) {
+            ++g_marks;
+            mark_line("REC ", idx, e, fc);
+        }
+    } else if (g_mode == Mode::Playing) {
+        if (g_cursor >= g_entries.size()) {
+            end_replay("done");
+            return;
+        }
+        // The head for THIS tick was already served by replay_head at the
+        // camera gate (cursor untouched there); now feed the same entry's
+        // hands + pad so aim/hands - which run right after this call -
+        // consume one consistent frame, then advance.
+        const RecEntry& e = g_entries[g_cursor];
+        feed_sim_slots(e);
+        publish_entry_pad(e);
+        if (g_cursor % 10 == 0) {
+            ++g_marks;
+            mark_line("PLAY", g_cursor, e, fc);
+        }
+        ++g_cursor;
+    } else if (g_handArmed) {
+        // Flat drive pose: keep the funnel slots armed (a session appearing
+        // mid-arm would otherwise overwrite them at the next input_sync -
+        // re-arming per tick keeps the sim overlay authoritative).
+        float q[4];
+        xr_local_trim_quat(0.0f, 0.0f, 0.0f, q);
+        const float p[3] = {0.15f, -0.20f, -0.35f};
+        for (int i = 0; i < 4; ++i) bvr::vr::set_sim_hand_pose(i & 1, i >= 2, true, p, q);
+    }
+}
+
+void handle_command(const char* args) {
+    char verb[16] = {};
+    int consumed = 0;
+    if (sscanf_s(args, "%15s%n", verb, static_cast<unsigned>(sizeof verb), &consumed) != 1) {
+        BVR_LOG("[rec] usage: vrrec start|stop|play [file]|hand [p y r|off]|status");
+        return;
+    }
+    // The command seam delivers the raw line INCLUDING its trailing newline -
+    // skip all whitespace or `play` with no argument reads "\n" as a file name
+    // (errno 22, the first live failure of this module).
+    const char* rest = args + consumed;
+    while (*rest == ' ' || *rest == '\t' || *rest == '\r' || *rest == '\n') ++rest;
+
+    if (strcmp(verb, "start") == 0) {
+        if (g_mode != Mode::Idle) {
+            BVR_LOG("[rec] start REFUSED: %s", g_mode == Mode::Recording ? "already recording"
+                                                                         : "a replay is running");
+            return;
+        }
+        g_entries.clear();
+        g_entries.reserve(65536);
+        g_header = {};
+        bvr::vr::HeadPose rp{};
+        int32_t yawUnits = 0;
+        float ws = 100.0f;
+        camera::get_recenter_state(&rp, &yawUnits, &ws);
+        g_header.recenter = {rp.px, rp.py, rp.pz, rp.qx, rp.qy, rp.qz, rp.qw, 1};
+        g_header.recenterYawUnits = yawUnits;
+        g_header.worldScale = ws;
+        g_marks = 0;
+        g_mode = Mode::Recording;
+        BVR_LOG("[rec] START (recenter yaw %d units, worldScale %.1f - recenter BEFORE "
+                "start, not during)",
+                yawUnits, ws);
+    } else if (strcmp(verb, "stop") == 0) {
+        if (g_mode == Mode::Recording) {
+            write_file();
+            g_mode = Mode::Idle;
+        } else if (g_mode == Mode::Playing) {
+            end_replay("ABORTED");
+        } else {
+            BVR_LOG("[rec] nothing to stop");
+        }
+    } else if (strcmp(verb, "play") == 0) {
+        if (g_mode != Mode::Idle) {
+            BVR_LOG("[rec] play REFUSED: busy");
+            return;
+        }
+        if (bvr::vr::session_live()) {
+            BVR_LOG("[rec] play REFUSED: an XR session is live (two writers on the "
+                    "funnel) - close the headset session first");
+            return;
+        }
+        std::wstring path;
+        if (*rest) {
+            int n = MultiByteToWideChar(CP_UTF8, 0, rest, -1, nullptr, 0);
+            std::wstring name(static_cast<size_t>(n), L'\0');
+            MultiByteToWideChar(CP_UTF8, 0, rest, -1, name.data(), n);
+            name.resize(wcslen(name.c_str()));
+            while (!name.empty() && (name.back() == L'\r' || name.back() == L'\n' ||
+                                     name.back() == L' ' || name.back() == L'\t'))
+                name.pop_back();
+            path = recordings_dir() + L"\\" + name;
+        } else if (!newest_file(path)) {
+            BVR_LOG("[rec] no recordings found");
+            return;
+        }
+        if (!read_file(path)) return;
+        // Restore the mapping's hidden state - without this every comparison
+        // fails (the whole xr->game map routes through it).
+        bvr::vr::HeadPose rp{g_header.recenter.px, g_header.recenter.py, g_header.recenter.pz,
+                             g_header.recenter.qx, g_header.recenter.qy, g_header.recenter.qz,
+                             g_header.recenter.qw};
+        camera::set_recenter_state(rp, g_header.recenterYawUnits, g_header.worldScale);
+        g_cursor = 0;
+        g_marks = 0;
+        g_mode = Mode::Playing;
+        BVR_LOG("[rec] PLAY %s: %u frames, source=%s (recenter yaw %d, worldScale %.1f "
+                "restored)",
+                g_fileA, static_cast<uint32_t>(g_entries.size()),
+                g_header.sourceVr ? "headset" : "flat", g_header.recenterYawUnits,
+                g_header.worldScale);
+    } else if (strcmp(verb, "hand") == 0) {
+        if (strncmp(rest, "off", 3) == 0) {
+            g_handArmed = false;
+            bvr::vr::clear_sim_hand_poses();
+            BVR_LOG("[rec] hand sim OFF (funnel back to live slots)");
+        } else {
+            // Optional pitch/yaw/roll degrees; default = straight ahead.
+            float p = 0.0f, y = 0.0f, r = 0.0f;
+            sscanf_s(rest, "%f %f %f", &p, &y, &r);
+            float q[4];
+            xr_local_trim_quat(p / kRadToDeg, y / kRadToDeg, r / kRadToDeg, q);
+            const float pos[3] = {0.15f, -0.20f, -0.35f};
+            for (int i = 0; i < 4; ++i)
+                bvr::vr::set_sim_hand_pose(i & 1, i >= 2, true, pos, q);
+            g_handArmed = true;
+            BVR_LOG("[rec] hand sim ON: all four funnel slots at p=%.1f y=%.1f r=%.1f "
+                    "(model+ray+laser follow; 'vrrec hand off' clears)",
+                    p, y, r);
+        }
+    } else if (strcmp(verb, "status") == 0) {
+        const char* m = g_mode == Mode::Recording ? "RECORDING"
+                        : g_mode == Mode::Playing ? "PLAYING"
+                                                  : "idle";
+        BVR_LOG("[rec] status: %s | entries=%u cursor=%u marks=%u handSim=%d | last file %s",
+                m, static_cast<uint32_t>(g_entries.size()), g_cursor, g_marks,
+                g_handArmed ? 1 : 0, g_fileA[0] ? g_fileA : "(none)");
+    } else {
+        BVR_LOG("[rec] unknown 'vrrec %s' (start|stop|play [file]|hand [p y r|off]|status)",
+                verb);
+    }
+}
+
+} // namespace bvr::b1r::recorder

--- a/src/game/bioshock1r/recorder.h
+++ b/src/game/bioshock1r/recorder.h
@@ -1,0 +1,63 @@
+#pragma once
+// Session 20: vrrec - record and replay the mod's full per-frame input state
+// (head pose, the four hand-funnel poses, the published XR pad) so a headset
+// run can be re-examined FLAT, frame for frame, through the exact production
+// code paths.
+//
+// Design (session-19 plan, design-check refined):
+// - ONE tap in camera.cpp's CalcView tail, game thread, once per game tick
+//   (the stereo second pass skips the drive body, so the tap can't double-
+//   fire). It records what the game CONSUMED this frame - an
+//   on_present_begin tap cannot record flat (no session, early bail) and
+//   simpose injects downstream of the funnel.
+// - Replay is frame-for-frame at CalcView cadence (determinism over
+//   wall-clock): head via a dedicated replay lane in the camera gate (NOT
+//   simHead - that lane is angles-only with deadline semantics), hands via
+//   the sim overlay on the input_get_hand_pose funnel (all three consumers -
+//   ray, model, laser - read one world), pad via publish_xr_state.
+// - The RECENTER STATE + worldScale are serialized in the file header and
+//   restored on play: the whole xr->game mapping routes through them, so
+//   without this every comparison fails.
+// - `vrrec play` refuses while an XR session lives (two writers on the
+//   funnel). Recording in-headset is fine - that is the point.
+// - `[rec] mark` every 10th frame prints head + the aim-R pose mapped
+//   through the SAME pure functions production uses (frame_context.h) +
+//   the pad, so record and replay logs are directly comparable.
+
+#include "core/vr/openxr_runtime.h"
+#include "game/bioshock1r/frame_context.h"
+
+namespace bvr::b1r::recorder {
+
+// True while a replay is consuming entries (the camera gate checks this
+// BEFORE the sim/live lanes - a replayed frame must never recenter or read
+// the live head).
+bool playing();
+
+// Fill `hp` with the current entry's recorded head pose. False when the
+// current entry was recorded with the camera not driven (the replayed frame
+// then leaves the camera to the game, faithfully). Only valid while
+// playing().
+bool replay_head(bvr::vr::HeadPose& hp);
+
+// The once-per-tick tap, called from camera.cpp's CalcView tail right before
+// aim/hands consume the frame: records (or replays) this frame's state.
+// `consumedHead` is the head pose the camera drive used this frame (zeroed
+// when !vrDrove); `liveHead` distinguishes a real headset drive from the
+// simhead lane (recorded as the file's source tag).
+void on_tick(const FrameContext& fc, const bvr::vr::HeadPose& consumedHead, bool vrDrove,
+             bool liveHead);
+
+// Seam command handler: args after the "vrrec" verb (game thread).
+//   start             begin recording (header snapshots recenter+worldScale -
+//                     recenter BEFORE start, not during)
+//   stop              finalize the file / abort a running replay
+//   play [file]       replay the newest (or named) recording; refused while
+//                     an XR session lives
+//   hand [p y r]      arm a static synthetic pose on ALL FOUR funnel slots
+//                     (the flat record path: the model, ray and laser follow
+//                     it); "vrrec hand off" clears
+//   status
+void handle_command(const char* args);
+
+} // namespace bvr::b1r::recorder

--- a/src/game/bioshock1r/ue_math.h
+++ b/src/game/bioshock1r/ue_math.h
@@ -9,10 +9,21 @@
 // yaw turns toward +Y (right), positive pitch looks up, positive roll tilts
 // clockwise (right).
 
+#include "core/util/xr_math.h"
+
 #include <cmath>
 #include <cstdint>
 
 namespace bvr::b1r {
+
+// The quat helpers were promoted to core (session 20) so the laser (core/vr)
+// composes trims with the SAME algebra as the game-side ray and model.
+// Re-exported here so game code keeps its unqualified spelling.
+using bvr::xrmath::quat_axis_angle;
+using bvr::xrmath::quat_conj;
+using bvr::xrmath::quat_mul;
+using bvr::xrmath::quat_rotate;
+using bvr::xrmath::xr_local_trim_quat;
 
 struct FVector { float x, y, z; };             // Unreal units
 struct FRotator { int32_t pitch, yaw, roll; }; // 65536 units per full turn
@@ -30,55 +41,6 @@ constexpr float kRadToDeg = 57.29578f;
 // see body.h.
 inline int32_t wrap_rot(int32_t delta) {
     return static_cast<int16_t>(delta & 0xFFFF);
-}
-
-inline void quat_rotate(float qx, float qy, float qz, float qw, const float v[3],
-                        float out[3]) {
-    float t[3] = {2.0f * (qy * v[2] - qz * v[1]), 2.0f * (qz * v[0] - qx * v[2]),
-                  2.0f * (qx * v[1] - qy * v[0])};
-    out[0] = v[0] + qw * t[0] + (qy * t[2] - qz * t[1]);
-    out[1] = v[1] + qw * t[1] + (qz * t[0] - qx * t[2]);
-    out[2] = v[2] + qw * t[2] + (qx * t[1] - qy * t[0]);
-}
-
-// Hamilton product a (x) b, xyzw order: rotating by the result applies b
-// FIRST, then a. `pose (x) trim` therefore applies the trim in the POSE'S OWN
-// local frame - which is what a mesh-alignment offset must be. Adding euler
-// angles after conversion only behaves at one controller orientation; the M7
-// in-headset test proved that the hard way (the "pivot that breaks
-// everything").
-inline void quat_mul(const float a[4], const float b[4], float out[4]) {
-    out[0] = a[3] * b[0] + a[0] * b[3] + a[1] * b[2] - a[2] * b[1];
-    out[1] = a[3] * b[1] - a[0] * b[2] + a[1] * b[3] + a[2] * b[0];
-    out[2] = a[3] * b[2] + a[0] * b[1] - a[1] * b[0] + a[2] * b[3];
-    out[3] = a[3] * b[3] - a[0] * b[0] - a[1] * b[1] - a[2] * b[2];
-}
-
-inline void quat_axis_angle(float ax, float ay, float az, float rad, float out[4]) {
-    float s = sinf(rad * 0.5f);
-    out[0] = ax * s;
-    out[1] = ay * s;
-    out[2] = az * s;
-    out[3] = cosf(rad * 0.5f);
-}
-
-inline void quat_conj(const float q[4], float out[4]) {
-    out[0] = -q[0];
-    out[1] = -q[1];
-    out[2] = -q[2];
-    out[3] = q[3];
-}
-
-// Local-frame trim quaternion from user-facing angles, XR axes, signs chosen
-// to match the UE conventions the sliders claim: +pitch tilts up, +yaw turns
-// right, +roll tilts clockwise (right). Applied as pose (x) trim.
-inline void xr_local_trim_quat(float pitchRad, float yawRad, float rollRad, float out[4]) {
-    float qy[4], qp[4], qr[4], t[4];
-    quat_axis_angle(0.0f, 1.0f, 0.0f, -yawRad, qy);  // +Y is up; -angle = right
-    quat_axis_angle(1.0f, 0.0f, 0.0f, pitchRad, qp); // +X is right; + = up
-    quat_axis_angle(0.0f, 0.0f, -1.0f, rollRad, qr); // -Z is forward; + = clockwise
-    quat_mul(qp, qr, t);
-    quat_mul(qy, t, out);
 }
 
 inline void xr_to_ue(const float v[3], float out[3]) {


### PR DESCRIPTION
## What this is

The aim/laser/model sync session (session-19 plan item 4, stages 4.1-4.6, worked as designed). Every stage passed its numeric flat gate on clean boots; the in-headset checklist in STATUS.md is the open gate before v0.3.0.

## The headline: one trim algebra

The fire ray trimmed via rotator ADDS in game space, the laser via spherical-decomposition adds, the model via a quat composed in the controller LOCAL frame - three algebras for one physical quantity, agreeing only at the tuning pose.

- `vraim synccheck` (new): sweeps 21 axis-angle orientations incl. roll through BOTH pose->rot chains as pure functions shared with production. **Pre-fix baseline: up to 28.21 deg of ray-vs-barrel divergence at rolled poses** with identical trims fed to both chains.
- Unification: ray + laser adopt the model's `q_ctrl (x) q_trim` compose (helpers promoted to `core/util/xr_math.h`; `ray_pose_from_xr` = `model_pose_from_xr` + roll drop); the laser's origin basis is angle-built zero-roll (near-vertical degeneracy bail gone); legacy `aligntrim` deleted. **Post-fix: 0.03 deg max = the int-rotator quantization floor.** Tuned trim values carry over by construction.

## Also in this PR

- **`vrrec` record+replay**: one CalcView-tail tap records head + the four funnel poses + the pad; replay feeds a dedicated head lane, funnel sim slots, and the pad publish, with recenter state + worldScale in the file header. Acceptance: 7112-frame neutral-stick sweep replayed **712/712 marks bitwise identical**.
- **FName index->string**: the event scan's discarded FName-ctor address is captured; GNames located by disassembly (RVA 0x13904EC + entry layout, ENGINE_NOTES). Gate: 0 -> 'None', 1 -> 'ByteProperty', weapon attach bone -> 'Launcher'.
- **Named skeleton dumps** (`vrbones skel [hands|weapon]`): any actor's skeleton with bone names (the SharedSkeletonData FName->index map walked in reverse). The shotgun: SG_Body/SG_Pump/SG_Shell.
- **Muzzle ray** (`vraim muzzle on|off`, default OFF pending the headset verdict): right-hand ray + laser follow the RENDERED barrel (per-weapon automatic via the reference pose; the shotgun barrel measured ~9-11 deg above the attach forward - the misalignment previously hand-trimmed by eye).
- **Idle-sway kill** (`vrhands swaykill on|off`, default ON): measured +-1.2 deg barrel breathing at idle; the bob script function turned out to be the velocity-weighted WALK bob (nothing to zero via SET - negative result logged), so the kill freezes the drive reference behind a measured 2x-envelope threshold with a 600 ms settle window. Frozen bitwise 8/8 flat; fire/reload animations pass through and re-freeze.

## Verification

Every stage: clean-boot flat acceptance under the standard harness (stereo heartbeat clean, fire tests exact, crash dumps 8->8 across all boots). Details + baselines in ENGINE_NOTES session 20; procedures in TESTING.md (Record/replay).

**Do not merge before the in-headset checklist (STATUS.md) passes and the explicit go.**