### PR TITLE
Session 21: render sync - fov audit, fg scene decoded, per-weapon profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,14 @@ session. No game files are modified and no game assets are distributed.
 
 > **Status:** playable. Working today: full-rate stereo rendering, 6DOF head tracking,
 > motion-controller aim with a laser (right hand = weapons, left hand = plasmids), the visible
-> viewmodel following the controller with the inactive hand hidden, body-follows-head movement
-> ("walk where you look"), the game HUD (health/EVE/ammo - and the pause menu) on a readable
-> floating panel in VR, VR-standard controller bindings with stick-flick ammo switching, a
-> single-eye desktop mirror, and in-headset tuning sliders that persist. See
-> [docs/STATUS.md](docs/STATUS.md) for the current state and [docs/ROADMAP.md](docs/ROADMAP.md)
-> for what is next (per-weapon aim alignment is the known big gap).
+> viewmodel following the controller with the inactive hand hidden, **per-weapon aim profiles**
+> (every weapon keeps its own laser calibration and swaps it in the moment you equip it),
+> body-follows-head movement ("walk where you look"), the game HUD (health/EVE/ammo - and the
+> pause menu) on a readable floating panel in VR, VR-standard controller bindings with
+> ammo-select on the right stick, a single-eye desktop mirror, and in-headset tuning sliders
+> that persist. The shipped defaults ARE a full calibration (aim trims, per-weapon profiles,
+> body follow) tuned in-headset on a Quest 3. See [docs/STATUS.md](docs/STATUS.md) for the
+> current state and [docs/ROADMAP.md](docs/ROADMAP.md) for what is next.
 
 ## Requirements
 
@@ -69,13 +71,35 @@ To uninstall, delete the two DLLs (restore itsloopyo's backup if you made one).
 Tuning (all in the overlay, all persisted by **"Save preset values"** / `vrpreset save`):
 
 - **World scale / IPD / game FOV** - comfort and scale calibration
-- **Head anchor offsets** - if the camera sits wrong in the body
-- **Per-hand aim trim** - laser/bullet direction alignment per hand
+- **Per-hand aim trim** (up to +-90 deg) - laser/bullet direction alignment per hand
+- **Per-weapon profiles** - the right hand's aim trim + ray offsets automatically follow the
+  EQUIPPED weapon: tune with a weapon up and only that weapon's profile changes, swapped in
+  the moment you switch. Calibration flow: fire at a wall, nudge the sliders until the laser
+  sits on the bullet holes, next weapon, then one "Save preset values". The overlay's
+  "weapon profile:" line shows which weapon you are editing.
 - **Per-hand ray offsets** - the "Ray offset hand: L / R" selector + three sliders move the
   laser (and the bullets with it - they are one ray) to line up with the controller and model
+- **Head anchor offsets** - if the camera sits wrong in the body
 - **Per-hand model offsets** - the "Tuning hand: L / R" selector picks which hand the six
   position/rotation sliders edit, so the pistol and the plasmid hand are tuned independently
-- **`vrbody off`** - live A/B for the body-follows-head transfer (deadzone defaults 23 deg)
+- **`vrbody off`** - live A/B for the body-follows-head transfer (instant 1:1 by default)
+
+### The bundled preset (v0.3.0+)
+
+**A fresh install needs no tuning**: the shipped defaults are a complete in-headset
+calibration (left/plasmid hand trim, per-weapon profiles for all eight holdables, body
+follow, HUD placement). Just install and press VR PRESET 1.
+
+The release zip also carries the same calibration as plain files (`vrpreset.ini`,
+`hands.ini`, `weapons.ini`):
+
+- **New users**: nothing to do - the DLL defaults are identical to these files.
+- **Existing users with their own tuning**: your files in `%LOCALAPPDATA%\BioshockVR\`
+  ALWAYS win over the built-in defaults, key by key - updating the DLLs changes nothing you
+  tuned. To adopt the bundled calibration instead, back up and delete (or overwrite) those
+  three files in `%LOCALAPPDATA%\BioshockVR\` and restart the game. To adopt only parts
+  (say, the weapon profiles but not your world scale), copy just that one file - or even
+  single lines: every `key=value` line stands alone.
 
 The flat-screen crosshair is hidden by default (the laser replaces it); the "Flat-screen
 crosshair" checkbox or `vrxhair on` brings it back.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -420,3 +420,25 @@ runtime.
   it), and tuned trim values carry over: the old and new algebras agree exactly at the
   neutral tuning pose. The legacy `vrhands aligntrim` euler coupling was deleted - wrong
   algebra everywhere but the tuning pose, and nothing left for it to do.
+
+- **2026-07-28 (session 21): per-weapon profiles are a SWAP LAYER over the
+  existing R-hand atomics, not a lookup at ray build.** The alternative
+  (resolving `profile(weaponKey)` inside the hot ray/laser/model paths) would
+  have threaded weapon identity through three modules and made the laser
+  publish depend on a map lookup. Instead the six R-hand atomics stay the
+  single live truth every consumer already reads; the profile layer only
+  stashes them on a weapon-key change and re-loads the new key's values
+  (seeded from current on first sight). Consequences the design accepts: the
+  map lags the atomics between switches (stash points: switch + save), and
+  anything that overwrites the R atomics wholesale must re-apply the active
+  profile afterwards - which is exactly the preset-tail
+  `aim::reapply_weapon_profile()` hook (the flat-caught clobber). Same-frame
+  consistency is free because swap and consumers all run in the CalcView
+  tail on the game thread.
+
+- **2026-07-28 (session 21): every new render lever ships DEFAULT OFF.**
+  `vrfgnode sync|fova` can invalidate the headset-approved session-16
+  calibration (lockpull/gains encode the old fovA/fovB zoom-pull), so the
+  shipping composition stays byte-identical to session 20 until the
+  session-22 retune re-runs the acceptance ladder in the new regime and the
+  user judges it in the headset.

--- a/docs/ENGINE_NOTES.md
+++ b/docs/ENGINE_NOTES.md
@@ -1669,3 +1669,52 @@ cylinder) animates untouched - it is a different SkeletonInstance. Side
 effect by construction: hand-cluster finger animation during reload freezes
 too (the drive was already overwriting it); the weapon's own reload
 animation still shows.
+
+### The FOV audit: no lie exists between render and submission (session 21)
+
+**Question** (prompted by BioVR's measured "yaw warped, pitch clean" mismatch
+symptom matching our +-90 sign-flipping laser-vs-gun drift): does the FOV the
+game RENDERS under vrstereo equal the FOV our projection layer is TAGGED
+with? The readback that feeds the claim (camera.cpp) reads the same engine
+address we write, so it echoes our own value - it had never been
+ground-truthed against the renderer's actual output.
+
+**Instrumentation added**: (1) `xr: fovaudit submit` log at the projection
+submission site - the per-eye claimed tangents + source
+(readback/fallback/manual) + swap dims, logged on change;
+(2) `fovaudit` seam command - option int, gfov write state, submitted
+tangents, option-derived expectation side by side; (3)
+`tools/decode-framedump.ps1` - parses a `dumpframe full [n]` dump, recovers
+tangents per draw from the cb0 screen-ray helper block (floats 12..18 =
+`(2tanH, 0, -tanH, 0, 0, -2tanV, tanV)`), attributes each depth-tested draw
+to its governing cb0 capture (exact: a block is written whenever the VS b0
+buffer OBJECT changes), clusters by tangent pair, and tags per cluster how
+many draws carry the per-section fg-bake RVAs (0x3DBF7C/0x3EDCBF) in their
+stacks - the lens-independent fg marker (needed because the shipped vrfgfov
+match makes fg tangents EQUAL world tangents by design, so tangent
+clustering alone cannot separate the passes).
+
+**Measurement** (clean boot, NG+ Medical Pavilion, VR PRESET 1, vrstereo
+heartbeat clean, `dumpframe full 2` = both SR eyes): ONE perspective cluster
+per window - tanH=2.1445 tanV=1.2063 (= 130-deg hfov at 16:9) on 298/300
+depth-tested draws (q0/q1), identical across both eye windows, matching the
+option-derived tan(130/2)=2.144507 / *9/16=1.206285 to dump print precision
+(dH=dV=0.00001). The fg draws (fgBakeStacks=9, 576-byte b0 tier, first draws
+of the pass) carry the SAME tangents - the fg lens match verified from the
+cb side. Every undecodable block (119 draws/window) has ALL-ZERO screen-ray
+slots = non-perspective passes (shadow/UI) - no hidden second lens. Render
+viewport 1920x1080 (399 draws), so the 16:9 vertical derivation holds.
+
+**Verdict - negative result, the fov-lie hypothesis for the +-90 drift is
+DEAD flat**: the renderer does not clamp option 130, both stereo eyes render
+the same symmetric frustum, and submission builds its claim from the same
+option int at the same aspect (structural; `projViews[eye].fov` is symmetric
+both eyes from one scalar - the runtime's asymmetric per-eye fov never
+reaches submission, which is exactly BioVR's "remove the lie" discipline,
+already our architecture). Remaining live suspects for the drift: (a)
+session-only claim state - the new submit log line prints src + swap dims,
+one-glance check on the next headset run (src must read `readback`, swap
+must read the render resolution); (b) pose-tag attribution - `fovaudit pose
+on` arms a tagged-vs-consumed yaw delta log (in-headset only; flat has no
+session); (c) the structural foreground-vs-compositor split - the world-pass
+re-homing experiment.

--- a/docs/ENGINE_NOTES.md
+++ b/docs/ENGINE_NOTES.md
@@ -1868,3 +1868,26 @@ work. Cosmetic follow-up queued: during some VISIBLE stretches the flat
 window also stops presenting despite the pace guard (presents=0 while the
 skip counter is idle) - the guard covers xrWaitFrame but something else
 in the frame loop stalls; in-play impact none.
+
+### Session 21 part 3 - the MachineGun/GrenadeLauncher keying gap
+
+Run-2 log proof: Shotgun/Pistol/ChemicalThrower/Crossbow keyed and swapped
+per wheel switch (the rig read works), but 'MachineGun' and
+'GrenadeLauncher' NEVER keyed - those two carry a DIFFERENT NATIVE VTABLE
+than kPlayerWeaponVtableRva, so the vtable-gated holdable path rejected
+them and fell back to the stale cached weapon: the old key stayed active
+and the user's MG/GL tuning edits landed in the previous weapon's profile.
+Fix: `hands::current_holdable()` returns the raw Hands.CurrentHoldable
+pointer class-agnostically (with a rig-known/unknown status so legacy
+fallbacks only serve pre-rig states); the profile layer keys purely on
+object_class_name (UClass-vtable-validated, works for ANY class) and
+CLEARS the key when a holdable's class cannot resolve (edits then touch no
+profile - logged). weapon_actor() keeps its PlayerWeapon-vtable gate for
+legacy consumers. The MG/GL live-switch proof stays on the headset list
+(cannot switch flat); everything else gated exact on a clean boot.
+
+Also this round: the user's fixed LEFT-hand calibration (aim trim
++4.4/+30.0 deg, ray offset R+4.6/U+0.7 cm) written to vrpreset.ini and
+baked as CODE DEFAULTS (their explicit ask); their four live profiles
+rescued to weapons.ini via wsave before anything could drop them (the run
+had not pressed save).

--- a/docs/ENGINE_NOTES.md
+++ b/docs/ENGINE_NOTES.md
@@ -1784,3 +1784,42 @@ OFF = the rig at true world-lens geometry; the whole counter-model domain
   the passes).
 - The 576-byte cb tier is NOT fg-exclusive (world draws use it too; 88
   draws at the tier, 9 fg).
+
+### UObject identity: class-name keys for any live object (session 21)
+
+**Derivation (live, seam-only, no disasm):** the equipped weapon actor's
+header decodes as a classic UObject: +0x28 = the object's own FName index
+(read 18009 -> 'Shotgun' via fname_text; +0x2C = the instance number), and
++0x30 = the UClass pointer - a heap object carrying its own vtable (RVA
+0xE2F04C) whose +0x28 FName is the CANONICAL class name (number 0).
+Cross-checked on the AHands actor: its class resolves to **'PlayerHands'**
+(the ShockGame subclass - explains the all_classes 'Hands : Actor' entry as
+the base). Production accessor `patterns::object_class_name()` validates
+every dereference plus the UClass vtable before trusting the layout.
+
+**Per-weapon profiles (vraim weapon|wsave|wkey, weapons.ini):** the R-hand
+trim + ray-origin offsets hot-swap keyed by that class name; the R atomics
+stay the single live truth (laser + fire ray + model publish read them
+unchanged), stash-on-switch / seed-on-first-sight semantics, persisted as
+`<Class>.<field>=<value>`. Flat-proven exact: sim-key round-trip restores
+stashed values to the digit both directions ('Shotgun' 5.00/3.00 restored
+after a 'Pistol' 9/8 detour), weapons.ini write/load round-trips (10 values,
+2 weapons at boot), and the equipped shotgun keyed 'Shotgun' PRE-FIRE via
+the resolving scan. IMPORTANT ordering semantic: a resolved profile applies
+OVER the vrpreset.ini R values - by design (the profile is the per-weapon
+truth; the preset seeds the first profile on a virgin weapons.ini).
+
+**Weapon-actor resolution hardening:** the old proximity-only accept (120
+UU from the expected gun spot) missed in live boot states (2 owner-matched
+candidates, both rejected); the scan now accepts STRUCTURALLY first - the
+candidate whose Base (+0x450) IS the AHands actor (attachment, the
+session-20 equip-flow fact) - with proximity as fallback, and the profile
+resolver backs off after 3 consecutive null resolves (the session-18
+scan-cadence lesson; the game intro legitimately has NO weapon for minutes).
+
+**Boot-harness hazard found on the way:** boot.ps1's press-mashing can land
+on NEW GAME instead of CONTINUE after a force-kill dialog cycle - the run
+lands in the 1960 plane intro ("IMPORTING NEW GAME PLUS DATA" on this NG+
+profile). No save damage (the intro does not autosave before the lighthouse
+transition; the .bsb set was verified untouched), but flat runs must
+screenshot-verify the landing state before measuring.

--- a/docs/ENGINE_NOTES.md
+++ b/docs/ENGINE_NOTES.md
@@ -1823,3 +1823,48 @@ lands in the 1960 plane intro ("IMPORTING NEW GAME PLUS DATA" on this NG+
 profile). No save damage (the intro does not autosave before the lighthouse
 transition; the .bsb set was verified untouched), but flat runs must
 screenshot-verify the landing state before measuring.
+
+### Session 21 part 2 - the headset feedback round (same day)
+
+**THE +-90 DRIFT ROOT CAUSE CLOSES: it was the render lock itself.** The
+user ran `vrbones lock off` (as part of the fovA preview) and reported
+"exactly what I was looking for - the aim is in tune with the model...
+perfect". The lock's counter-model (calibrated sessions 13-16 against the
+old fg composition) miscorrects laterally at large hand yaws - the very
+sign-flipping laser-vs-gun offset reported in session 20. Lock is now
+DEFAULT OFF (`vrbones lock abs` = the live A/B back); the solve code stays
+for reference until the composition work retires it.
+
+**Hands.CurrentHoldable = hands+0x45C** (patterns.h has the derivation):
+the equipped-weapon pointer read straight off the rig actor. It replaces
+learned/cache/scan as the weapon resolver's primary source - the
+trigger-learned object PINNED the resolver to the previously FIRED weapon
+across wheel switches (unequipped weapons keep vtable + owner), which is
+why profiles only swapped on fire in the first headset run (log-proven:
+swaps at fire timestamps, minutes after the switches).
+
+**Profile seeding race (log-proven, fixed):** the first resolve beat the
+preset's value load by ~1 s, seeded the first profile from pre-preset
+ZEROS, and the preset-tail re-apply then wrote the zeros over the user's
+tuned baseline. Now: the resolver idles until a value source exists
+(preset baseline captured or ini profiles loaded), new profiles seed from
+the CAPTURED preset baseline (not from the outgoing weapon's values), all
+flat-gated exact.
+
+**fovA in-headset negative (parked, default off):** under `vrfgnode fova
+match` the user reports THE WORLD moving with head motion (the rig
+"decent") - the fovA argument evidently feeds more than the rig's section
+bake (a world-coupled or full-screen consumer downstream of the fg node's
+fovs). Do not re-arm in-headset until that consumer is identified; the
+flat instrument findings stand.
+
+**FPS/freeze audit of the headset run (log analysis):** every
+sub-20-presents/s stall run coincides exactly with an XR session
+FOCUSED->VISIBLE window (VD overlay open / headset set down), including
+the long 19:37-19:38 window where the fova commands were typed; zero
+mid-play heap scans (all 5 scans at boot), zero xrWaitFrame-blocked
+lines, steady heartbeat during FOCUSED play. The freezes were not mod
+work. Cosmetic follow-up queued: during some VISIBLE stretches the flat
+window also stops presenting despite the pace guard (presents=0 while the
+skip counter is idle) - the guard covers xrWaitFrame but something else
+in the frame loop stalls; in-play impact none.

--- a/docs/ENGINE_NOTES.md
+++ b/docs/ENGINE_NOTES.md
@@ -1718,3 +1718,69 @@ must read the render resolution); (b) pose-tag attribution - `fovaudit pose
 on` arms a tagged-vs-consumed yaw delta log (in-headset only; flat has no
 session); (c) the structural foreground-vs-compositor split - the world-pass
 re-homing experiment.
+
+### The foreground pass decoded: a second scene node, and the fovA zoom-pull lever (session 21)
+
+**Architecture (dump stack-diff + capstone, all constants in patterns.h
+"FOREGROUND SCENE NODE"):** the fg pass is a SECOND SCENE NODE flowing
+through the SAME render machinery as the world (fg and world skeletal draws
+share the whole draw layer; a per-section transform-provider virtual at
+vtbl+0x20 does the bake). The scene build (0x4CCE70) allocates a 0x400-byte
+fg node from the frame pool every build and constructs it at 0x56DC30 with
+MEASURED argument semantics: (parentScene, &scene.view@+0x118, x,
+vec3 cameraLoc, rotator cameraRot, float fovA <- PC+0x45C, float fovB <-
+PC+0x460), storing it at scene+0x1B0 (vtable 0xE1846C). The finisher
+(0x56DD90) builds the node's view matrix at +0x150 (+ inverse at +0x190,
+world-projection diag at +0x1D0) FROM THE LOC/ROT ARGS; the fovs land at
++0x3F0/+0x3F4. The ctor runs BEFORE CalcView inside each build (call sites
+build+0xD59 vs +0xF1A).
+
+**The fg camera inputs are ALREADY world-synced per eye** (pass-labeled
+ctor-arg capture, `vrfgnode on` + `dump`): pass 1's node receives the LEFT
+eye camera, pass 2's the RIGHT (values match apply_eye_offset's +-3.17 UU
+at the live yaw exactly), rotation = the DRIVEN camera rotator. Two raised
+hypotheses measured and KILLED the same night: (a) "fg view = stale
+pre-drive camera" - simhead sweep showed the DRIVEN yaw/pitch in the args;
+(b) "crossed eyes under SR" (each pass getting the sibling's camera - would
+have inverted rig disparity) - the pass-labeled capture shows correct-eye
+delivery. The `vrfgnode sync on` substitution (feeds the ctor camera.cpp's
+per-eye stash) is therefore a measured flat-static NO-OP; kept default-OFF
+as an in-headset latency A/B only.
+
+**THE LEVER - the fovA/fovB pair IS the fg zoom-pull.** fovA (from
+PC+0x45C, engine-restamped to 75.0 every frame - unpokeable as data; the
+session-15 "75.0 poked inert" verdict explained) is the REFERENCE fov;
+fovB (PC+0x460) the actual fg fov. Their ratio drives the rig's
+magnification + eye pull-back (the fov-coupled dolly sessions 13-16
+countered with the render lock + lockpull). `vrfgnode fova match`
+(ctor-arg substitution fovA:=fovB - always wins, unlike the data poke):
+the rig collapses to TRUE world geometry - screenshot mean-abs-diff 11.09
+with 44.2% of channels changed vs a 2.9 ambient floor, world pixels
+untouched, exact round-trip on `fova off`. Fire path alive under
+`fova match` + `vrbones lock off` (3 weapon-hook calls, no crash); ctor
+substitutions 3358+/0 misses; crash dumps stable across all fg-node work.
+**Candidate end-state (retune next session, headset-judged): vrfgfov on
+(projection matched) + fova match (zoom-pull neutralized) + render lock
+OFF = the rig at true world-lens geometry; the whole counter-model domain
+(lock, lockgain/lockdgain/lockpull, kFgEye* constants) retires.**
+
+**Negative results, all live-measured this session:**
+- NO script-side fg membership property exists: the full Actor property
+  list (282 props) and Hands' own (70) contain nothing foreground/pass
+  related - membership is native-only (fits the name-table finding: only
+  FOV-related foreground names exist).
+- Pawn+0x724 = the pawn->Hands reference (found by pointer-value hexdump
+  scan; the ONLY holder in pawn+0..0x1C00, PC holds none in +0..0x800).
+  Nulling it is FATAL within ~1 s (0xC0000005 at +0x6F5ED7, a hash-chain
+  walk on a corrupted [obj+0x10] - secondary damage, not the direct
+  consumer). NOT a lever. 26 code refs to +0x724 exist, all in game-logic
+  regions (0x1CA-0x313xxx) - the scene build never reads it directly.
+- The three section-transform provider classes (bake fns 0x3DBF10 /
+  0x3EDC40 / 0x60C5B0; vtbl slot +0x20 at rvas 0xDF20B4/0xDF32D4/0xE1CAA0)
+  are SKINNING STRATEGIES with 656/178/240 live instances - not fg
+  markers. Per-draw fg identification = the fg-bake stack RVAs
+  (0x3DBF7C/0x3EDCBF), which tools/decode-framedump.ps1 tags (lens-blind,
+  works under the matched lens where tangent clustering cannot separate
+  the passes).
+- The 576-byte cb tier is NOT fg-exclusive (world draws use it too; 88
+  draws at the tier, 9 fg).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -256,6 +256,11 @@ Goal: retire the project-level risks before building on them. Findings → ENGIN
       `%LOCALAPPDATA%\BioshockVR\hands.ini`. Keyed `default` for now - PER-WEAPON keys still
       want the live weapon's class name, which means resolving the UObject class/name offsets
       on this build (the only save carries pistol + wrench, so one profile covers it).*
+      *UPGRADED 2026-07-28 (session 21): TRUE per-weapon profiles shipped - the R-hand aim
+      trim + ray-origin offsets hot-swap keyed by the weapon's CLASS NAME (UObject +0x28
+      name / +0x30 class resolved live via GNames), persisted to weapons.ini, saved by the
+      preset button, weapon resolved pre-fire via the Base==AHands structural scan. The
+      live-switch swap proof is on the session-21 in-headset checklist.*
 ### M7-v2 - the rebuild (planned 2026-07-26 with the user)
 
 Goal in the user's words: the weapon and the plasmid hand each move as ONE with their own

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -525,6 +525,11 @@ kill. Both prerequisites below are now MET.):**
       puts the gun at double the hand's perceived distance and doubles hand motion - the
       session-11 percepts). Design sketch in the session-16 part-3 conversation; the per-eye
       write path (bones reapply) already exists.
+      *RE-CONFIRMED POLISH 2026-07-28 (session 21 part 3, user's call: "not that important
+      for the gameplay"): the ask is now two independent sliders (world + hand/model scale).
+      New candidate routes since the fg-scene decode - the fovA per-rig zoom (once its
+      world-coupling is explained and masked) or DrawScale on a fova-matched rig - see
+      STATUS "POLISH / POST-POLISH" for the probe order.*
 - [ ] IPD slider verification + calibration (parked here 2026-07-24 from M4 rung 1 by user
       choice - user could not tell if it does anything; test with an exaggerated offset,
       calibrate world scale first since perceived depth scale is the worldScale/IPD ratio)

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1555,31 +1555,42 @@ retired: xr_hello32 (32-bit) ran a complete OpenXR session on VDXR 1.0.10 with t
 (60 frames, RTX 4060 LUID match) - M2 is unblocked. DR-2 done. Repo public at
 https://github.com/mohamad-balouza/bioshock-vr. Em dashes banned repo-wide.
 
-## Next steps (re-rewritten 2026-07-28 after the part-2 headset feedback; the +-90 drift is CLOSED - it was the render lock, now default OFF)
+## Next steps (re-rewritten 2026-07-28 after the part-2 headset feedback; the +-90 drift is CLOSED - it was the render lock, now default OFF. Part 3: the user demoted the scale work to polish - "not that important for the gameplay")
 
-1. **Session 22 - MODEL/WORLD SCALE DECOUPLING (the user's ask, the new
-   headline).** Two independent sliders: world scale (the existing
-   worldScale) and a HAND/MODEL scale that does not touch the world.
-   Known walls from session 16 (do not re-walk blind): cluster bone .s
-   blows up the attached weapon (the attach path inverts chain scale);
-   actor DrawScale is geometry-inert on the fg path. Candidate routes, in
-   probe order: (a) understand the fovA world-coupling (the fovA arg
-   changes rendered rig scale flat - if its world-consumer is found and
-   masked, fovA becomes a clean per-rig zoom = the model-scale slider for
-   free); (b) DrawScale on a fova-matched rig (the session-21 STATUS note:
-   inert was only proven on the OLD fg path); (c) the per-eye bone-offset
-   stereo-basis split parked in M9 (the session-16 design sketch).
-2. **fovA world-motion mystery (feeds 1a)**: flat-find what ELSE consumes
-   the fg node's fovA (the user saw THE WORLD move with head under `fova
-   match` while the rig stayed decent) - dump-diff a fova-on/off pair
-   window by window; the consumer is whichever non-rig pass's transforms
-   move. Until explained, fova stays default-off and out of headset runs.
+1. **Await the part-3 headset verdict** (profiles swapping per wheel
+   switch, save/reload persistence, lock-off default feel) - fixes ship
+   from whatever comes back; then merge PR #6. v0.3.0 tags on the user's
+   explicit go after a green run.
+2. **Then the gameplay track (M9)**: pawn-eye-point anchoring (the user's
+   walk-bob decoupling idea - camera base from Pawn.Location + eye height
+   behind a default-OFF toggle), off-hand tracking + two-handed weapons
+   (both prerequisites shipped), wrench swing gesture, first-boot-restart
+   fix.
+3. **The submission-side closeout (cheap, headset-only, any run)**: one
+   glance at the `xr: fovaudit submit` line (src must read `readback`,
+   swap = the render resolution) + `fovaudit pose on` for 30 s of head
+   motion. Largely academic now the drift closed as the lock, but one
+   glance settles it forever.
 
-3. **The submission-side closeout (cheap, headset-only)**: one glance at
-   the `xr: fovaudit submit` line (src must read `readback`, swap = the
-   render resolution) + `fovaudit pose on` for 30 s of head motion.
-   Largely academic now the drift closed as the lock, but one glance
-   settles it forever.
+**POLISH / POST-POLISH (user's call 2026-07-28 part 3 - explicitly not
+gameplay-critical):**
+
+- **Model/world scale decoupling**: two independent sliders - world scale
+  (the existing worldScale) and a HAND/MODEL scale that does not touch
+  the world. Known walls from session 16 (do not re-walk blind): cluster
+  bone .s blows up the attached weapon (the attach path inverts chain
+  scale); actor DrawScale is geometry-inert on the fg path. Candidate
+  routes, in probe order: (a) the fovA world-coupling hunt below - if the
+  world-consumer is found and masked, fovA becomes a clean per-rig zoom =
+  the model-scale slider for free; (b) DrawScale on a fova-matched rig
+  (inert was only proven on the OLD fg path); (c) the per-eye bone-offset
+  stereo-basis split parked in M9 (the session-16 design sketch).
+- **fovA world-motion mystery (feeds the above)**: flat-find what ELSE
+  consumes the fg node's fovA (the user saw THE WORLD move with head
+  under `fova match` while the rig stayed decent) - dump-diff a
+  fova-on/off pair window by window; the consumer is whichever non-rig
+  pass's transforms move. Until explained, fova stays default-off and out
+  of headset runs.
 
 3. **Wall-calibration pass (the user, in headset)**: per-weapon profiles
    are live - calibrate each weapon dot==shot with the

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -165,6 +165,44 @@ now the default - confirm the aim-model sync feels like your `lock off`
 moment with no commands. (4) Optional: `fovaudit pose on` for 30 s (the
 submission closeout from the session-21 checklist still stands).
 
+### Session 21 part 3 (same day) - run 2: profiles nearly perfect, the MG/GL gap
+
+**The user's run 2:** per-weapon profiles "almost perfect... pretty good" -
+Shotgun/Pistol/ChemicalThrower/Crossbow keyed and swapped per wheel switch
+(log-proven, instant, no fire needed). But **MachineGun and
+GrenadeLauncher never keyed** (their tuning edits polluted whichever
+profile was still active): those two carry a DIFFERENT NATIVE VTABLE than
+kPlayerWeaponVtableRva, so the vtable-gated holdable read rejected them
+and the stale-cache fallback pinned the old key. FIXED the same night:
+`hands::current_holdable()` returns the rig's holdable CLASS-AGNOSTICALLY
+(the profile layer keys purely on object_class_name, which validates via
+the UClass vtable and resolves ANY class; an unresolvable class now CLEARS
+the key so edits can never touch another weapon's profile - logged).
+Flat-gated: 4 profiles load, Shotgun keys + applies, preset-save chains
+weapons.ini (mtime + 20 lines verified), fire subs 2/2, dumps stable. The
+MG/GL live-switch proof needs the wheel - headset item.
+
+**Also done on the user's ask:** (a) their four GOOD profiles from run 2
+were rescued to weapons.ini via `vraim wsave` before the game closed (the
+run had not pressed save) - Crossbow/others may carry MG/GL pollution, the
+user re-checks per weapon; (b) the user's FIXED LEFT-HAND calibration (aim
+trim +4.4/+30.0 deg, ray offset right +4.6 / up +0.7 cm, model offsets all
+zero) is written into vrpreset.ini AND baked as CODE DEFAULTS (aim.cpp) -
+new installs now start on their calibration; the rest of their preset
+(worldScale 100, ipd 63, gfov 130, deadzone 23) already matched the
+shipped defaults. The R-hand/profile default bake waits for their next
+tuning pass (their call). weapons.ini is now a LIVE USER FILE - never
+delete it in harness cleanups.
+
+**Headset re-test (run 3, short):** (1) equip the MACHINE GUN - the log
+must echo `weapon profile 'MachineGun' CREATED ...` the moment it equips;
+tune it; same for the GRENADE LAUNCHER; (2) re-check Crossbow (and any
+weapon tuned right before/after the MG/GL attempts in run 2) for polluted
+values - retune where needed; (3) switch across all six - each keeps its
+own; (4) "Save preset values" once at the end; (5) plasmid hand: confirm
+the left laser sits right out of the box (its calibration is now the
+default).
+
 ## Previous state (2026-07-28, session 20 - THE AIM-SYNC SESSION: one trim algebra, vrrec record+replay, FName/GNames, the muzzle ray, the idle-sway kill - ALL SIX STAGES FLAT-GREEN on branch s20-aim-sync)
 
 **Branch `s20-aim-sync`, MERGED to main as PR #5 (2026-07-28, the user's

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -203,6 +203,26 @@ own; (4) "Save preset values" once at the end; (5) plasmid hand: confirm
 the left laser sits right out of the box (its calibration is now the
 default).
 
+### Session 21 part 4 (same day) - RUN 3 PASSED, v0.3.0 SHIPS
+
+**Run 3: "Alright perfect, looks pretty good and everything is added" -
+MachineGun + GrenadeLauncher keyed and held their own profiles (the
+class-agnostic fix proven live), all eight holdables calibrated, the left
+hand re-tuned (trim -6.8/+30.0, offsets -2.8/0.6/0.5), deadzone set 0 by
+the user (lock-off removed the percept the 23-deg band existed for).**
+Their live values were saved via the seam (`vrpreset save` -> all three
+inis) and BAKED AS CODE DEFAULTS on their explicit ask: aim L/R defaults,
+deadzone 0 (body.cpp), and all 8 weapon profiles seeded at init
+(weapons.ini overrides key by key). Aim-trim sliders widened to +-90 deg
+(the user's L yaw sat pinned at the old +-30 cap). VIRGIN-INSTALL GATE:
+with all three inis set aside, a clean boot + preset reproduced the full
+calibration from code alone (L trim/offsets, R baseline, deadzone 0, 8
+profiles, Shotgun keyed + applied) - a fresh install needs no tuning;
+inis restored after, fire subs 2/2, dumps stable. README rewritten (per
+weapon profiles + the bundled-preset section incl. how existing users
+adopt or keep their own). v0.3.0: PR #6 merged, tagged, released with
+the preset inis in the zip - the user's go on record this part.
+
 ## Previous state (2026-07-28, session 20 - THE AIM-SYNC SESSION: one trim algebra, vrrec record+replay, FName/GNames, the muzzle ray, the idle-sway kill - ALL SIX STAGES FLAT-GREEN on branch s20-aim-sync)
 
 **Branch `s20-aim-sync`, MERGED to main as PR #5 (2026-07-28, the user's
@@ -2075,6 +2095,17 @@ and it resumes.
   LOAD GAME via 80 ms dpad taps; main menu ignores mouse clicks); crash
   baseline 8 -> 9 (the one deliberate discovery crash).
 - NOT started: stage 4 (pawn-eye anchoring) - queued behind the retune.
+- Parts 2-4 (same day, three headset runs + fixes between): the +-90
+  drift CLOSED as the render lock itself (lock now default OFF); weapon
+  resolver rebuilt twice on live evidence (learned-object pinning, then
+  the MG/GL native-vtable gap -> class-agnostic Hands.CurrentHoldable at
+  +0x45C); profile seeding race fixed (preset baseline); the user's full
+  calibration saved + BAKED AS DEFAULTS (incl. deadzone 0 and 8 default
+  weapon profiles; virgin-install gate green); trim sliders +-90;
+  scale-decoupling demoted to polish (user's call); fovA in-headset
+  negative (world moves - consumer unknown, parked); FPS audit: all
+  stalls = VISIBLE windows, not mod work. v0.3.0 MERGED + TAGGED +
+  RELEASED with the preset inis bundled.
 
 ### 2026-07-28 - Session 20 part 2 (headset results, PR #5 merged, the BioVR analysis, the re-plan)
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -126,6 +126,45 @@ rendered at true world geometry, retiring the whole counter-model domain
 - Crash-dump baseline moved 8 -> 9 this session (the pawn+0x724 discovery
   crash, deliberately taken and logged); every later boot held 9.
 
+### Session 21 part 2 (same day) - THE HEADSET FEEDBACK ROUND
+
+**The user's verdicts:** (a) **`vrbones lock off` is "exactly what I was
+looking for - the aim is in tune with the model... perfect"** - the +-90
+laser-vs-gun drift ROOT CAUSE was the render lock's own correction. LOCK
+IS NOW DEFAULT OFF (`vrbones lock abs` = the A/B back). (b) `vrfgnode
+fova match` made THE WORLD move with head motion (rig "decent") -
+in-headset NEGATIVE, parked default-off; the fovA arg evidently feeds a
+world-coupled consumer beyond the rig bake (ENGINE_NOTES). (c) Per-weapon
+profiles "didn't change per weapon" - TWO log-proven bugs, both fixed +
+flat-gated the same night: the resolver's learned-object preference
+pinned the key to the previously FIRED weapon across wheel switches (now:
+Hands.CurrentHoldable at hands+0x45C read directly off the rig - instant,
+scanless, pre-fire swap detection), and the first profile seeded from
+pre-preset ZEROS then re-applied over the user's baseline (now: the
+resolver idles until the preset baseline is captured; new profiles seed
+from that baseline, not from the outgoing weapon's values). (d) NEW ASK,
+next session's headline: DECOUPLE world scale from model scale - a world
+slider and a separate hand/model scale slider (worldScale currently
+scales both; the session-16 negatives - bone .s attach blowup, DrawScale
+inert on the fg path - are the known walls; the fovA true-scale geometry
+may be the opening if its world coupling gets explained). (e) FPS/freeze
+audit: every stall in the run's log coincides with a FOCUSED->VISIBLE
+window (VD overlay/headset off) - NOT mod work; zero mid-play scans, zero
+blocked waits, clean heartbeat during play. Flat gates for the fixes:
+baseline captured (0/-7.9/7.5), 'Shotgun' created FROM the baseline,
+actor+class resolve pre-fire via the rig read, sim-swap round-trip exact
+(4.00/2.00 restored; Pistol seeded from baseline), fire subs 2/2, dumps
+9->9, no stray weapons.ini.
+
+**Re-test in headset (short):** (1) tune the pistol's laser at a wall,
+wheel-switch to the shotgun - its own tuning must be there IMMEDIATELY
+(no fire needed), switch back - pistol tuning returns; the log echoes
+`weapon profile '<name>' applied` per switch. (2) "Save preset values"
+once happy; reload + PRESET 1: all weapon tunings return. (3) Lock-off is
+now the default - confirm the aim-model sync feels like your `lock off`
+moment with no commands. (4) Optional: `fovaudit pose on` for 30 s (the
+submission closeout from the session-21 checklist still stands).
+
 ## Previous state (2026-07-28, session 20 - THE AIM-SYNC SESSION: one trim algebra, vrrec record+replay, FName/GNames, the muzzle ray, the idle-sway kill - ALL SIX STAGES FLAT-GREEN on branch s20-aim-sync)
 
 **Branch `s20-aim-sync`, MERGED to main as PR #5 (2026-07-28, the user's
@@ -1516,25 +1555,31 @@ retired: xr_hello32 (32-bit) ran a complete OpenXR session on VDXR 1.0.10 with t
 (60 frames, RTX 4060 LUID match) - M2 is unblocked. DR-2 done. Repo public at
 https://github.com/mohamad-balouza/bioshock-vr. Em dashes banned repo-wide.
 
-## Next steps (rewritten 2026-07-28 after session 21; the session-20 plan's items 1-3 are DONE - 1 as a clean negative, 2 as the fovA discovery, 3 shipped)
+## Next steps (re-rewritten 2026-07-28 after the part-2 headset feedback; the +-90 drift is CLOSED - it was the render lock, now default OFF)
 
-1. **Session 22 - THE FOVA-MATCH RETUNE (the big one).** Arm `vrfgnode
-   fova match` + `vrbones lock off` under vrstereo and re-run the
-   session-14/16 acceptance ladder (size ratio on distance doubling,
-   camera-offset parallax, simhead glue sweep) in the new regime. The
-   session-16 calibration (lockpull 12.8, gains 0.9) encodes the OLD
-   zoom-pull and does not apply. If the ladder holds: make the trio the
-   default, delete the render-lock domain (bones.cpp solve, the lock
-   knobs, kFgEye* constants), and re-derive the drive's composition
-   against the true world lens. Headset gate: the user's +-90 laser-vs-gun
-   drift and the world-size percept, judged by eye (checklist item 3 gives
-   the preview tonight).
+1. **Session 22 - MODEL/WORLD SCALE DECOUPLING (the user's ask, the new
+   headline).** Two independent sliders: world scale (the existing
+   worldScale) and a HAND/MODEL scale that does not touch the world.
+   Known walls from session 16 (do not re-walk blind): cluster bone .s
+   blows up the attached weapon (the attach path inverts chain scale);
+   actor DrawScale is geometry-inert on the fg path. Candidate routes, in
+   probe order: (a) understand the fovA world-coupling (the fovA arg
+   changes rendered rig scale flat - if its world-consumer is found and
+   masked, fovA becomes a clean per-rig zoom = the model-scale slider for
+   free); (b) DrawScale on a fova-matched rig (the session-21 STATUS note:
+   inert was only proven on the OLD fg path); (c) the per-eye bone-offset
+   stereo-basis split parked in M9 (the session-16 design sketch).
+2. **fovA world-motion mystery (feeds 1a)**: flat-find what ELSE consumes
+   the fg node's fovA (the user saw THE WORLD move with head under `fova
+   match` while the rig stayed decent) - dump-diff a fova-on/off pair
+   window by window; the consumer is whichever non-rig pass's transforms
+   move. Until explained, fova stays default-off and out of headset runs.
 
-2. **The submission-side closeout (cheap, headset-only)**: one glance at
-   the new `xr: fovaudit submit` line (src must read `readback`, swap =
-   the render resolution) + `fovaudit pose on` for 30 s of head motion
-   (the tagged-vs-consumed yaw deltas). Closes the last submission-side
-   suspects for the +-90 flip.
+3. **The submission-side closeout (cheap, headset-only)**: one glance at
+   the `xr: fovaudit submit` line (src must read `readback`, swap = the
+   render resolution) + `fovaudit pose on` for 30 s of head motion.
+   Largely academic now the drift closed as the lock, but one glance
+   settles it forever.
 
 3. **Wall-calibration pass (the user, in headset)**: per-weapon profiles
    are live - calibrate each weapon dot==shot with the

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,7 +2,131 @@
 
 > Handoff file. Rewrite "Current state" and "Next steps" every session; append to the session log.
 
-## Current state (2026-07-28, session 20 - THE AIM-SYNC SESSION: one trim algebra, vrrec record+replay, FName/GNames, the muzzle ray, the idle-sway kill - ALL SIX STAGES FLAT-GREEN on branch s20-aim-sync)
+## Current state (2026-07-28, session 21 - RENDER SYNC: the fov audit came back clean, the fg scene decoded down to its ctor args, the fovA zoom-pull lever found, per-weapon profiles shipped - branch s21-render-sync)
+
+**Branch `s21-render-sync` off main (post-PR-#5). Three flat-gated commits:
+the FOV audit (negative result + permanent instruments), the fg scene-node
+discovery (the `vrfgnode` instrument + the fovA lever, every new render
+lever DEFAULT OFF - the shipping look is byte-identical to session 20), and
+per-weapon aim profiles (shipping; engages only when a weapon resolves).
+v0.3.0 is still NOT tagged - it waits for the in-headset verdict on the
+checklist below and the user's explicit go.**
+
+### 1. THE FOV AUDIT (plan item 1) - the fov-lie hypothesis is DEAD, and that is the finding
+
+Instrumented the projection submission (per-eye claimed tangents + claim
+source logged on change; the `fovaudit` seam command prints option vs
+submitted vs option-derived side by side; `fovaudit pose on` arms a
+tagged-vs-consumed yaw log for the headset) and built
+`tools/decode-framedump.ps1` (recovers tangents from the cb0 screen-ray
+block per depth-tested draw, clusters them, tags fg draws by the
+lens-blind fg-bake stack RVAs). Measured under vrstereo on a clean boot
+(`dumpframe full 2`): ONE tangent cluster per eye window - tanH=2.1445
+tanV=1.2063 = exactly tan(130/2) at 16:9 - identical in both eyes, fg
+draws included (the vrfgfov lens match verified from the cb side for the
+first time), and no hidden second lens (every undecodable block is a
+zero-filled non-perspective pass). The submission builds its claim from
+the same option int at the same aspect, so rendered == submitted by
+construction + measurement. BioVR's "remove the lie" discipline was
+ALREADY our architecture. The +-90 drift is NOT a projection-tag mismatch;
+the live suspects narrowed to the pose-tag domain (one new log line + the
+poseaudit measure it on the next headset run) and the fg composition
+(finding 2).
+
+### 2. THE FG SCENE DECODED (plan item 2 - world-pass re-homing found a better lever)
+
+The dump stack-diff + capstone work mapped the fg mechanism end to end
+(constants in patterns.h "FOREGROUND SCENE NODE"; full story + negatives
+in ENGINE_NOTES):
+
+- The fg pass is a SECOND SCENE NODE (0x400 bytes, allocated per frame,
+  ctor RVA 0x56DC30, stored at scene+0x1B0) flowing through the SAME
+  render machinery as the world; the per-section transform providers are
+  skinning strategies (656/178/240 live instances), NOT fg markers.
+- The ctor receives the CAMERA POSE + TWO FOVS as plain arguments: vec3
+  camera loc, rotator camera rot, fovA (PC+0x45C, engine-restamped 75.0
+  every frame - why session 15's poke read inert), fovB (PC+0x460, the
+  vrfgfov field).
+- The camera inputs are ALREADY per-eye correct under SR stereo
+  (pass-labeled capture: pass 1 receives the LEFT eye camera, pass 2 the
+  RIGHT, matching apply_eye_offset to the digit). Two models raised and
+  KILLED by measurement the same night: the stale-pre-drive camera and
+  CROSSED EYES (which would have inverted the rig's disparity). The
+  `vrfgnode sync` substitution built for the crossing is a measured
+  flat-static no-op - kept default-OFF as an in-headset latency A/B only.
+- **THE FIND: fovA/fovB is the fg ZOOM-PULL pair.** `vrfgnode fova match`
+  (ctor-argument substitution - always wins, no byte patching) collapses
+  the rig to TRUE world-lens geometry: screenshot diff 11.09 mean / 44.2%
+  of channels changed vs the 2.9 ambient floor, world pixels untouched,
+  exact round-trip on `fova off`, fire path clean under `fova match` +
+  `vrbones lock off`. This is the fov-coupled eye-dolly/magnification the
+  render lock has countered since session 13, now controllable at ONE
+  seam.
+- Negatives (ENGINE_NOTES): no script-side fg membership property exists
+  (Actor + Hands property lists enumerated); pawn+0x724 = pawn->Hands and
+  nulling it is FATAL (one crash, dump #9, minidump kept) - a proven
+  non-lever; the 576-byte cb tier is not fg-exclusive.
+
+**Candidate end-state for session 22 (needs the retune + the user's
+eyes): `vrfgfov on` + `vrfgnode fova match` + `vrbones lock off` = the rig
+rendered at true world geometry, retiring the whole counter-model domain
+(render lock, lockgain/lockdgain/lockpull, kFgEye* constants).**
+
+### 3. PER-WEAPON PROFILES (plan item 3) - SHIPPING
+
+- **Identity**: `patterns::object_class_name()` - UObject +0x28 = own
+  FName index, +0x30 = UClass (vtable-gated at RVA 0xE2F04C), derived
+  live and cross-checked (weapon -> 'Shotgun'; the AHands actor ->
+  'PlayerHands'). The profile key is the canonical class name.
+- **The layer**: the R-hand trim + ray-origin offsets hot-swap per weapon
+  class; the R atomics stay the single live truth (laser, fire ray, model
+  publish all unchanged by construction); stash-on-switch,
+  seed-from-current on first sight; persisted to weapons.ini;
+  `vrpreset save` chains it; and the preset's value load RE-APPLIES the
+  active profile at its tail (a flat-caught ordering clobber, fixed and
+  gated). Commands: `vraim weapon | wsave | wkey sim <name> | wkey real`;
+  the aim overlay shows the active key.
+- **Resolution**: the weapon actor resolves PRE-FIRE now - the anchored
+  scan accepts STRUCTURALLY first (candidate Base +0x450 == the AHands
+  actor; attachment, not proximity) with the 120 UU proximity fallback,
+  plus null-resolve backoff (the game intro has no weapon for minutes and
+  must not full-heap-scan at 2 s cadence - live-reproduced).
+- **Flat gates, all exact**: sim-key round-trip restores stashed values
+  to the digit both directions; weapons.ini write/load round-trips (10
+  values / 2 weapons); the composed chain proven on a clean boot (ini
+  loaded at init -> the equipped shotgun keyed 'Shotgun' pre-fire ->
+  profile values applied over the preset baseline -> re-applied after the
+  preset chain); fire seam subs 2/2 with the profile live; heartbeat
+  clean; dumps stable. The REAL weapon-switch swap cannot be driven flat
+  (`exec NextWeapon` FAULTS - standing trap): it is the headline of the
+  in-headset checklist.
+- **The calibration flow**: our laser IS the fire ray - equip, fire at a
+  wall, nudge the R trim/ray-offset sliders until the beam sits on the
+  bullet hole, next weapon; profiles capture automatically; one "Save
+  preset values" press persists everything.
+
+### Harness notes (new traps, all field-hit this session)
+
+- **boot.ps1 roulette**: after an abandoned run the MAIN MENU focus sits
+  on NEW GAME, and the A-press loop starts a new game (the 1960 plane
+  intro; this NG+ profile shows "IMPORTING NEW GAME PLUS DATA"). No save
+  damage - the intro does not autosave before the lighthouse and the .bsb
+  set was verified untouched - but flat runs MUST screenshot-verify the
+  landing state. Deterministic recovery: main menu -> dpad-DOWN as an
+  80 ms TAP (250 ms holds auto-repeat) to LOAD GAME -> A -> A on the
+  newest entry. Mouse clicks do NOT register on the MAIN menu (they do on
+  gameswf pause menus).
+- The weapon-profile update gates on gameplay view AND backs off after 3
+  null resolves - do not loosen either guard.
+- A weapons.ini written by flat tests is a TEST ARTIFACT and was deleted
+  at session end (the session-17 "ini overrides code defaults" trap,
+  weapons edition): profiles apply OVER the preset's R values by design,
+  so a stale test ini would clobber live tuning. The user's real profiles
+  seed from their tuned R values on first play.
+- Crash-dump baseline moved 8 -> 9 this session (the pawn+0x724 discovery
+  crash, deliberately taken and logged); every later boot held 9.
+
+## Previous state (2026-07-28, session 20 - THE AIM-SYNC SESSION: one trim algebra, vrrec record+replay, FName/GNames, the muzzle ray, the idle-sway kill - ALL SIX STAGES FLAT-GREEN on branch s20-aim-sync)
 
 **Branch `s20-aim-sync`, MERGED to main as PR #5 (2026-07-28, the user's
 explicit call after the part-2 results below - everything default-armed is
@@ -1392,47 +1516,38 @@ retired: xr_hello32 (32-bit) ran a complete OpenXR session on VDXR 1.0.10 with t
 (60 frames, RTX 4060 LUID match) - M2 is unblocked. DR-2 done. Repo public at
 https://github.com/mohamad-balouza/bioshock-vr. Em dashes banned repo-wide.
 
-## Next steps (re-ordered 2026-07-28 after the part-2 results + BioVR analysis)
+## Next steps (rewritten 2026-07-28 after session 21; the session-20 plan's items 1-3 are DONE - 1 as a clean negative, 2 as the fovA discovery, 3 shipped)
 
-1. **THE FOV AUDIT (first - cheap, prime suspect for the +-90 drift AND the
-   world-size percept).** Measure: the FOV the game ACTUALLY renders under
-   vrstereo (recover tangents from dumpframe projection matrices - the
-   session-13 technique) vs what our submitted projection layer is TAGGED
-   with (openxr_runtime.cpp submission - do we pass the runtime's
-   asymmetric views[].fov?) vs the game FOV we write. If they disagree:
-   submit a symmetric frustum built from the RENDERED fov exactly
-   (BioVR-style "remove the lie"). Flat gate: rendered tangents ==
-   submitted tangents per eye, logged. Headset gate: the +-90 flip
-   shrinks/dies. This benefits everything downstream incl. item 2.
+1. **Session 22 - THE FOVA-MATCH RETUNE (the big one).** Arm `vrfgnode
+   fova match` + `vrbones lock off` under vrstereo and re-run the
+   session-14/16 acceptance ladder (size ratio on distance doubling,
+   camera-offset parallax, simhead glue sweep) in the new regime. The
+   session-16 calibration (lockpull 12.8, gains 0.9) encodes the OLD
+   zoom-pull and does not apply. If the ladder holds: make the trio the
+   default, delete the render-lock domain (bones.cpp solve, the lock
+   knobs, kFgEye* constants), and re-derive the drive's composition
+   against the true world lens. Headset gate: the user's +-90 laser-vs-gun
+   drift and the world-size percept, judged by eye (checklist item 3 gives
+   the preview tonight).
 
-2. **WORLD-PASS RE-HOMING (the big swing, user's call).** Find what marks
-   the AHands rig as foreground (actor flag / class check / fg list) and
-   flip it so the rig + attached weapon render through the WORLD pass at
-   their true world position. Instrument: dumpframe classifies draws per
-   pass - poke candidates, watch the rig's draws migrate tiers. Kills the
-   whole drift domain (fg lens split, eye dolly, render lock) with
-   FX/equip anchoring intact. Do NOT spawn a puppet actor. Expected
-   trades: gun clips walls (normal VR), possible lighting differences,
-   mesh may read oversized in the world pass - but DrawScale (+0x2AC +
-   dirty protocol) was only proven inert on the FG path and likely works
-   on the world path = the scale knob for free. Fallback if the switch
-   cannot be found/flipped: item 3 carries the release.
+2. **The submission-side closeout (cheap, headset-only)**: one glance at
+   the new `xr: fovaudit submit` line (src must read `readback`, swap =
+   the render resolution) + `fovaudit pose on` for 30 s of head motion
+   (the tagged-vs-consumed yaw deltas). Closes the last submission-side
+   suspects for the +-90 flip.
 
-3. **PER-WEAPON PROFILES + WALL CALIBRATION** (retires the muzzle
-   derivation; needed in some form either way): per-weapon aim-trim +
-   origin offsets keyed by weapon identity (fname_text / learned weapon
-   object; consider resolving the weapon's class name for a stable key),
-   hot-swap on switch, persisted. Calibration flow: our laser IS the fire
-   ray, so "fire at the wall, adjust until the beam sits on the bullet
-   hole, per weapon" is exact - overlay sliders/commands + save.
+3. **Wall-calibration pass (the user, in headset)**: per-weapon profiles
+   are live - calibrate each weapon dot==shot with the
+   laser-on-bullet-hole flow, per weapon, then one "Save preset values".
 
-4. **Follow-up (user's idea): pawn-eye-point anchoring** - anchor the VR
-   frame to Pawn.Location + EyeHeight (static) instead of the animated
-   camera base so walk-bob never leaks into camera or hands. Do after 2.
+4. **Pawn-eye-point anchoring (the user's idea, unstarted)**: anchor the
+   VR frame to Pawn.Location + EyeHeight instead of the animated camera
+   base so walk-bob never leaks into camera or hands. Cleanest AFTER the
+   fova-match regime lands (one composition rewrite, not two).
 
-5. **Then**: off-hand tracking + two-handed weapons (ROADMAP M9, both
-   prerequisites shipped), wrench swing gesture, first-boot-restart fix.
-   v0.3.0 tags when items 1-3 are headset-verified with the user's go.
+5. **Then**: off-hand tracking + two-handed weapons (M9, prerequisites
+   shipped), wrench swing gesture, first-boot-restart fix. v0.3.0 tags
+   when the session-20/21 work is headset-verified with the user's go.
 
 2. **DONE 2026-07-27: v0.1.0 IS PUBLISHED** - tag on main at PR #3's merge,
    release zip (both RelWithDebInfo DLLs + README.txt) at
@@ -1506,7 +1621,47 @@ Carried-over backlog (numbering kept from session 17):
 13. **Parked in M9** (user's call 2026-07-24): IPD slider verification, small
     head-motion bobbing, the vrstereo off/re-arm state bug, HUD-in-both-eyes.
 
-### IN-HEADSET CHECKLIST - aim sync + testing framework (session 20) - RAN SAME DAY, results in "Session 20 part 2" above (muzzle failed -> default OFF; drift persists -> session-21 plan; swaykill clean; PR #5 merged on the user's call)
+### IN-HEADSET CHECKLIST - render sync + per-weapon profiles (session 21)
+
+Setup as always: Quest 3 + Virtual Desktop (VDXR), launch from Steam,
+CONTINUE = the NG+ Medical Pavilion anchor (TRAP: if the game boots into
+the 1960 plane intro, the main-menu focus moved to NEW GAME - use main
+menu -> LOAD GAME -> the newest entry), press **VR PRESET 1**. Shipping
+defaults are byte-identical to session 20 except the per-weapon profile
+layer; every new render lever is opt-in. Nothing in the camera/recenter/
+body path changed.
+
+1. **Non-regression sweep (60 s, first).** Park the hand, look around
+   wide, stick-walk, turn past 90 both ways, two right-trigger pulls + an
+   Electro Bolt, pause menu once. Anything session 20 did not do: stop
+   and report.
+2. **PER-WEAPON PROFILES (the shipping headline).** With the shotgun up,
+   fire at a wall and nudge the R trim + ray-offset sliders until the
+   laser sits exactly on the bullet holes. Switch weapons through the
+   wheel - pistol, MG, crossbow - and tune two or three the same way.
+   Switch back and forth: each weapon must keep ITS OWN tuning (the log
+   echoes `weapon profile '<name>' applied` per switch - this live-switch
+   swap is the one proof the flat harness cannot do). Then "Save preset
+   values", quit to menu, reload, PRESET 1: every weapon's tuning must
+   come back by itself.
+3. **THE FOVA PREVIEW (opt-in, 2 minutes - session 22's decision data).**
+   `vrfgnode fova match` then `vrbones lock off`. The gun/hands will read
+   MUCH smaller and deeper - that is true world geometry (the flat A/B
+   shows the composition collapse). Judge two things only: (a) at +-90
+   hand yaw, does the rendered gun now sit closer to the laser (the drift
+   you reported)? (b) does the world-size percept change? Do NOT re-tune
+   anything in this mode; `vrfgnode fova off` + `vrbones lock abs`
+   restores the shipping look exactly.
+4. **The submission log glance.** After PRESET 1, find the one-line
+   `xr: fovaudit submit ...` in the log: report `src=` and `swap=`
+   (expected: `readback` and your render resolution). Optionally run
+   `fovaudit pose on` for ~30 s of head motion and grab the `poseaudit`
+   lines - they close the pose-tag suspect for the +-90 flip.
+5. **Anything off**: `vraim wkey real` re-resolves the weapon profile;
+   the R sliders always edit the ACTIVE weapon. If a symptom survives
+   `vrfgnode off` + the default toggles, it predates this session.
+
+### PREVIOUS CHECKLIST - aim sync + testing framework (session 20) - RAN SAME DAY, results in "Session 20 part 2" above (muzzle failed -> default OFF; drift persists -> session-21 plan; swaykill clean; PR #5 merged on the user's call)
 
 Setup as always: Quest 3 + Virtual Desktop (VDXR), launch from Steam, CONTINUE
 (the NG+ Medical Pavilion all-weapons anchor), press **VR PRESET 1**. Nothing
@@ -1799,6 +1954,33 @@ and it resumes.
   (install.ps1 backs theirs up automatically).
 
 ## Session log (newest first)
+
+### 2026-07-28 - Session 21 (render sync: fov audit clean, the fg scene decoded, the fovA lever, per-weapon profiles)
+
+- FOV AUDIT (plan item 1): instrumented submission tangents (`fovaudit`,
+  on-change submit log, poseaudit) + built tools/decode-framedump.ps1;
+  measured rendered == submitted == option-derived to 1e-5, both eyes, fg
+  draws included, no hidden lens. NEGATIVE RESULT: no fov lie exists -
+  BioVR's discipline was already our architecture. ENGINE_NOTES entry.
+- FG SCENE (plan item 2): decoded the fg pass to a second scene node
+  (ctor 0x56DC30, camera-pose + fovA/fovB args, node at scene+0x1B0);
+  proved the camera inputs already per-eye correct (killed the
+  crossed-eye and stale-camera models by pass-labeled measurement);
+  FOUND THE fovA/fovB ZOOM-PULL - `vrfgnode fova match` collapses the rig
+  to true world geometry (diff 11.09/44.2% vs 2.9 floor, exact
+  round-trip). Negatives logged: no script fg property; pawn+0x724 null =
+  fatal (dump #9); providers = skinning strategies. All levers default
+  OFF; the session-22 retune decides the new regime.
+- PER-WEAPON PROFILES (plan item 3, SHIPPING): UObject identity derived
+  live (+0x28 name / +0x30 class, 'Shotgun'/'PlayerHands' cross-check);
+  R-hand trim+offset profiles keyed by class name, hot-swap + weapons.ini
+  + preset-chain save + preset-tail re-apply; weapon resolves PRE-FIRE
+  via the structural Base==AHands accept + null backoff. All flat gates
+  exact; the live-switch swap is the checklist headline.
+- Harness: boot.ps1 NEW-GAME roulette diagnosed (menu focus; recovery =
+  LOAD GAME via 80 ms dpad taps; main menu ignores mouse clicks); crash
+  baseline 8 -> 9 (the one deliberate discovery crash).
+- NOT started: stage 4 (pawn-eye anchoring) - queued behind the retune.
 
 ### 2026-07-28 - Session 20 part 2 (headset results, PR #5 merged, the BioVR analysis, the re-plan)
 

--- a/src/core/vr/openxr_runtime.cpp
+++ b/src/core/vr/openxr_runtime.cpp
@@ -136,6 +136,22 @@ std::atomic<bool> g_loggedFirstProjection{false};
 std::atomic<bool> g_loggedFirstStereo{false};
 uint64_t g_lastProjBlockedLogMs = 0;
 
+// Session-21 FOV audit: the tangents the projection layer was last TAGGED
+// with and which source produced the claimed hfov. Logged on change at the
+// submission site and readable by the game thread's `fovaudit` command; the
+// flat gate compares these against tangents recovered from dumpframe cb0
+// blocks. The pose audit (default off) additionally logs the yaw the layer
+// is tagged with vs the yaw the game thread last consumed from the head-pose
+// funnel - a generation-skew instrument, in-headset only (flat has no session).
+constexpr const char* kFovSrcNames[3] = {"readback", "fallback", "manual"};
+std::atomic<float> g_auditTanH{0.0f};
+std::atomic<float> g_auditTanV{0.0f};
+std::atomic<int> g_auditFovSrc{-1};
+std::atomic<bool> g_poseAudit{false};
+std::atomic<float> g_consumedHeadQuat[4] = {}; // x,y,z,w - game-thread stamp
+std::atomic<uint32_t> g_consumedHeadCount{0};
+uint64_t g_lastPoseAuditLogMs = 0; // render thread only
+
 // M4 rung 1: AlternateEye stereo (AER). The render thread owns everything here
 // except g_aerEyeSign, which CalcView on the game thread reads through
 // current_eye_sign() to pick the per-frame eye offset. The sign also encodes
@@ -1153,6 +1169,14 @@ uint32_t build_laser_layers(XrCompositionLayerQuad* quads) {
     return built;
 }
 
+// Yaw of an XR-space orientation (forward = -Z, right = +X), for the pose
+// audit. Absolute convention is arbitrary; only deltas are read.
+float xr_quat_yaw_deg(float qx, float qy, float qz, float qw) {
+    float fwd[3] = {0.0f, 0.0f, -1.0f}, f[3];
+    bvr::xrmath::quat_rotate(qx, qy, qz, qw, fwd, f);
+    return atan2f(-f[0], -f[2]) * 57.29578f;
+}
+
 void on_present_end(IDXGISwapChain* swapchain) {
     if (!g_frameOpen) {
         // No XR frame this present (session gone, or the pace guard skipped
@@ -1181,10 +1205,16 @@ void on_present_end(IDXGISwapChain* swapchain) {
     // Claim the fov the game actually rendered with (adapter readback);
     // fall back to the circumscribed target before the first readback lands.
     // The manual calibration override beats both (see its declaration).
+    int hfovSrc = 0; // fov audit: 0 readback, 1 fallback, 2 manual
     float hfovDeg = g_renderedHfov.load(std::memory_order_relaxed);
-    if (hfovDeg <= 0.0f) hfovDeg = g_hfovDeg.load(std::memory_order_relaxed);
-    if (g_claimFovManual.load(std::memory_order_relaxed))
+    if (hfovDeg <= 0.0f) {
+        hfovDeg = g_hfovDeg.load(std::memory_order_relaxed);
+        hfovSrc = 1;
+    }
+    if (g_claimFovManual.load(std::memory_order_relaxed)) {
         hfovDeg = g_claimFovDeg.load(std::memory_order_relaxed);
+        hfovSrc = 2;
+    }
     bool projectionMode = g_cameraMode.load(std::memory_order_relaxed) &&
                           g_projectionReady.load(std::memory_order_relaxed) && hfovDeg > 0.0f;
 
@@ -1293,6 +1323,21 @@ void on_present_end(IDXGISwapChain* swapchain) {
                     float halfH = hfovDeg * 0.5f / 57.29578f;
                     float halfV = atanf(tanf(halfH) * static_cast<float>(g_swapH) /
                                         static_cast<float>(g_swapW));
+                    // FOV audit (session 21): the tangents this layer is
+                    // TAGGED with, logged on change. The flat gate compares
+                    // them against tangents recovered from dumpframe cb0.
+                    float tanClaimH = tanf(halfH), tanClaimV = tanf(halfV);
+                    if (tanClaimH != g_auditTanH.load(std::memory_order_relaxed) ||
+                        tanClaimV != g_auditTanV.load(std::memory_order_relaxed) ||
+                        hfovSrc != g_auditFovSrc.load(std::memory_order_relaxed)) {
+                        g_auditTanH.store(tanClaimH, std::memory_order_relaxed);
+                        g_auditTanV.store(tanClaimV, std::memory_order_relaxed);
+                        g_auditFovSrc.store(hfovSrc, std::memory_order_relaxed);
+                        BVR_LOG("xr: fovaudit submit tanH=%.6f tanV=%.6f (hfov %.2f deg, "
+                                "src=%s, swap %ux%u, symmetric both eyes)",
+                                tanClaimH, tanClaimV, hfovDeg, kFovSrcNames[hfovSrc],
+                                g_swapW, g_swapH);
+                    }
                     // AER: each eye shows its swapchain's most recently
                     // released image with the pose stored at its capture (the
                     // compositor reprojects the stale eye). Until both eyes
@@ -1310,6 +1355,29 @@ void on_present_end(IDXGISwapChain* swapchain) {
                             projViews[eye].subImage = sub;
                         }
                         projViews[eye].fov = {-halfH, halfH, halfV, -halfV};
+                    }
+                    // Pose-tag audit (session 21, armed by `fovaudit pose on`):
+                    // tagged-vs-consumed yaw, rate-limited. In-headset only.
+                    if (stereo && g_poseAudit.load(std::memory_order_relaxed)) {
+                        uint64_t now = GetTickCount64();
+                        if (now - g_lastPoseAuditLogMs >= 500) {
+                            g_lastPoseAuditLogMs = now;
+                            float yawTag = xr_quat_yaw_deg(
+                                projViews[0].pose.orientation.x, projViews[0].pose.orientation.y,
+                                projViews[0].pose.orientation.z, projViews[0].pose.orientation.w);
+                            float yawUse = xr_quat_yaw_deg(
+                                g_consumedHeadQuat[0].load(std::memory_order_relaxed),
+                                g_consumedHeadQuat[1].load(std::memory_order_relaxed),
+                                g_consumedHeadQuat[2].load(std::memory_order_relaxed),
+                                g_consumedHeadQuat[3].load(std::memory_order_relaxed));
+                            float d = yawTag - yawUse;
+                            while (d > 180.0f) d -= 360.0f;
+                            while (d < -180.0f) d += 360.0f;
+                            BVR_LOG("xr: poseaudit tagged yaw %.2f vs consumed %.2f "
+                                    "(delta %.2f deg, samples %u)",
+                                    yawTag, yawUse, d,
+                                    g_consumedHeadCount.load(std::memory_order_relaxed));
+                        }
                     }
                     proj.space = g_space;
                     proj.viewCount = 2;
@@ -1559,6 +1627,13 @@ bool get_head_pose(HeadPose& out) {
     std::lock_guard<std::mutex> lock(g_poseMutex);
     if (!g_poseValid) return false;
     out = g_headPose;
+    // Pose-tag audit stamp: the orientation the game thread actually consumed
+    // (compared against the submitted layer pose while the audit is armed).
+    g_consumedHeadQuat[0].store(out.qx, std::memory_order_relaxed);
+    g_consumedHeadQuat[1].store(out.qy, std::memory_order_relaxed);
+    g_consumedHeadQuat[2].store(out.qz, std::memory_order_relaxed);
+    g_consumedHeadQuat[3].store(out.qw, std::memory_order_relaxed);
+    g_consumedHeadCount.fetch_add(1, std::memory_order_relaxed);
     return true;
 }
 
@@ -1668,6 +1743,20 @@ void set_rendered_hfov(float hfovDeg) {
     g_renderedHfov.store(hfovDeg, std::memory_order_relaxed);
 }
 
+void fov_audit(float* tanH, float* tanV, int* src, unsigned* swapW, unsigned* swapH) {
+    if (tanH) *tanH = g_auditTanH.load(std::memory_order_relaxed);
+    if (tanV) *tanV = g_auditTanV.load(std::memory_order_relaxed);
+    if (src) *src = g_auditFovSrc.load(std::memory_order_relaxed);
+    if (swapW) *swapW = g_swapW;
+    if (swapH) *swapH = g_swapH;
+}
+
+void set_pose_audit(bool on) {
+    bool was = g_poseAudit.exchange(on, std::memory_order_relaxed);
+    if (was != on) BVR_LOG("xr: pose audit %s (tagged-vs-consumed yaw, stereo only)",
+                           on ? "ON" : "off");
+}
+
 int current_eye_sign() {
     return g_aerEyeSign.load(std::memory_order_relaxed);
 }
@@ -1745,6 +1834,14 @@ void handle_pace_command(const char*) {}
 void handle_mirror_command(const char*) {}
 float suggested_hfov_deg() { return 0.0f; }
 void set_rendered_hfov(float) {}
+void fov_audit(float* tanH, float* tanV, int* src, unsigned* swapW, unsigned* swapH) {
+    if (tanH) *tanH = 0.0f;
+    if (tanV) *tanV = 0.0f;
+    if (src) *src = -1;
+    if (swapW) *swapW = 0;
+    if (swapH) *swapH = 0;
+}
+void set_pose_audit(bool) {}
 int current_eye_sign() { return 0; }
 void sr_push_eye(int) {}
 void set_laser(const LaserConfig&) {}

--- a/src/core/vr/openxr_runtime.h
+++ b/src/core/vr/openxr_runtime.h
@@ -122,6 +122,21 @@ float suggested_hfov_deg();
 // binocular-scope distortion in the headset.
 void set_rendered_hfov(float hfovDeg);
 
+// --- Session 21: FOV audit ---------------------------------------------------
+// The tangents the projection layer was last TAGGED with, plus which source
+// produced the claimed hfov (0 = adapter readback, 1 = circumscribed fallback,
+// 2 = manual claim slider) and the swapchain dims. Zero/-1 until the first
+// projection-layer frame. Read by the `fovaudit` seam command; the flat gate
+// compares these against tangents recovered from dumpframe cb0 blocks.
+void fov_audit(float* tanH, float* tanV, int* src, unsigned* swapW, unsigned* swapH);
+
+// Pose-tag audit (default off, log-only): per stereo submission (rate-limited)
+// log the yaw the layer is TAGGED with against the yaw the game thread last
+// CONSUMED from the head-pose funnel. A steady nonzero delta means the image
+// is attributed to a pose generation the game never rendered from - the
+// next-cheapest suspect for a yaw-dependent lateral drift after the fov.
+void set_pose_audit(bool on);
+
 // --- M4 rung 1: AlternateEye stereo -----------------------------------------
 // Which eye the NEXT game frame should render for: -1 left, +1 right, 0 =
 // AlternateEye off (render centered, exactly the M3 behavior). The adapter's

--- a/src/game/bioshock1r/aim.cpp
+++ b/src/game/bioshock1r/aim.cpp
@@ -101,6 +101,15 @@ bool g_weaponKeySim = false;      // a sim key is armed (flat test seam)
 uint32_t g_weaponSwaps = 0;
 std::mutex g_weaponKeyUiMutex; // the overlay (render thread) reads the name
 char g_weaponKeyUi[48] = "-";
+// The preset-loaded R baseline. New profiles seed from THIS, not from
+// whatever R values happen to be live (headset run 1: the first resolve
+// beat the preset's value load by one second, so the first profile seeded
+// from pre-preset ZEROS and the preset-tail re-apply then wrote those
+// zeros over the user's tuned baseline). Until a baseline exists (or ini
+// profiles were loaded), the resolver stays idle - the flat flow and the
+// user's flow both press the preset before playing.
+WeaponProfile g_presetBaseline{};
+bool g_presetBaselineValid = false;
 // M7 laser: the visible form of this same ray, published to core every frame.
 // It lives here rather than with the hands so it cannot drift from the trim
 // above - a laser that disagrees with the bullet is worse than no laser.
@@ -812,15 +821,27 @@ void apply_weapon_key(const std::string& key, const char* why) {
     ++g_weaponSwaps;
     auto it = g_weaponProfiles.find(key);
     if (it == g_weaponProfiles.end()) {
-        stash_active_profile(); // impossible path guard; keeps map coherent
-        WeaponProfile p{g_pitchOffsetDeg[1].load(std::memory_order_relaxed),
-                        g_yawOffsetDeg[1].load(std::memory_order_relaxed),
-                        g_posFwdCm[1].load(std::memory_order_relaxed),
-                        g_posRightCm[1].load(std::memory_order_relaxed),
-                        g_posUpCm[1].load(std::memory_order_relaxed)};
+        // First sight: seed from the PRESET BASELINE (the user's generic
+        // tuning), not from the outgoing weapon's values - switching from a
+        // tuned shotgun to a never-seen pistol must not inherit
+        // shotgun-specific trims.
+        WeaponProfile p = g_presetBaselineValid
+                              ? g_presetBaseline
+                              : WeaponProfile{g_pitchOffsetDeg[1].load(std::memory_order_relaxed),
+                                              g_yawOffsetDeg[1].load(std::memory_order_relaxed),
+                                              g_posFwdCm[1].load(std::memory_order_relaxed),
+                                              g_posRightCm[1].load(std::memory_order_relaxed),
+                                              g_posUpCm[1].load(std::memory_order_relaxed)};
         g_weaponProfiles[key] = p;
-        BVR_LOG("[aim] weapon profile '%s' CREATED from current R values (%s)", key.c_str(),
-                why);
+        g_pitchOffsetDeg[1].store(p.trimPitch, std::memory_order_relaxed);
+        g_yawOffsetDeg[1].store(p.trimYaw, std::memory_order_relaxed);
+        g_posFwdCm[1].store(p.posFwd, std::memory_order_relaxed);
+        g_posRightCm[1].store(p.posRight, std::memory_order_relaxed);
+        g_posUpCm[1].store(p.posUp, std::memory_order_relaxed);
+        BVR_LOG("[aim] weapon profile '%s' CREATED from the %s (%s): trim %.2f/%.2f pos "
+                "%.1f/%.1f/%.1f",
+                key.c_str(), g_presetBaselineValid ? "preset baseline" : "current R values",
+                why, p.trimPitch, p.trimYaw, p.posFwd, p.posRight, p.posUp);
     } else {
         const WeaponProfile& p = it->second;
         g_pitchOffsetDeg[1].store(p.trimPitch, std::memory_order_relaxed);
@@ -839,19 +860,25 @@ void apply_weapon_key(const std::string& key, const char* why) {
 void update_weapon_profile(const FrameContext& ctx) {
     if (g_weaponKeySim) return; // a forced key holds until 'wkey real'
     if (!g_gameplayView) return; // no cutscene/menu heap scans
+    // Idle until a value source exists: either the preset baseline was
+    // captured (the user pressed VR PRESET 1) or ini profiles loaded. This
+    // closes the headset-run-1 race where the first resolve beat the
+    // preset's value load and seeded the first profile from zeros.
+    if (!g_presetBaselineValid && g_weaponProfiles.empty()) return;
     static uint32_t throttle = 0;
     static uint32_t nullResolves = 0;
-    // Failure backoff on top of the resolver's own 2 s scan cooldown: a
-    // world state with no acceptable weapon must not full-heap-scan every
-    // 2 s forever (the session-18 hands-scan ~1 fps lesson; live this boot:
-    // the intro has no weapon at all and scans repeated every ~3.5 s at the
-    // weaker mask). 3 consecutive nulls -> only every 2048th call reaches
-    // the resolver (~15 s at stereo CalcView rates).
+    // Failure backoff for the SCAN fallback only (the rig read is a pointer
+    // dereference and free): a world state with no acceptable weapon must
+    // not full-heap-scan on a cadence (the session-18 hands-scan ~1 fps
+    // lesson; the game intro has no weapon for minutes).
     uint32_t mask = nullResolves >= 3 ? 2047 : 15;
     if ((++throttle & mask) != 0) return;
-    // Resolving accessor: prefers the trigger-learned object, else the
-    // anchored heap scan - pre-fire weapons key too.
-    void* w = hands::resolve_weapon_actor(ctx);
+    // Primary: Hands.CurrentHoldable straight off the rig (weapon_actor()
+    // reads it first since session 21 part 2) - instant, scanless swap
+    // detection. The anchored heap scan remains the fallback for states
+    // where the rig pointer is not resolved yet.
+    void* w = hands::weapon_actor();
+    if (!w) w = hands::resolve_weapon_actor(ctx);
     nullResolves = w ? 0 : nullResolves + 1;
     if (w == g_weaponKeyActor) return;
     g_weaponKeyActor = w;
@@ -901,6 +928,22 @@ void init(const bvr::pattern_scan::ProcessImage& image, const patterns::Symbols&
     load_weapon_profiles();
     BVR_LOG("[aim] init: weapon fire-start=%p ability fire-start=%p", g_syms.weaponFireStart,
             g_syms.abilityFireStart);
+}
+
+void note_preset_baseline() {
+    // Called right after the preset's value load: the R atomics now hold
+    // the user's generic (non-per-weapon) tuning. New profiles seed from
+    // this; its existence also un-idles the profile resolver.
+    g_presetBaseline = {g_pitchOffsetDeg[1].load(std::memory_order_relaxed),
+                        g_yawOffsetDeg[1].load(std::memory_order_relaxed),
+                        g_posFwdCm[1].load(std::memory_order_relaxed),
+                        g_posRightCm[1].load(std::memory_order_relaxed),
+                        g_posUpCm[1].load(std::memory_order_relaxed)};
+    g_presetBaselineValid = true;
+    BVR_LOG("[aim] preset R baseline noted: trim %.2f/%.2f pos %.1f/%.1f/%.1f (seeds new "
+            "weapon profiles)",
+            g_presetBaseline.trimPitch, g_presetBaseline.trimYaw, g_presetBaseline.posFwd,
+            g_presetBaseline.posRight, g_presetBaseline.posUp);
 }
 
 void reapply_weapon_profile() {

--- a/src/game/bioshock1r/aim.cpp
+++ b/src/game/bioshock1r/aim.cpp
@@ -28,6 +28,9 @@
 #include <atomic>
 #include <cstdio>
 #include <cstring>
+#include <map>
+#include <mutex>
+#include <string>
 
 namespace bvr::b1r::aim {
 namespace {
@@ -76,6 +79,28 @@ std::atomic<float> g_yawOffsetDeg[2] = {0.0f, 0.0f};
 std::atomic<float> g_posFwdCm[2] = {0.0f, 0.0f};
 std::atomic<float> g_posRightCm[2] = {0.0f, 0.0f};
 std::atomic<float> g_posUpCm[2] = {0.0f, 0.0f};
+// ---- Session 21: per-weapon profiles ----------------------------------------
+// The RIGHT hand's trim + ray-origin offsets hot-swap per weapon, keyed by
+// the equipped weapon's canonical class name ('Shotgun', 'Pistol', ... via
+// patterns::object_class_name). The R atomics above stay THE live values
+// everything reads (ray, laser, model publish, sliders); on a weapon change
+// the outgoing values are stashed into the old key's profile and the new
+// key's (seeded from the current values when first seen) loads in. The
+// left/plasmid hand is untouched. weapons.ini persists the map (saved by
+// `vrpreset save` and `vraim wsave`). Real weapon switching cannot be
+// driven flat (exec NextWeapon FAULTS, session 20) - `vraim wkey sim
+// <name>` forces a key for the flat swap proof; the live-switch proof is
+// an in-headset checklist item. Game thread only (except the UI name copy).
+struct WeaponProfile {
+    float trimPitch, trimYaw, posFwd, posRight, posUp;
+};
+std::map<std::string, WeaponProfile> g_weaponProfiles;
+std::string g_weaponKey;          // active profile key ("" = none)
+void* g_weaponKeyActor = nullptr; // weapon pointer the key was resolved from
+bool g_weaponKeySim = false;      // a sim key is armed (flat test seam)
+uint32_t g_weaponSwaps = 0;
+std::mutex g_weaponKeyUiMutex; // the overlay (render thread) reads the name
+char g_weaponKeyUi[48] = "-";
 // M7 laser: the visible form of this same ray, published to core every frame.
 // It lives here rather than with the hands so it cannot drift from the trim
 // above - a laser that disagrees with the bullet is worse than no laser.
@@ -752,14 +777,171 @@ void log_status() {
             g_gameplayView ? 1 : 0);
 }
 
+// ---- per-weapon profile machinery (session 21) ------------------------------
+
+// Class names are plain ASCII; anything else maps to '_' so a hostile name
+// cannot break the ini line format.
+std::string narrow_key(const wchar_t* w) {
+    std::string s;
+    for (int i = 0; w && w[i] && i < 47; ++i)
+        s.push_back(w[i] >= 32 && w[i] < 127 && w[i] != '.' && w[i] != '=' ? static_cast<char>(w[i])
+                                                                           : '_');
+    return s;
+}
+
+// Capture the live R-hand values into the active profile (no-op keyless).
+void stash_active_profile() {
+    if (g_weaponKey.empty()) return;
+    WeaponProfile& p = g_weaponProfiles[g_weaponKey];
+    p.trimPitch = g_pitchOffsetDeg[1].load(std::memory_order_relaxed);
+    p.trimYaw = g_yawOffsetDeg[1].load(std::memory_order_relaxed);
+    p.posFwd = g_posFwdCm[1].load(std::memory_order_relaxed);
+    p.posRight = g_posRightCm[1].load(std::memory_order_relaxed);
+    p.posUp = g_posUpCm[1].load(std::memory_order_relaxed);
+}
+
+void apply_weapon_key(const std::string& key, const char* why) {
+    if (key == g_weaponKey) return;
+    stash_active_profile();
+    g_weaponKey = key;
+    {
+        std::lock_guard<std::mutex> lock(g_weaponKeyUiMutex);
+        strcpy_s(g_weaponKeyUi, key.empty() ? "-" : key.c_str());
+    }
+    if (key.empty()) return;
+    ++g_weaponSwaps;
+    auto it = g_weaponProfiles.find(key);
+    if (it == g_weaponProfiles.end()) {
+        stash_active_profile(); // impossible path guard; keeps map coherent
+        WeaponProfile p{g_pitchOffsetDeg[1].load(std::memory_order_relaxed),
+                        g_yawOffsetDeg[1].load(std::memory_order_relaxed),
+                        g_posFwdCm[1].load(std::memory_order_relaxed),
+                        g_posRightCm[1].load(std::memory_order_relaxed),
+                        g_posUpCm[1].load(std::memory_order_relaxed)};
+        g_weaponProfiles[key] = p;
+        BVR_LOG("[aim] weapon profile '%s' CREATED from current R values (%s)", key.c_str(),
+                why);
+    } else {
+        const WeaponProfile& p = it->second;
+        g_pitchOffsetDeg[1].store(p.trimPitch, std::memory_order_relaxed);
+        g_yawOffsetDeg[1].store(p.trimYaw, std::memory_order_relaxed);
+        g_posFwdCm[1].store(p.posFwd, std::memory_order_relaxed);
+        g_posRightCm[1].store(p.posRight, std::memory_order_relaxed);
+        g_posUpCm[1].store(p.posUp, std::memory_order_relaxed);
+        BVR_LOG("[aim] weapon profile '%s' applied: trim %.2f/%.2f pos %.1f/%.1f/%.1f (%s)",
+                key.c_str(), p.trimPitch, p.trimYaw, p.posFwd, p.posRight, p.posUp, why);
+    }
+}
+
+// Per-frame (throttled) weapon-change watch. The weapon actor accessor is
+// cached + vtable-revalidated in hands.cpp; the class name resolves only on
+// a pointer change, so steady-state cost is one pointer compare.
+void update_weapon_profile(const FrameContext& ctx) {
+    if (g_weaponKeySim) return; // a forced key holds until 'wkey real'
+    if (!g_gameplayView) return; // no cutscene/menu heap scans
+    static uint32_t throttle = 0;
+    static uint32_t nullResolves = 0;
+    // Failure backoff on top of the resolver's own 2 s scan cooldown: a
+    // world state with no acceptable weapon must not full-heap-scan every
+    // 2 s forever (the session-18 hands-scan ~1 fps lesson; live this boot:
+    // the intro has no weapon at all and scans repeated every ~3.5 s at the
+    // weaker mask). 3 consecutive nulls -> only every 2048th call reaches
+    // the resolver (~15 s at stereo CalcView rates).
+    uint32_t mask = nullResolves >= 3 ? 2047 : 15;
+    if ((++throttle & mask) != 0) return;
+    // Resolving accessor: prefers the trigger-learned object, else the
+    // anchored heap scan - pre-fire weapons key too.
+    void* w = hands::resolve_weapon_actor(ctx);
+    nullResolves = w ? 0 : nullResolves + 1;
+    if (w == g_weaponKeyActor) return;
+    g_weaponKeyActor = w;
+    const wchar_t* name = w ? patterns::object_class_name(w) : nullptr;
+    apply_weapon_key(name ? narrow_key(name) : std::string(), "weapon change");
+}
+
+void weapons_ini_path(wchar_t* out, size_t count) {
+    swprintf_s(out, count, L"%s\\weapons.ini", bvr::log::data_dir());
+}
+
+void load_weapon_profiles() {
+    wchar_t path[MAX_PATH];
+    weapons_ini_path(path, MAX_PATH);
+    FILE* f = nullptr;
+    if (_wfopen_s(&f, path, L"r") != 0 || !f) return; // no file yet is normal
+    char line[256];
+    int n = 0;
+    while (fgets(line, sizeof line, f)) {
+        char key[48] = {};
+        char field[32] = {};
+        float v = 0.0f;
+        if (sscanf_s(line, "%47[^.].%31[^=]=%f", key, static_cast<unsigned>(sizeof key), field,
+                     static_cast<unsigned>(sizeof field), &v) != 3)
+            continue;
+        WeaponProfile& p = g_weaponProfiles[key];
+        if (strcmp(field, "trimPitch") == 0) p.trimPitch = v;
+        else if (strcmp(field, "trimYaw") == 0) p.trimYaw = v;
+        else if (strcmp(field, "posFwd") == 0) p.posFwd = v;
+        else if (strcmp(field, "posRight") == 0) p.posRight = v;
+        else if (strcmp(field, "posUp") == 0) p.posUp = v;
+        else continue;
+        ++n;
+    }
+    fclose(f);
+    if (n)
+        BVR_LOG("[aim] %d weapon-profile value(s) loaded from weapons.ini (%u weapon(s))", n,
+                static_cast<unsigned>(g_weaponProfiles.size()));
+}
+
 } // namespace
 
 void init(const bvr::pattern_scan::ProcessImage& image, const patterns::Symbols& symbols) {
     g_imageBase = image.base;
     g_image = image;
     g_syms = symbols;
+    load_weapon_profiles();
     BVR_LOG("[aim] init: weapon fire-start=%p ability fire-start=%p", g_syms.weaponFireStart,
             g_syms.abilityFireStart);
+}
+
+void reapply_weapon_profile() {
+    // The VR preset's value load writes the vrpreset.ini R trims over
+    // whatever profile was live (flat-caught: profile applied, preset chain
+    // finished seconds later, R reverted). Re-apply WITHOUT stashing - the
+    // preset values are a baseline, not a profile edit.
+    if (g_weaponKey.empty()) return;
+    auto it = g_weaponProfiles.find(g_weaponKey);
+    if (it == g_weaponProfiles.end()) return;
+    const WeaponProfile& p = it->second;
+    g_pitchOffsetDeg[1].store(p.trimPitch, std::memory_order_relaxed);
+    g_yawOffsetDeg[1].store(p.trimYaw, std::memory_order_relaxed);
+    g_posFwdCm[1].store(p.posFwd, std::memory_order_relaxed);
+    g_posRightCm[1].store(p.posRight, std::memory_order_relaxed);
+    g_posUpCm[1].store(p.posUp, std::memory_order_relaxed);
+    BVR_LOG("[aim] weapon profile '%s' re-applied after preset load", g_weaponKey.c_str());
+}
+
+void save_weapon_profiles() {
+    stash_active_profile(); // the live R values are the active profile's truth
+    if (g_weaponProfiles.empty()) return;
+    wchar_t path[MAX_PATH];
+    weapons_ini_path(path, MAX_PATH);
+    FILE* f = nullptr;
+    if (_wfopen_s(&f, path, L"w") != 0 || !f) {
+        BVR_LOG("[aim] could not write weapons.ini");
+        return;
+    }
+    fprintf(f, "# BioShock VR - per-weapon R-hand aim profiles (session 21).\n");
+    fprintf(f, "# <WeaponClassName>.<field>=<value>; trims in degrees, pos offsets in cm.\n");
+    for (const auto& [key, p] : g_weaponProfiles) {
+        fprintf(f, "%s.trimPitch=%.2f\n", key.c_str(), p.trimPitch);
+        fprintf(f, "%s.trimYaw=%.2f\n", key.c_str(), p.trimYaw);
+        fprintf(f, "%s.posFwd=%.2f\n", key.c_str(), p.posFwd);
+        fprintf(f, "%s.posRight=%.2f\n", key.c_str(), p.posRight);
+        fprintf(f, "%s.posUp=%.2f\n", key.c_str(), p.posUp);
+    }
+    fclose(f);
+    BVR_LOG("[aim] %u weapon profile(s) saved to weapons.ini",
+            static_cast<unsigned>(g_weaponProfiles.size()));
 }
 
 // The origin offset rides the FINAL (trimmed) ray frame - both lanes, the
@@ -819,6 +1001,7 @@ void on_calcview(const FrameContext& ctx) {
         g_lastPc = ctx.pc;
         g_objRight = nullptr;
         g_objLeft = nullptr;
+        g_weaponKeyActor = nullptr; // weapon actor died with the world - re-resolve
     }
 
     // Cutscene guard (the open M3 item): the view actor during normal play is
@@ -833,6 +1016,10 @@ void on_calcview(const FrameContext& ctx) {
         if (!g_gameplayView && ctx.viewActor == ctx.pc)
             g_gameplayView = true; // menu attract scene views through the PC itself
     }
+
+    // Per-weapon profile hot-swap (session 21): the active R-hand trim/offsets
+    // follow the equipped weapon's class (gameplay view only - see the guard).
+    update_weapon_profile(ctx);
 
     for (int i = 0; i < 2; ++i) {
         Ray& out = g_ray[i];
@@ -1191,11 +1378,41 @@ void handle_command(const char* args) {
                 haveRef ? d0[0] : 0.0f, haveRef ? d0[1] : 0.0f, haveRef ? d0[2] : 0.0f);
     } else if (strcmp(verb, "synccheck") == 0) {
         run_synccheck();
+    } else if (strcmp(verb, "weapon") == 0) {
+        // Per-weapon profile status (session 21).
+        void* w = hands::weapon_actor();
+        const wchar_t* cls = w ? patterns::object_class_name(w) : nullptr;
+        BVR_LOG("[aim] weapon profile: active='%s'%s actor=%p class='%S' | %u profile(s), "
+                "%u swap(s) | R trim %.2f/%.2f pos %.1f/%.1f/%.1f",
+                g_weaponKey.empty() ? "-" : g_weaponKey.c_str(), g_weaponKeySim ? " (SIM)" : "",
+                w, cls ? cls : L"-", static_cast<unsigned>(g_weaponProfiles.size()),
+                g_weaponSwaps, g_pitchOffsetDeg[1].load(std::memory_order_relaxed),
+                g_yawOffsetDeg[1].load(std::memory_order_relaxed),
+                g_posFwdCm[1].load(std::memory_order_relaxed),
+                g_posRightCm[1].load(std::memory_order_relaxed),
+                g_posUpCm[1].load(std::memory_order_relaxed));
+    } else if (strcmp(verb, "wsave") == 0) {
+        save_weapon_profiles();
+    } else if (strcmp(verb, "wkey") == 0) {
+        // Flat test seam: force a profile key (real switching cannot be driven
+        // flat - exec NextWeapon FAULTS). 'wkey real' resumes actor tracking.
+        char name[48] = {};
+        if (strncmp(rest, "real", 4) == 0) {
+            g_weaponKeySim = false;
+            g_weaponKeyActor = nullptr; // force re-resolve from the live actor
+            BVR_LOG("[aim] wkey: back to live weapon tracking");
+        } else if (sscanf_s(rest, "sim %47s", name, static_cast<unsigned>(sizeof name)) == 1) {
+            g_weaponKeySim = true;
+            apply_weapon_key(name, "wkey sim");
+        } else {
+            BVR_LOG("[aim] usage: vraim wkey sim <ClassName> | vraim wkey real");
+        }
     } else if (strcmp(verb, "status") == 0) {
         log_status();
     } else {
         BVR_LOG("[aim] unknown command '%s' "
-                "(on|off|probe|dump|origin|seam|test|synccheck|scan|scanimpl|scanoff|status)",
+                "(on|off|probe|dump|origin|seam|test|synccheck|weapon|wsave|wkey|scan|"
+                "scanimpl|scanoff|status)",
                 verb);
     }
 }
@@ -1292,6 +1509,16 @@ void draw_debug_ui() {
     if (ImGui::Checkbox("Ray starts at the hand (off = engine origin, direction only)",
                         &handOrigin))
         g_handOrigin.store(handOrigin, std::memory_order_relaxed);
+
+    // Per-weapon profiles (session 21): the R sliders above edit the ACTIVE
+    // weapon's profile - swap happens automatically on weapon change; "Save
+    // preset values" persists weapons.ini too. Calibration flow: fire at a
+    // wall, nudge the R trim/offset sliders until the beam sits on the
+    // bullet hole, next weapon.
+    {
+        std::lock_guard<std::mutex> lock(g_weaponKeyUiMutex);
+        ImGui::Text("weapon profile: %s", g_weaponKeyUi);
+    }
 
     // The laser is this same ray made visible, so it lives in this section and
     // shares the trim sliders above - use it to judge the trim by eye.

--- a/src/game/bioshock1r/aim.cpp
+++ b/src/game/bioshock1r/aim.cpp
@@ -66,8 +66,11 @@ std::atomic<bool> g_useAimPose{true};
 std::atomic<bool> g_muzzleRay{false};
 // Per-hand since session 16 part 3 (user request): each controller's wrist
 // posture wants its own trim. 0 = left (plasmid), 1 = right (weapon).
-std::atomic<float> g_pitchOffsetDeg[2] = {0.0f, 0.0f};
-std::atomic<float> g_yawOffsetDeg[2] = {0.0f, 0.0f};
+// LEFT defaults = the user's in-headset calibration (session 21 part 3,
+// their explicit ask: bake the fixed left hand into the defaults). The
+// right hand stays 0 - the per-weapon profiles own it now.
+std::atomic<float> g_pitchOffsetDeg[2] = {4.4f, 0.0f};
+std::atomic<float> g_yawOffsetDeg[2] = {30.0f, 0.0f};
 // Per-hand aim-ray ORIGIN offsets in cm (session 18 part 2, user request):
 // the model offsets move the MESH about its pivot, so a tuned model can sit
 // right while the ray no longer runs along the barrel. These move the RAY
@@ -77,8 +80,8 @@ std::atomic<float> g_yawOffsetDeg[2] = {0.0f, 0.0f};
 // disagree; the model deliberately does not take them (it has its own
 // sliders, and the two are tuned against each other).
 std::atomic<float> g_posFwdCm[2] = {0.0f, 0.0f};
-std::atomic<float> g_posRightCm[2] = {0.0f, 0.0f};
-std::atomic<float> g_posUpCm[2] = {0.0f, 0.0f};
+std::atomic<float> g_posRightCm[2] = {4.6f, 0.0f}; // L = user calibration (s21p3)
+std::atomic<float> g_posUpCm[2] = {0.7f, 0.0f};    // L = user calibration (s21p3)
 // ---- Session 21: per-weapon profiles ----------------------------------------
 // The RIGHT hand's trim + ray-origin offsets hot-swap per weapon, keyed by
 // the equipped weapon's canonical class name ('Shotgun', 'Pistol', ... via
@@ -873,16 +876,27 @@ void update_weapon_profile(const FrameContext& ctx) {
     // lesson; the game intro has no weapon for minutes).
     uint32_t mask = nullResolves >= 3 ? 2047 : 15;
     if ((++throttle & mask) != 0) return;
-    // Primary: Hands.CurrentHoldable straight off the rig (weapon_actor()
-    // reads it first since session 21 part 2) - instant, scanless swap
-    // detection. The anchored heap scan remains the fallback for states
-    // where the rig pointer is not resolved yet.
-    void* w = hands::weapon_actor();
-    if (!w) w = hands::resolve_weapon_actor(ctx);
-    nullResolves = w ? 0 : nullResolves + 1;
+    // Primary: Hands.CurrentHoldable raw off the rig, CLASS-AGNOSTIC
+    // (session 21 part 3: MachineGun/GrenadeLauncher carry a different
+    // native vtable, so the vtable-gated path rejected them and the stale
+    // cache pinned the OLD key - their edits landed in the previous
+    // weapon's profile). When the rig read works, its pointer is the
+    // identity, period: no fallback may resurrect a stale weapon. The
+    // legacy paths only serve states where the rig is not resolved yet.
+    void* w = nullptr;
+    bool haveRig = hands::current_holdable(&w);
+    if (!haveRig) {
+        w = hands::weapon_actor();
+        if (!w) w = hands::resolve_weapon_actor(ctx);
+    }
+    nullResolves = (haveRig || w) ? 0 : nullResolves + 1;
     if (w == g_weaponKeyActor) return;
     g_weaponKeyActor = w;
     const wchar_t* name = w ? patterns::object_class_name(w) : nullptr;
+    if (w && !name)
+        BVR_LOG("[aim] holdable %p has NO resolvable class name - profile key cleared, "
+                "slider edits will touch no profile until it resolves",
+                w);
     apply_weapon_key(name ? narrow_key(name) : std::string(), "weapon change");
 }
 

--- a/src/game/bioshock1r/aim.cpp
+++ b/src/game/bioshock1r/aim.cpp
@@ -66,10 +66,11 @@ std::atomic<bool> g_useAimPose{true};
 std::atomic<bool> g_muzzleRay{false};
 // Per-hand since session 16 part 3 (user request): each controller's wrist
 // posture wants its own trim. 0 = left (plasmid), 1 = right (weapon).
-// LEFT defaults = the user's in-headset calibration (session 21 part 3,
-// their explicit ask: bake the fixed left hand into the defaults). The
-// right hand stays 0 - the per-weapon profiles own it now.
-std::atomic<float> g_pitchOffsetDeg[2] = {4.4f, 0.0f};
+// Defaults = the user's in-headset calibration, v0.3.0 bake (session 21
+// part 4, their explicit ask: the saved preset becomes the defaults). The
+// right-hand TRIM stays 0 - the per-weapon profiles own the right hand;
+// its POS offsets below carry the generic baseline.
+std::atomic<float> g_pitchOffsetDeg[2] = {-6.8f, 0.0f};
 std::atomic<float> g_yawOffsetDeg[2] = {30.0f, 0.0f};
 // Per-hand aim-ray ORIGIN offsets in cm (session 18 part 2, user request):
 // the model offsets move the MESH about its pivot, so a tuned model can sit
@@ -79,9 +80,9 @@ std::atomic<float> g_yawOffsetDeg[2] = {30.0f, 0.0f};
 // ray's zero-roll basis at ray build, so the laser and the bullet cannot
 // disagree; the model deliberately does not take them (it has its own
 // sliders, and the two are tuned against each other).
-std::atomic<float> g_posFwdCm[2] = {0.0f, 0.0f};
-std::atomic<float> g_posRightCm[2] = {4.6f, 0.0f}; // L = user calibration (s21p3)
-std::atomic<float> g_posUpCm[2] = {0.7f, 0.0f};    // L = user calibration (s21p3)
+std::atomic<float> g_posFwdCm[2] = {-2.8f, 0.0f};  // v0.3.0 user-calibration bake
+std::atomic<float> g_posRightCm[2] = {0.6f, -2.8f};
+std::atomic<float> g_posUpCm[2] = {0.5f, 7.5f};
 // ---- Session 21: per-weapon profiles ----------------------------------------
 // The RIGHT hand's trim + ray-origin offsets hot-swap per weapon, keyed by
 // the equipped weapon's canonical class name ('Shotgun', 'Pistol', ... via
@@ -900,6 +901,21 @@ void update_weapon_profile(const FrameContext& ctx) {
     apply_weapon_key(name ? narrow_key(name) : std::string(), "weapon change");
 }
 
+// v0.3.0 default profiles = the user's calibrated set (session 21 part 4,
+// their ask: the saved preset becomes the defaults - dot==shot per weapon
+// out of the box). Seeded BEFORE weapons.ini loads, so a user's own file
+// always overrides, key by key.
+void seed_default_profiles() {
+    g_weaponProfiles["ChemicalThrower"] = {0.00f, -8.17f, 0.93f, -0.43f, -9.78f};
+    g_weaponProfiles["Crossbow"] = {0.23f, -6.65f, 0.00f, -4.40f, 11.00f};
+    g_weaponProfiles["GrenadeLauncher"] = {0.00f, 0.00f, 0.00f, -2.80f, 7.50f};
+    g_weaponProfiles["MachineGun"] = {2.80f, -1.17f, 0.00f, -3.50f, 13.10f};
+    g_weaponProfiles["Pistol"] = {-1.17f, -4.20f, -0.70f, -2.06f, 18.71f};
+    g_weaponProfiles["ResearchCamera"] = {0.00f, 0.00f, 0.00f, -2.80f, 7.50f};
+    g_weaponProfiles["Shotgun"] = {0.00f, 0.00f, 0.00f, -2.76f, 7.50f};
+    g_weaponProfiles["Wrench"] = {0.00f, 0.00f, 0.00f, -2.80f, 7.50f};
+}
+
 void weapons_ini_path(wchar_t* out, size_t count) {
     swprintf_s(out, count, L"%s\\weapons.ini", bvr::log::data_dir());
 }
@@ -939,7 +955,8 @@ void init(const bvr::pattern_scan::ProcessImage& image, const patterns::Symbols&
     g_imageBase = image.base;
     g_image = image;
     g_syms = symbols;
-    load_weapon_profiles();
+    seed_default_profiles();
+    load_weapon_profiles(); // a user's weapons.ini overrides the seeds key by key
     BVR_LOG("[aim] init: weapon fire-start=%p ability fire-start=%p", g_syms.weaponFireStart,
             g_syms.abilityFireStart);
 }
@@ -1530,17 +1547,19 @@ void draw_debug_ui() {
     if (ImGui::Checkbox("Use the runtime AIM pose (off = grip pose)", &useAim))
         g_useAimPose.store(useAim, std::memory_order_relaxed);
     // Per-hand trims (session 16 part 3): R = weapon, L = plasmid.
+    // Range +-90 since v0.3.0: the user's left-wrist posture pinned the old
+    // +-30 cap (their saved L yaw sat at exactly 30.0 = the slider max).
     float rp = g_pitchOffsetDeg[1].load(std::memory_order_relaxed);
-    if (ImGui::SliderFloat("R aim pitch trim (deg)", &rp, -30.0f, 30.0f))
+    if (ImGui::SliderFloat("R aim pitch trim (deg)", &rp, -90.0f, 90.0f))
         g_pitchOffsetDeg[1].store(rp, std::memory_order_relaxed);
     float ry = g_yawOffsetDeg[1].load(std::memory_order_relaxed);
-    if (ImGui::SliderFloat("R aim yaw trim (deg)", &ry, -30.0f, 30.0f))
+    if (ImGui::SliderFloat("R aim yaw trim (deg)", &ry, -90.0f, 90.0f))
         g_yawOffsetDeg[1].store(ry, std::memory_order_relaxed);
     float lp = g_pitchOffsetDeg[0].load(std::memory_order_relaxed);
-    if (ImGui::SliderFloat("L aim pitch trim (deg)", &lp, -30.0f, 30.0f))
+    if (ImGui::SliderFloat("L aim pitch trim (deg)", &lp, -90.0f, 90.0f))
         g_pitchOffsetDeg[0].store(lp, std::memory_order_relaxed);
     float ly = g_yawOffsetDeg[0].load(std::memory_order_relaxed);
-    if (ImGui::SliderFloat("L aim yaw trim (deg)", &ly, -30.0f, 30.0f))
+    if (ImGui::SliderFloat("L aim yaw trim (deg)", &ly, -90.0f, 90.0f))
         g_yawOffsetDeg[0].store(ly, std::memory_order_relaxed);
 
     // Ray ORIGIN offsets (session 18 part 2): move the laser + fire origin to

--- a/src/game/bioshock1r/aim.h
+++ b/src/game/bioshock1r/aim.h
@@ -106,4 +106,11 @@ void save_weapon_profiles();
 // at apply_vr_preset's tail. Game thread.
 void reapply_weapon_profile();
 
+// Capture the just-loaded preset R values as the seed for new weapon
+// profiles, and un-idle the profile resolver (it waits for a value source
+// so a pre-preset resolve can never seed a profile from zeros - the
+// headset-run-1 race). Called right after load_vr_preset_values(). Game
+// thread.
+void note_preset_baseline();
+
 } // namespace bvr::b1r::aim

--- a/src/game/bioshock1r/aim.h
+++ b/src/game/bioshock1r/aim.h
@@ -94,4 +94,16 @@ void set_pos_offset(int hand, float fwdCm, float rightCm, float upCm);
 // True while substitution is armed (master switch + a usable hand ray).
 bool active();
 
+// Session 21 per-weapon profiles: persist the R-hand trim/offset map
+// (weapons.ini, keyed by weapon class name). Called by `vrpreset save`'s
+// chain (one in-headset save button covers everything) and `vraim wsave`.
+// Game thread.
+void save_weapon_profiles();
+
+// Re-apply the ACTIVE weapon profile over the R atomics without stashing -
+// the VR preset's value load runs at arbitrary time vs the first profile
+// resolve and must not leave preset baselines over a live profile. Called
+// at apply_vr_preset's tail. Game thread.
+void reapply_weapon_profile();
+
 } // namespace bvr::b1r::aim

--- a/src/game/bioshock1r/body.cpp
+++ b/src/game/bioshock1r/body.cpp
@@ -40,8 +40,12 @@ std::atomic<float> g_ratePerSec{0.0f};
 // which is what removes the last of the "the gun moves with the camera a bit"
 // percept - and only a deliberate turn past the band carries the body along.
 // Beyond it the body trails the head by exactly the band width, so head and
-// body never diverge by more than 23 deg no matter how far you turn.
-std::atomic<float> g_deadzoneDeg{23.0f};
+// body never diverge by more than the band no matter how far you turn.
+// DEFAULT 0 since v0.3.0 (session 21 part 4, the user's call): with the
+// render lock retired nothing moves with the camera anymore, so the band
+// that hid the lock's swing is not needed - instant 1:1 body follow.
+// (The 23-deg calibration was the session-17 answer to a lock-era percept.)
+std::atomic<float> g_deadzoneDeg{0.0f};
 std::atomic<float> g_maxDegPerSec{180.0f};  // safety slew cap, not feel
 std::atomic<int>   g_field{0};              // 0 pc, 1 pawn, 2 both
 std::atomic<bool>  g_probeLog{false};

--- a/src/game/bioshock1r/bones.cpp
+++ b/src/game/bioshock1r/bones.cpp
@@ -130,7 +130,13 @@ char g_status[160] = "idle";
 // Render-lock (session 13): solve the anchor against the renderer's OWN
 // foreground transform (captured per frame from the vm draws' cb0) so the
 // rig lands on the world-correct pixel. See patterns.h "Foreground scene".
-std::atomic<int> g_renderLock{1};         // 0 off, 1 abs (true position), 2 diff
+// DEFAULT OFF since session 21 part 2 - the user's in-headset verdict:
+// "lock off is exactly what I was looking for, the aim is in tune with the
+// model" - the lock's own correction WAS the +-90-flipping laser-vs-gun
+// drift reported in session 20 (its model was calibrated against the old
+// fg composition and miscorrects laterally at large hand yaws).
+// `vrbones lock abs` remains the live A/B back to the old behavior.
+std::atomic<int> g_renderLock{0};         // 0 off, 1 abs (true position), 2 diff
                                           // (head-split cancel only)
 // Correction gains. Session 13 measured "gain 0.5 lands, 1.0 doubles" and
 // blamed a rigid-path rebake; session 14 decomposed that 1.79x overshoot as

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -201,7 +201,9 @@ void apply_eye_offset(FVector* loc, const FRotator& rot, int sign) {
 // Camera commands: "fov <deg>", "fov off", "gfov <deg>", "gfov off",
 // "offset <x> <y> <z>", "camrot <pitch> <yaw> <roll>" (render-camera-only
 // rotation offset in degrees - the flat stand-in for HMD head-look),
-// "recenter".
+// "recenter", "fovaudit [pose on|off]" (session 21: option vs submitted vs
+// option-derived fov side by side; `pose on` arms the tagged-vs-consumed
+// yaw log for the headset).
 // Discovery commands (route to core/debug/value_scan; game thread only):
 //   memscan <f>  memrescan <f>  memlist [n]  memread <idx>
 //   memscani <u>  memrescani <u>   (integer-typed variants)
@@ -334,9 +336,45 @@ void apply_command(const char* cmd, const char* args) {
         BVR_LOG("[b1r] fg lens match %s (last written %.1f)", on ? "ON" : "off",
                 g_fgFovWritten.load(std::memory_order_relaxed));
     } else if (strcmp(cmd, "fginfo") == 0) {
-        BVR_LOG("[b1r] fginfo: pc=%p viewActor=%p (fsweep them for the fg fov property)",
+        BVR_LOG("[b1r] fginfo: pc=%p viewActor=%p hands=%p weapon=%p (fsweep/hexdump "
+                "targets)",
                 g_playerController.load(std::memory_order_relaxed),
-                g_lastViewActor.load(std::memory_order_relaxed));
+                g_lastViewActor.load(std::memory_order_relaxed), hands::hands_actor(),
+                hands::weapon_actor());
+    } else if (strcmp(cmd, "fovaudit") == 0) {
+        // Session 21 FOV audit: the three fov truths side by side - the
+        // engine option we write, what the runtime last TAGGED the projection
+        // layer with, and the option-derived expectation at the swap aspect.
+        // The RENDERED side comes from `dumpframe full 2` decoded by
+        // tools/decode-framedump.ps1; the flat gate is rendered == submitted.
+        // "fovaudit pose on|off" arms the tagged-vs-consumed yaw log (headset).
+        if (strncmp(args, "pose", 4) == 0) {
+            bvr::vr::set_pose_audit(strstr(args + 4, "on") != nullptr);
+        } else {
+            int32_t* opt = patterns::hfov_option_ptr();
+            float tanH = 0.0f, tanV = 0.0f;
+            int src = -1;
+            unsigned sw = 0, sh = 0;
+            bvr::vr::fov_audit(&tanH, &tanV, &src, &sw, &sh);
+            // Option-derived expectation. Flat there is no session (swap dims
+            // 0x0) - assume the 16:9 render aspect the dumps confirm per draw.
+            float optTanH = 0.0f, optTanV = 0.0f;
+            if (opt) {
+                optTanH = tanf(static_cast<float>(*opt) * 0.5f / kRadToDeg);
+                optTanV = optTanH * ((sw && sh) ? (static_cast<float>(sh) / static_cast<float>(sw))
+                                                : (9.0f / 16.0f));
+            }
+            BVR_LOG("[b1r] fovaudit: option=%d gfovWrite=%s(%.1f) | submitted tanH=%.6f "
+                    "tanV=%.6f src=%s swap=%ux%u | option-derived tanH=%.6f tanV=%.6f",
+                    opt ? *opt : -1,
+                    g_gameFovWrite.load(std::memory_order_relaxed) ? "on" : "off",
+                    g_gameFovDeg.load(std::memory_order_relaxed), tanH, tanV,
+                    src == 0   ? "readback"
+                    : src == 1 ? "fallback"
+                    : src == 2 ? "manual"
+                               : "none",
+                    sw, sh, optTanH, optTanV);
+        }
     } else if (strcmp(cmd, "fsweep") == 0) {
         float lo = 0.0f, hi = 0.0f;
         if (sscanf_s(args, "%x %u %f %f", &addr, &len, &lo, &hi) == 4)

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -180,6 +180,13 @@ bool g_srBaseValid = false;
 FVector g_srBaseLoc{};
 FRotator g_srBaseRot{};
 
+// Session 21 fg view-sync stash: the final per-eye camera (post eye offset)
+// of the current pair. Game thread only (1t); freshness-gated by stamp so a
+// mode flip cannot leave scenedraw substituting stale poses.
+FVector g_eyeCamLoc[2] = {};
+FRotator g_eyeCamRot[2] = {};
+uint64_t g_eyeCamStampMs[2] = {};
+
 float* fov_ptr(void* pc) {
     return reinterpret_cast<float*>(static_cast<uint8_t*>(pc) + patterns::kFovLiveOffset);
 }
@@ -445,6 +452,8 @@ void apply_command(const char* cmd, const char* args) {
         body::handle_command(args); // M7.5 yaw transfer; logs its own echoes
     } else if (strcmp(cmd, "vrrec") == 0) {
         recorder::handle_command(args); // session 20 record+replay; logs its own echoes
+    } else if (strcmp(cmd, "vrfgnode") == 0) {
+        scenedraw::handle_fgnode_command(args); // session 21 fg-scene-node instrument
     } else if (strcmp(cmd, "exec") == 0) {
         console_exec::run_viewport(args); // engine console command, viewport chain
     } else if (strcmp(cmd, "execc") == 0) {
@@ -687,6 +696,9 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
             *loc = g_srBaseLoc;
             *rot = g_srBaseRot;
             apply_eye_offset(loc, *rot, +1);
+            g_eyeCamLoc[1] = *loc; // fg view-sync stash, RIGHT eye
+            g_eyeCamRot[1] = *rot;
+            g_eyeCamStampMs[1] = GetTickCount64();
         } else if (rot) {
             rot->yaw += static_cast<int32_t>(reentryYawDeg * kRotUnitsPerDegree);
         }
@@ -1072,6 +1084,9 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
         g_srBaseRot = *rot;
         g_srBaseValid = true;
         apply_eye_offset(loc, *rot, -1);
+        g_eyeCamLoc[0] = *loc; // fg view-sync stash, LEFT eye
+        g_eyeCamRot[0] = *rot;
+        g_eyeCamStampMs[0] = GetTickCount64();
     } else {
         g_srBaseValid = false;
     }
@@ -1188,6 +1203,18 @@ void get_recenter_state(bvr::vr::HeadPose* pose, int32_t* yawUnits, float* world
     if (pose) *pose = g_recenterPose;
     if (yawUnits) *yawUnits = g_recenterYawUnits;
     if (worldScale) *worldScale = g_worldScale.load(std::memory_order_relaxed);
+}
+
+bool driven_eye_cam(int eye, float loc[3], int32_t rot[3]) {
+    if (eye < 0 || eye > 1) return false;
+    if (GetTickCount64() - g_eyeCamStampMs[eye] > 200) return false; // stale/idle
+    loc[0] = g_eyeCamLoc[eye].x;
+    loc[1] = g_eyeCamLoc[eye].y;
+    loc[2] = g_eyeCamLoc[eye].z;
+    rot[0] = g_eyeCamRot[eye].pitch;
+    rot[1] = g_eyeCamRot[eye].yaw;
+    rot[2] = g_eyeCamRot[eye].roll;
+    return true;
 }
 
 void set_recenter_state(const bvr::vr::HeadPose& pose, int32_t yawUnits, float worldScale) {

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -630,6 +630,7 @@ void apply_vr_preset() {
     hands::handle_command("pose aim"); // align to the AIM ray
     body::handle_command("on");        // M7.5: stick-forward = look direction
     load_vr_preset_values();           // tuned sliders (ini) over defaults
+    aim::note_preset_baseline();       // seed source for new weapon profiles
     aim::reapply_weapon_profile();     // the active weapon profile beats the baseline
     scenedraw::handle_command("vrstereo on"); // last: 1t + stereo, sticky
     BVR_LOG("[b1r] VR PRESET 1 armed (unwind: vrstereo off + overlay checkboxes)");

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -555,8 +555,10 @@ void save_vr_preset() {
     fclose(f);
     BVR_LOG("[b1r] VR preset values saved to vrpreset.ini");
     // The per-hand model offsets live in hands.ini; saving them here too makes
-    // the one in-headset save button cover every tuned slider.
+    // the one in-headset save button cover every tuned slider. Same for the
+    // session-21 per-weapon profiles (weapons.ini).
     hands::save_offsets();
+    aim::save_weapon_profiles();
 }
 
 void load_vr_preset_values() {
@@ -628,6 +630,7 @@ void apply_vr_preset() {
     hands::handle_command("pose aim"); // align to the AIM ray
     body::handle_command("on");        // M7.5: stick-forward = look direction
     load_vr_preset_values();           // tuned sliders (ini) over defaults
+    aim::reapply_weapon_profile();     // the active weapon profile beats the baseline
     scenedraw::handle_command("vrstereo on"); // last: 1t + stereo, sticky
     BVR_LOG("[b1r] VR PRESET 1 armed (unwind: vrstereo off + overlay checkboxes)");
 }

--- a/src/game/bioshock1r/camera.h
+++ b/src/game/bioshock1r/camera.h
@@ -27,6 +27,16 @@ void set_fov_override(float hfovDeg); // <= 0 disables; game value restored
 void get_recenter_state(bvr::vr::HeadPose* pose, int32_t* yawUnits, float* worldScale);
 void set_recenter_state(const bvr::vr::HeadPose& pose, int32_t yawUnits, float worldScale);
 
+// Session 21 fg view-sync: the FINAL per-eye camera of the most recent
+// SequentialReentry pair (0 = left, 1 = right), stashed after each pass's
+// eye offset. The engine's fg scene node ctor runs BEFORE CalcView inside
+// each build and so receives the camera one BUILD stale - the OTHER eye's
+// camera under SR (the crossed-eye defect, ENGINE_NOTES session 21).
+// scenedraw's ctor detour substitutes these instead: correct eye, one PAIR
+// stale, both eyes from the same pair (consistent disparity). False when
+// no fresh stash exists (stereo off, drive idle > 200 ms, or never driven).
+bool driven_eye_cam(int eye, float loc[3], int32_t rot[3]);
+
 // Full ImGui section: hook status, telemetry, and all debug controls.
 // Called from the overlay through IGameAdapter::drawDebugUi().
 void draw_debug_ui();

--- a/src/game/bioshock1r/hands.cpp
+++ b/src/game/bioshock1r/hands.cpp
@@ -185,6 +185,7 @@ bool accept_hands(void* obj, void* user) {
 struct WeaponScanCtx {
     float camX, camY, camZ;
     const uint8_t* imageBase;
+    void* handsActor; // structural accept: Base(+0x450) == the AHands rig
     void* best;
     float bestDist;
     bool logEvery;
@@ -201,18 +202,31 @@ bool accept_weapon(void* obj, void* user) {
                                               c->imageBase);
     if (ownerRva != patterns::kShockPlayerVtableRva) return false;
 
+    // Structural accept first (session 21): the EQUIPPED weapon is attached
+    // to the AHands rig - its Base (+0x450) is the hands actor. Distance to
+    // the expected gun spot depends on pose/state and misses in some boot
+    // states (live: 2 owner-matched candidates, both >120 UU); attachment
+    // does not.
+    void* base = *reinterpret_cast<void* const*>(p + patterns::kActorBaseOffset);
+    if (c->handsActor && base == c->handsActor) {
+        c->best = obj;
+        c->bestDist = 0.0f;
+        return false;
+    }
+
     float loc[3];
     memcpy(loc, p + patterns::kActorLocOffset, sizeof loc);
     float dx = loc[0] - c->camX, dy = loc[1] - c->camY, dz = loc[2] - c->camZ;
     float dist = sqrtf(dx * dx + dy * dy + dz * dz);
     if (c->logEvery)
-        BVR_LOG("[hands] player weapon match @ %p loc=(%.1f %.1f %.1f) distToGunSpot=%.1f UU",
-                obj, loc[0], loc[1], loc[2], dist);
+        BVR_LOG("[hands] player weapon match @ %p loc=(%.1f %.1f %.1f) distToGunSpot=%.1f UU "
+                "base=%p",
+                obj, loc[0], loc[1], loc[2], dist, base);
     if (dist < 120.0f && dist < c->bestDist) {
         c->best = obj;
         c->bestDist = dist;
     }
-    return false; // never "accept" - the nearest wins after the walk
+    return false; // never "accept" - attachment/nearest wins after the walk
 }
 
 bool weapon_valid(void* w) {
@@ -278,8 +292,15 @@ void* find_weapon_actor(const FrameContext& ctx, bool probeOnly) {
     float dir[3];
     FRotator viewRot{ctx.camPitch, ctx.camYaw, 0};
     ue_rot_to_dir(viewRot, dir);
-    WeaponScanCtx wc{ctx.camX + dir[0] * 50.0f, ctx.camY + dir[1] * 50.0f,
-                     ctx.camZ + dir[2] * 50.0f, g_imageBase, nullptr, 1e9f, probeOnly};
+    WeaponScanCtx wc{ctx.camX + dir[0] * 50.0f,
+                     ctx.camY + dir[1] * 50.0f,
+                     ctx.camZ + dir[2] * 50.0f,
+                     g_imageBase,
+                     has_vtable(g_handsActor, patterns::kHandsVtableRva) ? g_handsActor
+                                                                         : nullptr,
+                     nullptr,
+                     1e9f,
+                     probeOnly};
     int matches = 0;
     patterns::scan_for_vtable_object(patterns::kPlayerWeaponVtableRva,
                                      patterns::kWeaponOwnerOffset + sizeof(void*),
@@ -453,6 +474,10 @@ void* weapon_actor() {
     void* w = weapon_valid(g_weaponActor) ? g_weaponActor
                                           : bvr::b1r::aim::learned_weapon_object();
     return weapon_valid(w) ? w : nullptr;
+}
+
+void* resolve_weapon_actor(const FrameContext& ctx) {
+    return find_weapon_actor(ctx, false);
 }
 
 // Live mesh-alignment trim, read by `vraim synccheck` so its model chain runs

--- a/src/game/bioshock1r/hands.cpp
+++ b/src/game/bioshock1r/hands.cpp
@@ -496,6 +496,26 @@ void* resolve_weapon_actor(const FrameContext& ctx) {
     return find_weapon_actor(ctx, false);
 }
 
+bool current_holdable(void** out) {
+    // Raw rig read, CLASS-AGNOSTIC: the MachineGun and GrenadeLauncher carry
+    // a different native vtable than kPlayerWeaponVtableRva, so the
+    // vtable-gated weapon_actor() path rejected them and fell back to the
+    // stale cached weapon - the session-21 part-3 defect (their profile key
+    // never changed and edits landed in the previous weapon's profile). The
+    // profile layer keys on the CLASS NAME, which validates through the
+    // UClass vtable instead - any holdable class resolves. Returns false
+    // when the rig itself is unknown/unreadable (callers then fall back to
+    // the legacy paths); *out may be null (nothing equipped).
+    if (!has_vtable(g_handsActor, patterns::kHandsVtableRva)) return false;
+    void* hold = nullptr;
+    if (!read_ptr(static_cast<const uint8_t*>(g_handsActor) +
+                      patterns::kHandsCurrentHoldableOffset,
+                  &hold))
+        return false;
+    *out = hold;
+    return true;
+}
+
 // Live mesh-alignment trim, read by `vraim synccheck` so its model chain runs
 // on the REAL tuned values (session 20).
 float model_trim_pitch_deg(int hand) {

--- a/src/game/bioshock1r/hands.cpp
+++ b/src/game/bioshock1r/hands.cpp
@@ -471,6 +471,22 @@ void* hands_actor() {
 }
 
 void* weapon_actor() {
+    // Primary (session 21 part 2): read Hands.CurrentHoldable straight off
+    // the rig - THE equipped weapon by definition, updated by the engine at
+    // equip time. The old learned/cache preference pinned the resolver to
+    // the previously FIRED weapon across wheel switches (an unequipped
+    // weapon keeps its vtable and owner), which broke per-weapon profile
+    // swapping in the first headset run.
+    if (has_vtable(g_handsActor, patterns::kHandsVtableRva)) {
+        void* hold = nullptr;
+        if (read_ptr(static_cast<const uint8_t*>(g_handsActor) +
+                         patterns::kHandsCurrentHoldableOffset,
+                     &hold) &&
+            weapon_valid(hold)) {
+            g_weaponActor = hold;
+            return hold;
+        }
+    }
     void* w = weapon_valid(g_weaponActor) ? g_weaponActor
                                           : bvr::b1r::aim::learned_weapon_object();
     return weapon_valid(w) ? w : nullptr;

--- a/src/game/bioshock1r/hands.h
+++ b/src/game/bioshock1r/hands.h
@@ -96,6 +96,14 @@ void* weapon_actor();
 // too. Game thread; callers gate on gameplay view to avoid cutscene scans.
 void* resolve_weapon_actor(const FrameContext& ctx);
 
+// Hands.CurrentHoldable read raw off the rig, CLASS-AGNOSTIC (session 21
+// part 3: the MachineGun/GrenadeLauncher native vtable differs from
+// kPlayerWeaponVtableRva, so vtable-gated paths rejected them and pinned
+// the stale weapon). False = the rig is unknown/unreadable (fall back to
+// the legacy paths); true with *out possibly null. The per-weapon profile
+// layer's identity source - it validates by CLASS NAME, not vtable.
+bool current_holdable(void** out);
+
 // Persist the per-hand model offsets to hands.ini (same as `vrhands save`).
 // Called by `vrpreset save` too, so the one in-headset save button covers the
 // model sliders along with the preset's own values.

--- a/src/game/bioshock1r/hands.h
+++ b/src/game/bioshock1r/hands.h
@@ -90,6 +90,12 @@ float model_trim_roll_deg(int hand);
 void* hands_actor();
 void* weapon_actor();
 
+// Like weapon_actor(), but SCANS when the cache is empty (trigger-learned
+// object preferred; else the anchored heap scan, 2 s internal cooldown).
+// The session-21 per-weapon profile key source - pre-fire weapons resolve
+// too. Game thread; callers gate on gameplay view to avoid cutscene scans.
+void* resolve_weapon_actor(const FrameContext& ctx);
+
 // Persist the per-hand model offsets to hands.ini (same as `vrhands save`).
 // Called by `vrpreset save` too, so the one in-headset save button covers the
 // model sliders along with the preset's own values.

--- a/src/game/bioshock1r/patterns.cpp
+++ b/src/game/bioshock1r/patterns.cpp
@@ -256,4 +256,21 @@ int32_t fname_count() {
     return *reinterpret_cast<const int32_t*>(arrayBase + 4);
 }
 
+const wchar_t* object_class_name(const void* obj) {
+    using bvr::pattern_scan::is_memory_valid;
+    if (!g_imageBase || !obj) return nullptr;
+    const uint8_t* o = static_cast<const uint8_t*>(obj);
+    if (!is_memory_valid(o, kUObjectClassOffset + sizeof(void*))) return nullptr;
+    const uint8_t* cls =
+        *reinterpret_cast<const uint8_t* const*>(o + kUObjectClassOffset);
+    if (!cls || !is_memory_valid(cls, kUObjectNameIndexOffset + sizeof(int32_t)))
+        return nullptr;
+    // The +0x30 target must BE a UClass - vtable-gated so a stranger layout
+    // (or a freed object) can never produce a bogus profile key.
+    if (*reinterpret_cast<const void* const*>(cls) != g_imageBase + kUClassVtableRva)
+        return nullptr;
+    return fname_text(
+        *reinterpret_cast<const int32_t*>(cls + kUObjectNameIndexOffset));
+}
+
 } // namespace bvr::b1r::patterns

--- a/src/game/bioshock1r/patterns.h
+++ b/src/game/bioshock1r/patterns.h
@@ -560,6 +560,17 @@ inline constexpr uint32_t kFgSceneNodeFovAOffset = 0x3F0; // from PC+0x45C (defa
 inline constexpr uint32_t kFgSceneNodeFovBOffset = 0x3F4; // from PC+0x460 (the vrfgfov field)
 inline constexpr uint32_t kFgSceneNodeBytes = 0x400;
 
+// ---- UObject identity (session 21) ------------------------------------------
+// Derived live via the seam: the equipped weapon actor's +0x28 dword read
+// 18009 -> 'Shotgun' through fname_text (+0x2C = the instance number), and
+// +0x30 -> a heap object carrying the UClass vtable whose OWN +0x28 is the
+// same index with number 0 (the canonical class name). Cross-checked on the
+// AHands actor: +0x28 -> 'PlayerHands', class object at +0x30 agrees.
+// kUClassVtableRva validates the +0x30 target before it is trusted.
+inline constexpr uint32_t kUObjectNameIndexOffset = 0x28; // FName index (+0x2C = number)
+inline constexpr uint32_t kUObjectClassOffset = 0x30;     // UClass*
+inline constexpr uint32_t kUClassVtableRva = 0xE2F04C;
+
 // ---- Name system (session 20) ----------------------------------------------
 // Derived by capstone disassembly of the FName constructor the event scan
 // already finds (thin SEH/lock wrapper at RVA 0x70D660 -> worker 0x70D3C0);
@@ -580,6 +591,12 @@ inline constexpr uint32_t kFNameEntryTextOffset = 0x10;
 const wchar_t* fname_text(int32_t index);
 // GNames.Count (0 if unavailable) - for status lines.
 int32_t fname_count();
+
+// Canonical class name of any live UObject, or null. Every step validated:
+// obj readable -> obj+kUObjectClassOffset -> UClass vtable at kUClassVtableRva
+// -> class+kUObjectNameIndexOffset -> fname_text. The per-weapon profile key
+// (session 21). Game thread.
+const wchar_t* object_class_name(const void* obj);
 
 struct Symbols {
     // void __thiscall(APlayerController* this, AActor** viewActor,

--- a/src/game/bioshock1r/patterns.h
+++ b/src/game/bioshock1r/patterns.h
@@ -531,6 +531,35 @@ inline constexpr float kFgInvTanV = 2.3094011f; // 1/0.4330127
 inline constexpr float kFgViewYawBiasDeg = 1.7f;
 inline constexpr float kFgViewPitchBiasDeg = 1.1f;
 
+// ---- The FOREGROUND SCENE NODE (session 21) --------------------------------
+// The fg pass is a SECOND SCENE NODE, pure data through shared render
+// machinery (dump stack-diff: fg and world draws share the whole skeletal
+// draw layer; they differ only in which recorded scene command iterates the
+// mesh and which section-transform provider bakes it). The scene build
+// (kSceneBuildRva 0x4CCE70) allocates a 0x400-byte fg node per frame from
+// the frame pool and constructs it at the RVA below with
+// (parentScene, &parentScene.view@+0x118, x, vec3 PC+0x65C, triple PC+0x668,
+// float PC+0x45C, float PC+0x460), then stores it at parentScene+0x1B0.
+// Derivation: static capstone disasm of the build's [PC+0x460] float read
+// (the only fg-fov consumer in the build region; found by disp-0x460 code
+// search) at build+0xD71, and of the ctor + its finisher (0x56DD90 - view
+// offset/rotation compose into node+0x150). The ctor's base-class call
+// receives THE PARENT VIEW POINTER - the fg node's view starts as a copy of
+// the world view; the fg divergence (actor orientation, eye pull) enters
+// downstream. The vec3 at PC+0x65C and triple at PC+0x668 read zero live at
+// rest (auxiliary offsets; 75/75/60 fov floats sit just before them at
+// PC+0x648..0x650).
+inline constexpr uint32_t kFgSceneNodeCtorRva = 0x56DC30;
+inline constexpr uint8_t kFgSceneNodeCtorPrologue[5] = {0x55, 0x8B, 0xEC, 0x6A, 0xFF};
+inline constexpr uint32_t kFgSceneNodeVtableRva = 0xE1846C; // written by the build after ctor
+inline constexpr uint32_t kSceneViewOffset = 0x118;   // parent scene's view block
+inline constexpr uint32_t kSceneFgNodeOffset = 0x1B0; // parentScene -> fg node (per frame)
+inline constexpr uint32_t kScenePcOffset = 0x48;      // parentScene -> PlayerController
+inline constexpr uint32_t kFgSceneNodeViewOffset = 0x150; // view matrix the finisher composes
+inline constexpr uint32_t kFgSceneNodeFovAOffset = 0x3F0; // from PC+0x45C (default 75.0)
+inline constexpr uint32_t kFgSceneNodeFovBOffset = 0x3F4; // from PC+0x460 (the vrfgfov field)
+inline constexpr uint32_t kFgSceneNodeBytes = 0x400;
+
 // ---- Name system (session 20) ----------------------------------------------
 // Derived by capstone disassembly of the FName constructor the event scan
 // already finds (thin SEH/lock wrapper at RVA 0x70D660 -> worker 0x70D3C0);

--- a/src/game/bioshock1r/patterns.h
+++ b/src/game/bioshock1r/patterns.h
@@ -560,6 +560,19 @@ inline constexpr uint32_t kFgSceneNodeFovAOffset = 0x3F0; // from PC+0x45C (defa
 inline constexpr uint32_t kFgSceneNodeFovBOffset = 0x3F4; // from PC+0x460 (the vrfgfov field)
 inline constexpr uint32_t kFgSceneNodeBytes = 0x400;
 
+// Hands.CurrentHoldable - THE equipped-weapon pointer, read directly off the
+// rig actor (session 21 part 2). Derived live: with hands=594733A0 and the
+// equipped weapon=5FAB2F00 known, the weapon pointer occurs EXACTLY ONCE in
+// hands+0..0x800, at +0x45C - right after the actor's Base/Owner block
+// (hands+0x450 held the pawn = Hands.Base; the weapon's own +0x450 holds the
+// hands actor: the attach chain weapon -> hands -> pawn is self-consistent).
+// This replaces learned/cache/scan as the primary weapon resolution: the
+// trigger-learned object PINNED the old resolver to the previously-fired
+// weapon across wheel switches (an unequipped weapon stays vtable- and
+// owner-valid), which is why per-weapon profiles only swapped on FIRE in the
+// first headset run.
+inline constexpr uint32_t kHandsCurrentHoldableOffset = 0x45C;
+
 // ---- UObject identity (session 21) ------------------------------------------
 // Derived live via the seam: the equipped weapon actor's +0x28 dword read
 // 18009 -> 'Shotgun' through fname_text (+0x2C = the instance number), and

--- a/src/game/bioshock1r/scenedraw.cpp
+++ b/src/game/bioshock1r/scenedraw.cpp
@@ -15,6 +15,7 @@
 #include "core/hooks/d3d11_hook.h"
 #include "core/util/log.h"
 #include "core/vr/openxr_runtime.h"
+#include "game/bioshock1r/camera.h"
 #include "game/bioshock1r/patterns.h"
 
 #include <windows.h>
@@ -75,6 +76,7 @@ HookSlot g_flush{"flush"};
 HookSlot g_submit{"submit"};
 HookSlot g_build{"build"};
 HookSlot g_flushpoint{"flushpoint"};
+HookSlot g_fgctor{"fgctor"}; // session 21: the FOREGROUND SCENE NODE ctor
 
 // Controls: command poller (game thread) writes, detour threads read.
 std::atomic<bool>  g_doubleCall{false};
@@ -757,6 +759,107 @@ void __fastcall BuildDetour(void* ecx, void* edx, void* a1, void* a2, void* a3,
         g_activeTid.store(0, std::memory_order_relaxed);
 }
 
+// ---- session 21: fg scene node instrument (world-pass re-homing) -----------
+// The scene build constructs a per-frame FOREGROUND SCENE NODE for the
+// first-person rig (patterns::kFgSceneNodeCtorRva; layout facts in
+// patterns.h). This read-only hook snapshots the ctor's parent-view argument
+// plus the whole node at TWO points - ctor tail and frame submit - so
+// `vrfgnode dump` shows where the fg view diverges from the parent (world)
+// view: at construction, during command record, or not at all (then the
+// divergence is bake-side actor-frame math). Discovery instrument only;
+// nothing here writes engine state.
+using FgCtorFn = void*(__fastcall*)(void* self, void* edx, void* scene, void* parentView,
+                                    void* a3, float ofsX, float ofsY, float ofsZ,
+                                    int32_t rotA, int32_t rotB, int32_t rotC, float fovA,
+                                    float fovB);
+std::atomic<bool> g_fgWatch{false};
+std::atomic<uint32_t> g_fgCtorCalls{0};
+// fg view-sync (the crossed-eye fix): substitute the ctor's camera args with
+// the CORRECT eye's driven camera from camera.cpp's stash. Default OFF.
+std::atomic<bool> g_fgSync{false};
+std::atomic<uint32_t> g_fgSyncSubs{0};
+std::atomic<uint32_t> g_fgSyncMisses{0};
+// fovA-arg override (0 = off): the ctor's first fov input (from PC+0x45C,
+// engine-restamped to 75.0 every frame - unpokeable as data). If the bake's
+// eye pull-back derives from the fovA/fovB pair, overriding fovA == fovB
+// moves the rig's rendered depth - the pull's origin discriminator.
+std::atomic<float> g_fgFovAOverride{0.0f};
+// Snapshot state: written on the game thread inside the build (1t), read by
+// the command poller on the same thread - plain fields are safe.
+void* g_fgNodeScene = nullptr;
+void* g_fgNodeLast = nullptr;
+void* g_fgNodeParentView = nullptr;
+float g_fgCtorOfs[3] = {};
+int32_t g_fgCtorRot[3] = {};
+float g_fgCtorFov[2] = {};
+// Per-eye claim check: under SR stereo the two builds of one pair should
+// carry +-IPD/2-offset eye cameras in their WORLD views - do the fg nodes?
+// Two slots, alternating per ctor call; the dump prints both.
+float g_fgCtorOfs2[2][3] = {};
+int32_t g_fgCtorRot2[2][3] = {};
+uint32_t g_fgCtorSlot = 0;
+uint8_t g_fgParentSnap[0x100];
+uint8_t g_fgNodeSnapCtor[patterns::kFgSceneNodeBytes];
+uint8_t g_fgNodeSnapSubmit[patterns::kFgSceneNodeBytes];
+bool g_fgSnapCtorOk = false;
+bool g_fgSnapSubmitOk = false;
+
+bool snap_mem(void* dst, const void* src, size_t n) {
+    __try {
+        memcpy(dst, src, n);
+        return true;
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        return false;
+    }
+}
+
+void* __fastcall FgCtorDetour(void* self, void* edx, void* scene, void* parentView, void* a3,
+                              float ofsX, float ofsY, float ofsZ, int32_t rotA, int32_t rotB,
+                              int32_t rotC, float fovA, float fovB) {
+    // fg view-sync: the engine hands this ctor the camera one BUILD stale,
+    // which under SR stereo is the OTHER eye's camera (crossed eyes,
+    // full-IPD lateral error + inverted rig disparity - flat-measured,
+    // ENGINE_NOTES session 21). Substitute the CORRECT eye's driven camera
+    // from the previous pair: both eyes then come from one consistent pose
+    // sample, correct-eye, one pair stale (same order of lag as stock).
+    if (g_fgSync.load(std::memory_order_relaxed) && g_stereo.load(std::memory_order_relaxed)) {
+        int eye = g_secondPassTid.load(std::memory_order_relaxed) == GetCurrentThreadId() ? 1 : 0;
+        float sl[3];
+        int32_t sr[3];
+        if (camera::driven_eye_cam(eye, sl, sr)) {
+            ofsX = sl[0]; ofsY = sl[1]; ofsZ = sl[2];
+            rotA = sr[0]; rotB = sr[1]; rotC = sr[2];
+            g_fgSyncSubs.fetch_add(1, std::memory_order_relaxed);
+        } else {
+            g_fgSyncMisses.fetch_add(1, std::memory_order_relaxed);
+        }
+    }
+    float fovAOv = g_fgFovAOverride.load(std::memory_order_relaxed);
+    if (fovAOv != 0.0f) fovA = fovAOv < 0.0f ? fovB : fovAOv; // -1 = "match fovB"
+    void* ret = reinterpret_cast<FgCtorFn>(g_fgctor.original)(
+        self, edx, scene, parentView, a3, ofsX, ofsY, ofsZ, rotA, rotB, rotC, fovA, fovB);
+    g_fgCtorCalls.fetch_add(1, std::memory_order_relaxed);
+    if (g_fgWatch.load(std::memory_order_relaxed)) {
+        g_fgNodeScene = scene;
+        g_fgNodeLast = self;
+        g_fgNodeParentView = parentView;
+        g_fgCtorOfs[0] = ofsX; g_fgCtorOfs[1] = ofsY; g_fgCtorOfs[2] = ofsZ;
+        g_fgCtorRot[0] = rotA; g_fgCtorRot[1] = rotB; g_fgCtorRot[2] = rotC;
+        g_fgCtorFov[0] = fovA; g_fgCtorFov[1] = fovB;
+        // Slot by PASS: 0 = first build of the pair (LEFT eye), 1 = second
+        // (RIGHT). Under sync the values are post-substitution.
+        uint32_t slot =
+            g_secondPassTid.load(std::memory_order_relaxed) == GetCurrentThreadId() ? 1u : 0u;
+        g_fgCtorSlot = slot;
+        g_fgCtorOfs2[slot][0] = ofsX; g_fgCtorOfs2[slot][1] = ofsY; g_fgCtorOfs2[slot][2] = ofsZ;
+        g_fgCtorRot2[slot][0] = rotA; g_fgCtorRot2[slot][1] = rotB; g_fgCtorRot2[slot][2] = rotC;
+        g_fgSnapCtorOk = snap_mem(g_fgParentSnap, parentView, sizeof g_fgParentSnap) &&
+                         snap_mem(g_fgNodeSnapCtor, self, sizeof g_fgNodeSnapCtor);
+        g_fgSnapSubmitOk = false; // re-armed by the next submit
+    }
+    return ret;
+}
+
 void __fastcall SubmitDetour(void* ecx, void* edx, FVec3* loc, FRot3* rot,
                              void* arg3) {
     uint32_t tid = GetCurrentThreadId();
@@ -768,6 +871,12 @@ void __fastcall SubmitDetour(void* ecx, void* edx, FVec3* loc, FRot3* rot,
     }
     g_submitEntries.fetch_add(1, std::memory_order_relaxed);
     note_caller(to_rva(_ReturnAddress()));
+
+    // fg-node instrument: re-read the node at submit time (post-record) so
+    // the dump can diff ctor-state vs recorded-state. SEH-guarded - the node
+    // lives in the frame pool and a stale pointer must not fault.
+    if (g_fgWatch.load(std::memory_order_relaxed) && g_fgNodeLast && !g_fgSnapSubmitOk)
+        g_fgSnapSubmitOk = snap_mem(g_fgNodeSnapSubmit, g_fgNodeLast, sizeof g_fgNodeSnapSubmit);
 
     uint32_t presentLow =
         static_cast<uint32_t>(bvr::d3d11_hook::present_count());
@@ -1436,6 +1545,128 @@ bool stereo_active() {
 
 void request_vrstereo(bool on) {
     g_vrstereoPending.store(on ? 1 : 0, std::memory_order_relaxed);
+}
+
+void handle_fgnode_command(const char* args) {
+    if (strncmp(args, "fova", 4) == 0) {
+        float v = 0.0f;
+        if (strstr(args + 4, "off"))
+            v = 0.0f;
+        else if (strstr(args + 4, "match"))
+            v = -1.0f;
+        else if (sscanf_s(args + 4, " %f", &v) != 1)
+            v = 0.0f;
+        if (v != 0.0f && !g_fgctor.enabled.load(std::memory_order_relaxed) &&
+            !install_slot(g_fgctor, patterns::kFgSceneNodeCtorRva,
+                          reinterpret_cast<void*>(&FgCtorDetour),
+                          patterns::kFgSceneNodeCtorPrologue,
+                          sizeof patterns::kFgSceneNodeCtorPrologue))
+            return;
+        g_fgFovAOverride.store(v, std::memory_order_relaxed);
+        BVR_LOG("[fgnode] fovA override %s (%.2f; -1 = match fovB)", v != 0.0f ? "ON" : "off",
+                v);
+    } else if (strncmp(args, "sync", 4) == 0) {
+        bool on = strstr(args + 4, "off") == nullptr;
+        if (on && !g_fgctor.enabled.load(std::memory_order_relaxed) &&
+            !install_slot(g_fgctor, patterns::kFgSceneNodeCtorRva,
+                          reinterpret_cast<void*>(&FgCtorDetour),
+                          patterns::kFgSceneNodeCtorPrologue,
+                          sizeof patterns::kFgSceneNodeCtorPrologue))
+            return;
+        g_fgSync.store(on, std::memory_order_relaxed);
+        BVR_LOG("[fgnode] view-sync %s (subs %u misses %u) - fg scene gets the CORRECT "
+                "eye's driven camera%s",
+                on ? "ON" : "off", g_fgSyncSubs.load(std::memory_order_relaxed),
+                g_fgSyncMisses.load(std::memory_order_relaxed),
+                on ? "; requires vrstereo" : "");
+    } else if (strncmp(args, "on", 2) == 0) {
+        if (install_slot(g_fgctor, patterns::kFgSceneNodeCtorRva,
+                         reinterpret_cast<void*>(&FgCtorDetour),
+                         patterns::kFgSceneNodeCtorPrologue,
+                         sizeof patterns::kFgSceneNodeCtorPrologue)) {
+            g_fgWatch.store(true, std::memory_order_relaxed);
+            BVR_LOG("[fgnode] watch ON (fg scene node ctor hooked; 'vrfgnode dump' logs "
+                    "the ctor-vs-submit snapshots)");
+        }
+    } else if (strncmp(args, "off", 3) == 0) {
+        g_fgWatch.store(false, std::memory_order_relaxed);
+        g_fgSync.store(false, std::memory_order_relaxed);
+        disable_slot(g_fgctor);
+        BVR_LOG("[fgnode] watch + sync off");
+    } else if (strncmp(args, "dump", 4) == 0) {
+        BVR_LOG("[fgnode] ctorCalls=%u scene=%p node=%p pview=%p snaps ctor=%d submit=%d",
+                g_fgCtorCalls.load(std::memory_order_relaxed), g_fgNodeScene, g_fgNodeLast,
+                g_fgNodeParentView, g_fgSnapCtorOk ? 1 : 0, g_fgSnapSubmitOk ? 1 : 0);
+        if (!g_fgSnapCtorOk) {
+            BVR_LOG("[fgnode] no ctor snapshot yet (watch on + gameplay view needed)");
+            return;
+        }
+        BVR_LOG("[fgnode] ctor args: ofs=(%.4g %.4g %.4g) rot=(%d %d %d) fovA=%.2f fovB=%.2f",
+                g_fgCtorOfs[0], g_fgCtorOfs[1], g_fgCtorOfs[2], g_fgCtorRot[0], g_fgCtorRot[1],
+                g_fgCtorRot[2], g_fgCtorFov[0], g_fgCtorFov[1]);
+        BVR_LOG("[fgnode] pair slots: pass1/L ofs=(%.6g %.6g %.6g) rot=(%d %d %d) | pass2/R "
+                "ofs=(%.6g %.6g %.6g) rot=(%d %d %d)",
+                g_fgCtorOfs2[0][0], g_fgCtorOfs2[0][1], g_fgCtorOfs2[0][2], g_fgCtorRot2[0][0],
+                g_fgCtorRot2[0][1], g_fgCtorRot2[0][2], g_fgCtorOfs2[1][0], g_fgCtorOfs2[1][1],
+                g_fgCtorOfs2[1][2], g_fgCtorRot2[1][0], g_fgCtorRot2[1][1], g_fgCtorRot2[1][2]);
+        // Parent view block (scene+0x118): 64 floats.
+        const float* pv = reinterpret_cast<const float*>(g_fgParentSnap);
+        for (int i = 0; i < 64; i += 8)
+            BVR_LOG("[fgnode] pview+0x%03X: %.4g %.4g %.4g %.4g %.4g %.4g %.4g %.4g", i * 4,
+                    pv[i], pv[i + 1], pv[i + 2], pv[i + 3], pv[i + 4], pv[i + 5], pv[i + 6],
+                    pv[i + 7]);
+        // Locate the parent-view copy inside the node (first 16-byte run).
+        int foundAt = -1;
+        for (size_t off = 0; off + 16 <= sizeof g_fgNodeSnapCtor; off += 4) {
+            if (memcmp(g_fgNodeSnapCtor + off, g_fgParentSnap, 16) == 0) {
+                foundAt = static_cast<int>(off);
+                break;
+            }
+        }
+        BVR_LOG("[fgnode] parent-view first 16 bytes %s in node(ctor)%s0x%X",
+                foundAt >= 0 ? "FOUND" : "NOT found", foundAt >= 0 ? " at +" : " (searched +0..+",
+                foundAt >= 0 ? static_cast<unsigned>(foundAt)
+                             : static_cast<unsigned>(sizeof g_fgNodeSnapCtor));
+        // The node's own view region (+0x140..+0x200) at ctor time.
+        const float* nv = reinterpret_cast<const float*>(g_fgNodeSnapCtor);
+        for (int i = 0x140 / 4; i < 0x200 / 4; i += 8)
+            BVR_LOG("[fgnode] node+0x%03X: %.4g %.4g %.4g %.4g %.4g %.4g %.4g %.4g", i * 4,
+                    nv[i], nv[i + 1], nv[i + 2], nv[i + 3], nv[i + 4], nv[i + 5], nv[i + 6],
+                    nv[i + 7]);
+        BVR_LOG("[fgnode] node vec3@0x310=(%.4g %.4g %.4g) fovs@0x3F0=(%.2f %.2f)",
+                nv[0x310 / 4], nv[0x314 / 4], nv[0x318 / 4], nv[0x3F0 / 4], nv[0x3F4 / 4]);
+        // Submit-vs-ctor diff, 16-byte rows.
+        if (g_fgSnapSubmitOk) {
+            char rows[256];
+            size_t len = 0;
+            int changed = 0;
+            for (size_t off = 0; off < sizeof g_fgNodeSnapCtor; off += 16) {
+                if (memcmp(g_fgNodeSnapCtor + off, g_fgNodeSnapSubmit + off, 16) == 0) continue;
+                ++changed;
+                if (len < sizeof rows - 12)
+                    len += sprintf_s(rows + len, sizeof rows - len, " +0x%X",
+                                     static_cast<unsigned>(off));
+            }
+            BVR_LOG("[fgnode] submit-vs-ctor: %d changed row(s):%s", changed,
+                    changed ? rows : " none");
+            if (changed) {
+                const float* sv = reinterpret_cast<const float*>(g_fgNodeSnapSubmit);
+                for (int i = 0x140 / 4; i < 0x200 / 4; i += 8)
+                    BVR_LOG("[fgnode] subm+0x%03X: %.4g %.4g %.4g %.4g %.4g %.4g %.4g %.4g",
+                            i * 4, sv[i], sv[i + 1], sv[i + 2], sv[i + 3], sv[i + 4], sv[i + 5],
+                            sv[i + 6], sv[i + 7]);
+            }
+        }
+    } else {
+        BVR_LOG("[fgnode] usage: vrfgnode on|off|dump|sync on|sync off (hook=%d watch=%d "
+                "sync=%d calls=%u subs=%u misses=%u)",
+                g_fgctor.enabled.load(std::memory_order_relaxed) ? 1 : 0,
+                g_fgWatch.load(std::memory_order_relaxed) ? 1 : 0,
+                g_fgSync.load(std::memory_order_relaxed) ? 1 : 0,
+                g_fgCtorCalls.load(std::memory_order_relaxed),
+                g_fgSyncSubs.load(std::memory_order_relaxed),
+                g_fgSyncMisses.load(std::memory_order_relaxed));
+    }
 }
 
 void note_calcview() {

--- a/src/game/bioshock1r/scenedraw.h
+++ b/src/game/bioshock1r/scenedraw.h
@@ -51,6 +51,12 @@ bool stereo_active();
 // Safe from any thread (the overlay checkbox draws on the render thread).
 void request_vrstereo(bool on);
 
+// Session 21 discovery instrument: "vrfgnode on|off|dump" - read-only hook on
+// the engine's per-frame FOREGROUND SCENE NODE ctor (patterns.h "FOREGROUND
+// SCENE NODE"); dump logs the parent-view/node snapshots taken at ctor tail
+// and at frame submit. Game thread only.
+void handle_fgnode_command(const char* args);
+
 // Read-only telemetry section for the overlay (control is commands-only).
 void draw_debug_ui();
 

--- a/tools/decode-framedump.ps1
+++ b/tools/decode-framedump.ps1
@@ -1,0 +1,176 @@
+# decode-framedump.ps1 - recover projection tangents + pass clusters from a
+# frame_inspector dump (session 21 FOV audit / world-pass instrument).
+#
+# Reads framedump_*_qN.txt (written by the `dumpframe full [n]` seam command),
+# attributes every depth-tested draw to its governing cb0 capture (a block is
+# written whenever the VS b0 buffer OBJECT changes, so "most recent block at or
+# before the draw" is exact), recovers the projection tangents from the
+# screen-ray helper block at cb0 floats 12..18 - layout
+# (2*tanH, 0, -tanH, 0, 0, -2*tanV, tanV) - and clusters draws by tangent pair.
+#
+# Because the shipped fg lens match (vrfgfov, default ON) makes the foreground
+# pass render with WORLD-equal tangents, tangents alone cannot separate the
+# passes; each cluster therefore also reports how many of its draws carry the
+# per-section fg-bake RVAs (0x3DBF7C / 0x3EDCBF) in their callstack, which is
+# lens-independent (ENGINE_NOTES "Foreground scene FOV").
+#
+# Usage:
+#   .\decode-framedump.ps1 -Path "$env:LOCALAPPDATA\BioshockVR\framedump_*_q*.txt"
+#   .\decode-framedump.ps1 -Path <file> -SubmittedTanH 1.19175 -SubmittedTanV 0.67036
+#   .\decode-framedump.ps1 -Path <file> -OptionFov 100
+#   -ShowDraws N   lists the first N depth-tested draws per cluster (rig hunting)
+#   -Tolerance     gate tolerance on |tangent - reference| (default 0.0002,
+#                  the dump prints cb0 at %.4f)
+param(
+    [Parameter(Mandatory = $true)][string[]]$Path,
+    [double]$SubmittedTanH = 0,
+    [double]$SubmittedTanV = 0,
+    [int]$OptionFov = 0,
+    [int]$ShowDraws = 0,
+    [double]$Tolerance = 0.0002
+)
+
+$ErrorActionPreference = 'Stop'
+$inv = [System.Globalization.CultureInfo]::InvariantCulture
+$fgBakeRvas = @('3DBF7C', '3EDCBF')
+
+# cb0 contents are raw buffer bytes reinterpreted as floats - garbage prints
+# as nan/1.#IND and must not kill the parse. Unparseable -> NaN.
+function Parse-F([string]$s) {
+    $out = 0.0
+    if ([double]::TryParse($s, [System.Globalization.NumberStyles]::Float, $inv, [ref]$out)) { return $out }
+    return [double]::NaN
+}
+
+$files = @()
+foreach ($p in $Path) { $files += @(Get-Item -Path $p | Sort-Object Name) }
+if ($files.Count -eq 0) { throw "no dump files match: $Path" }
+
+$eventRe = [regex]'^(\d{5}) (\S+)\s+a=(\d+)\s+b=(\d+)\s+rtv0=T(-?\d+)\s+dsv=T(-?\d+)\s+vp=(\d+)x(\d+) cb=(\d+)/(\d+)/(\d+) srv0=T(-?\d+)\s+ret=0x([0-9A-Fa-f]+) stk=(\S*)'
+$drawKinds = @('DrawIndexed', 'Draw', 'DrawIdxInst', 'DrawInst', 'DrawIndexedInstanced', 'DrawInstanced')
+
+foreach ($file in $files) {
+    Write-Output ""
+    Write-Output "== $($file.Name) =="
+
+    # ---- parse ----------------------------------------------------------
+    $events = New-Object System.Collections.Generic.List[object]
+    $blocks = New-Object System.Collections.Generic.List[object]  # each: @{ev=<event idx in list>; f=double[]}
+    $curBlock = $null
+    $reader = New-Object System.IO.StreamReader($file.FullName)
+    try {
+        while ($null -ne ($line = $reader.ReadLine())) {
+            if ($null -ne $curBlock) {
+                if ($line -match '^\s{6,}(-?\d|nan|-nan|1\.#)' -or $line -match '^\s{6}cb0:') {
+                    $nums = $line -replace '^\s*cb0:', '' -split '\s+' | Where-Object { $_ -ne '' }
+                    foreach ($n in $nums) { [void]$curBlock.f.Add((Parse-F $n)) }
+                    if ($curBlock.f.Count -ge 336) { $blocks.Add($curBlock); $curBlock = $null }
+                    continue
+                } else {
+                    $blocks.Add($curBlock); $curBlock = $null  # short block (buffer < 1344 B)
+                }
+            }
+            if ($line -match '^\s{6}cb0:') {
+                $curBlock = @{ ev = $events.Count - 1; f = New-Object System.Collections.Generic.List[double] }
+                $nums = $line -replace '^\s*cb0:', '' -split '\s+' | Where-Object { $_ -ne '' }
+                foreach ($n in $nums) { [void]$curBlock.f.Add((Parse-F $n)) }
+                continue
+            }
+            $m = $eventRe.Match($line)
+            if ($m.Success) {
+                $events.Add(@{
+                    idx  = [int]$m.Groups[1].Value; kind = $m.Groups[2].Value
+                    a    = [uint32]$m.Groups[3].Value; b = [uint32]$m.Groups[4].Value
+                    rtv  = [int]$m.Groups[5].Value; dsv = [int]$m.Groups[6].Value
+                    cb0b = [uint32]$m.Groups[9].Value
+                    stk  = $m.Groups[14].Value
+                    blk  = -1
+                })
+            }
+        }
+        if ($null -ne $curBlock) { $blocks.Add($curBlock) }
+    } finally { $reader.Close() }
+
+    # attribute: governing block = most recent captured block at or before the event
+    $bi = 0
+    for ($ei = 0; $ei -lt $events.Count; $ei++) {
+        while ($bi + 1 -lt $blocks.Count -and $blocks[$bi + 1].ev -le $ei) { $bi++ }
+        if ($blocks.Count -gt 0 -and $blocks[$bi].ev -le $ei) { $events[$ei].blk = $bi }
+    }
+
+    # ---- tangents per block ----------------------------------------------
+    # screen-ray helper at floats 12..18: (2tanH, 0, -tanH, 0, 0, -2tanV, tanV)
+    $blockTan = @{}
+    for ($i = 0; $i -lt $blocks.Count; $i++) {
+        $f = $blocks[$i].f
+        if ($f.Count -lt 19) { continue }
+        $tanH1 = $f[12] / 2.0; $tanH2 = -$f[14]
+        $tanV1 = -$f[17] / 2.0; $tanV2 = $f[18]
+        $okH = ([math]::Abs($f[13]) -lt 0.001) -and ([math]::Abs($tanH1 - $tanH2) -lt 0.001) -and ($tanH1 -gt 0.05) -and ($tanH1 -lt 4.0)
+        $okV = ([math]::Abs($f[15]) -lt 0.001) -and ([math]::Abs($f[16]) -lt 0.001) -and ([math]::Abs($tanV1 - $tanV2) -lt 0.001) -and ($tanV1 -gt 0.05) -and ($tanV1 -lt 4.0)
+        if ($okH -and $okV) { $blockTan[$i] = @([math]::Round($tanH1, 4), [math]::Round($tanV1, 4)) }
+    }
+
+    # ---- cluster depth-tested draws ---------------------------------------
+    $clusters = @{}   # "tanH|tanV" -> stats
+    $noBlock = 0; $drawCount = 0; $depthDraws = 0
+    foreach ($ev in $events) {
+        if ($drawKinds -notcontains $ev.kind) { continue }
+        $drawCount++
+        if ($ev.dsv -lt 0) { continue }
+        $depthDraws++
+        if ($ev.blk -lt 0 -or -not $blockTan.ContainsKey($ev.blk)) { $noBlock++; continue }
+        $t = $blockTan[$ev.blk]
+        $key = '{0:F4}|{1:F4}' -f $t[0], $t[1]
+        if (-not $clusters.ContainsKey($key)) {
+            $clusters[$key] = @{
+                tanH = $t[0]; tanV = $t[1]; draws = 0; fgBake = 0
+                blocks = New-Object System.Collections.Generic.HashSet[int]
+                tiers = @{}; sample = New-Object System.Collections.Generic.List[object]
+            }
+        }
+        $c = $clusters[$key]
+        $c.draws++
+        [void]$c.blocks.Add($ev.blk)
+        if (-not $c.tiers.ContainsKey($ev.cb0b)) { $c.tiers[$ev.cb0b] = 0 }
+        $c.tiers[$ev.cb0b]++
+        $isFg = $false
+        foreach ($rva in $fgBakeRvas) { if ($ev.stk -match $rva) { $isFg = $true; break } }
+        if ($isFg) { $c.fgBake++ }
+        if ($c.sample.Count -lt [math]::Max($ShowDraws, 6)) { $c.sample.Add($ev) }
+    }
+
+    Write-Output ("events {0}, draws {1}, depth-tested {2}, captured cb0 blocks {3}" -f `
+        $events.Count, $drawCount, $depthDraws, $blocks.Count)
+    if ($noBlock -gt 0) { Write-Output "depth-tested draws with no decodable screen-ray block: $noBlock" }
+
+    foreach ($key in ($clusters.Keys | Sort-Object { - $clusters[$_].draws })) {
+        $c = $clusters[$key]
+        $tierStr = ($c.tiers.Keys | Sort-Object | ForEach-Object { '{0}:{1}' -f $_, $c.tiers[$_] }) -join ' '
+        $hfov = 2.0 * [math]::Atan($c.tanH) * 180.0 / [math]::PI
+        Write-Output ("cluster tanH={0:F4} tanV={1:F4} (hfov {2:F1} deg @16:9)  draws={3} blocks={4} fgBakeStacks={5}  b0tiers[{6}]" -f `
+            $c.tanH, $c.tanV, $hfov, $c.draws, $c.blocks.Count, $c.fgBake, $tierStr)
+        if ($ShowDraws -gt 0) {
+            $c.sample | Select-Object -First $ShowDraws | ForEach-Object {
+                $stkHead = ($_.stk -split ',' | Select-Object -First 4) -join ','
+                Write-Output ("    #{0:D5} {1} a={2} b0={3} stk={4}" -f $_.idx, $_.kind, $_.a, $_.cb0b, $stkHead)
+            }
+        }
+        # ---- gates ---------------------------------------------------------
+        if ($SubmittedTanH -gt 0) {
+            $dh = [math]::Abs($c.tanH - $SubmittedTanH); $dv = [math]::Abs($c.tanV - $SubmittedTanV)
+            $verdict = 'FAIL'
+            if ($dh -le $Tolerance -and $dv -le $Tolerance) { $verdict = 'PASS' }
+            Write-Output ("    vs SUBMITTED tanH={0:F5} tanV={1:F5}: dH={2:F5} dV={3:F5} -> {4}" -f `
+                $SubmittedTanH, $SubmittedTanV, $dh, $dv, $verdict)
+        }
+        if ($OptionFov -gt 0) {
+            $oH = [math]::Tan($OptionFov * [math]::PI / 360.0); $oV = $oH * 9.0 / 16.0
+            $dh = [math]::Abs($c.tanH - $oH); $dv = [math]::Abs($c.tanV - $oV)
+            $verdict = 'FAIL'
+            if ($dh -le $Tolerance -and $dv -le $Tolerance) { $verdict = 'PASS' }
+            Write-Output ("    vs OPTION {0} tanH={1:F5} tanV={2:F5}: dH={3:F5} dV={4:F5} -> {5}" -f `
+                $OptionFov, $oH, $oV, $dh, $dv, $verdict)
+        }
+    }
+}


### PR DESCRIPTION
## What this session did (the session-20 plan items 1-3, each flat-gated)

### 1. FOV audit - a clean negative, and permanent instruments
- New `fovaudit` seam command + on-change submission-tangent log + `fovaudit pose on` (tagged-vs-consumed yaw, for the headset).
- New `tools/decode-framedump.ps1`: recovers projection tangents from cb0 screen-ray blocks per depth-tested draw, clusters them, and tags fg draws by the lens-blind fg-bake stack RVAs.
- Measured under vrstereo (both SR eye windows): rendered tanH/tanV = 2.1445/1.2063 = exactly tan(130/2) at 16:9, identical per eye, fg draws included, no hidden second lens. Rendered == submitted == option-derived: **no fov lie exists** - the +-90 laser-vs-gun drift is not a projection-tag mismatch.

### 2. The fg scene decoded (world-pass re-homing found its real lever)
- The fg pass is a **second scene node** (per-frame ctor at RVA 0x56DC30, stored at scene+0x1B0) whose ctor receives the camera pose + two fovs as plain arguments; the camera inputs are already per-eye correct (crossed-eye and stale-camera hypotheses raised and killed by pass-labeled measurement).
- **The find: fovA/fovB is the fg zoom-pull pair.** `vrfgnode fova match` collapses the rig to true world-lens geometry (screenshot diff 11.09 mean / 44.2% changed vs a 2.9 floor, world pixels untouched, exact round-trip). This is the eye-dolly/magnification the render lock has countered since session 13, now controllable at one seam.
- New `vrfgnode on|off|dump|sync|fova` instrument; **every new render lever ships default OFF** - the shipping look is byte-identical to session 20. The session-22 retune (`fova match` + `lock off` + the acceptance ladder) decides the new regime.
- Negatives logged in ENGINE_NOTES: no script-side fg membership property; pawn+0x724 nulling fatal (non-lever); the section-transform providers are skinning strategies, not fg markers.

### 3. Per-weapon profiles - shipping
- UObject identity derived live: +0x28 own-name FName, +0x30 UClass (vtable-gated) -> `patterns::object_class_name()` ('Shotgun'; AHands -> 'PlayerHands').
- The R-hand aim trim + ray-origin offsets hot-swap per weapon class; R atomics stay the single live truth (laser/fire-ray/model unchanged by construction); weapons.ini persistence chained into `vrpreset save`; the preset tail re-applies the active profile (flat-caught clobber, fixed).
- Weapon resolves **pre-fire** (structural scan accept: candidate Base +0x450 == the AHands actor) with null-resolve backoff.
- Flat gates all exact: sim-key swap round-trips to the digit; ini write/load round-trips; the composed boot chain proven live; fire seam subs 2/2 with a profile live. The real weapon-switch swap is the in-headset checklist headline.

## Not tagged
v0.3.0 waits for the in-headset checklist (STATUS.md) and the user's explicit go.