### PR TITLE
Session 22: cinematics fixed by measurement, fullscreen routing, first-boot fix, head-roll eyes, turn controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,9 @@ To uninstall, delete the two DLLs (restore itsloopyo's backup if you made one).
 1. Load into the game flat first (menus are still flat-screen for now).
 2. Press **F10** to open the mod overlay and click **VR PRESET 1** - one press arms
    everything in the right order: VR pacing, 6DOF camera, motion controllers, controller aim +
-   laser, the viewmodel drive, body-follows-head, and stereo last.
-   **First-ever launch only:** the game checks for a gamepad once at startup, so on a fresh
-   install the motion controllers stay dead until you **restart the game once** after the
-   first preset press (the press itself enables them for every later launch). If you had any
-   physical controller plugged in when the game started, this does not apply.
+   laser, the viewmodel drive, body-follows-head, and stereo last. No restart is ever
+   needed - the mod answers the game's one-shot startup gamepad check itself, so the
+   motion controllers engage the moment the preset is pressed, first launch included.
 3. Quest 3 Touch controls:
 
 | Input | Action |
@@ -82,6 +80,12 @@ Tuning (all in the overlay, all persisted by **"Save preset values"** / `vrprese
 - **Head anchor offsets** - if the camera sits wrong in the body
 - **Per-hand model offsets** - the "Tuning hand: L / R" selector picks which hand the six
   position/rotation sliders edit, so the pistol and the plasmid hand are tuned independently
+- **Turn controls** - "Smooth turn speed" scales the stick turn rate; "Snap turn" replaces
+  smooth turning with discrete steps (angle slider, default 45 deg)
+- **Cinematics** - scripted scenes (the bathysphere descent), the hack minigame, loading
+  screens and FMVs are auto-detected. Cutscenes play as a full stereo projection with
+  head-look by default; untick "Cinematics as stereo projection" to watch them on a big
+  virtual screen instead. Flat 2D screens (hacking, loading) always use the readable screen.
 - **`vrbody off`** - live A/B for the body-follows-head transfer (instant 1:1 by default)
 
 ### The bundled preset (v0.3.0+)

--- a/docs/ENGINE_NOTES.md
+++ b/docs/ENGINE_NOTES.md
@@ -1891,3 +1891,60 @@ Also this round: the user's fixed LEFT-hand calibration (aim trim
 baked as CODE DEFAULTS (their explicit ask); their four live profiles
 rescued to weapons.ini via wsave before anything could drop them (the run
 had not pressed save).
+
+## Session 22 - scripted-camera scenes: the descent's real mechanism (measured flat)
+
+The session-22 plan carried two hypotheses for the bathysphere descent
+("no stereo + fisheye"): (a) scripted cameras bypass eventPlayerCalcView,
+(b) our gfov-130 option write fisheyes a ~75-authored camera. **Both are
+wrong for the descent** - measured on the crash-site save, vrstereo on,
+clean boot, the ride replayed end to end:
+
+- **CalcView keeps firing the whole ride** (heartbeat 150-1100 calls/s,
+  camera loc walking the scripted track), and the view actor stays
+  AShockPlayer - `[b1r] view state:` logs ZERO transitions across the
+  descent, the pause menu, and the hack minigame (one boot-time
+  menu/cutscene -> GAMEPLAY pair is the whole log). Strict-view and
+  CalcView-staleness detectors both MISS this scene class.
+- **The renderer consumes CalcView's camera even mid-scene**: the world
+  pass's cb0 camera position matches the CalcView heartbeat loc to the UU
+  (45542.2/-15444.8/-22293.4 vs 45543.1/-15447.8/-22293.4 at the same
+  second). Eye offsets applied in CalcView DO reach the pixels - the
+  "no stereo" percept is NOT missing disparity at the render level.
+- **The scene renders its OWN FOV and ignores the option**: dump decode
+  mid-ride shows ONE tangent cluster tanH=1.2800 tanV=0.7200 = 104.0 deg
+  at 16:9 in BOTH eye windows while the option int reads 130 (fovaudit
+  mid-ride: option=130, gfovWrite on). Control immediately after arrival:
+  cluster 2.1445/1.2063 = exactly option 130 (the session-21
+  rendered==option result holds for gameplay). The user's persisted
+  option is itself 130, so "restore the saved option" can never fix a
+  scene that does not read the option at all.
+- **Root cause of both user percepts: the projection layer CLAIMS the
+  option-derived FOV (130) over a 104-rendered image.** A 26-deg claim
+  error warps geometry (the "fisheye") and mis-registers the two eyes'
+  reprojection enough to break fusion (the "no stereo" percept) even
+  though pixel-level disparity exists.
+
+**The shipped detector (session 22): the live rendered-FOV watch**
+(core/gfx/hud_capture.cpp): once per present interval the first
+DSV-bound DrawIndexed's VS b0 head (80 bytes) is copied to a tiny staging
+buffer (CopySubresourceRegion, async) and mapped on a LATER present with
+DO_NOT_WAIT (zero stalls); tangents decode from the screen-ray block at
+floats 12..18 (the session-21 layout decode-framedump.ps1 verifies
+offline; both derivations must agree within 2% or the block is ignored).
+`fov_mismatch()` = rendered-vs-option outside +-10%, 3-interval
+hysteresis, transitions logged (`[hud] rendered-fov mismatch ON/off`) -
+session-independent, so the descent is a fully flat-testable repro:
+exactly one ON ~11 s after the lever pull (104.0 vs 130.0), live
+`fovaudit live:` echoes 1.2799/0.7200 age 0 ms mid-ride, one off at
+arrival. The cinematic quad fallback (openxr_runtime on_present_end)
+keys on strict-false OR publish-staleness OR fov_mismatch; the first two
+legs never fired during the descent and stay for menu-attract/true-bypass
+scene classes.
+
+Traps recorded: the descent ride creates a "Welcome to Rapture
+(AutoSave)" at arrival that becomes the NEWEST save - CONTINUE stops
+landing on the crash-site repro save after one replay (it drops to
+second in the LOAD list). A save LOAD produced NO view-state transition
+and NO fov-write OFF/ON churn (strict stayed true through the load
+screen on this box).

--- a/docs/ENGINE_NOTES.md
+++ b/docs/ENGINE_NOTES.md
@@ -2038,3 +2038,18 @@ Harness trap (session 22, marker retirement fallout): nothing pre-arms
 vrinput at boot anymore, and test presses only compose while vrinput is
 ON - boot.ps1 now sends `vrinput on` before its A-press loop; any manual
 boot flow must do the same.
+
+### Session 22 round 3 - imageRect crop NEGATIVE, the unsqueeze blit
+
+The first letterbox fix cropped the projection layer's subImage imageRect
+to the band. IN-HEADSET NEGATIVE (user run, VDXR): the bars stayed
+visible - the runtime did not honor the sub-rect on the projection layer
+(the drive suspension from the same flag worked, so detection was live;
+the crop simply had no visual effect). Replaced with a runtime-agnostic
+mechanism: while the letterbox holds, the eye capture stretches the image
+band across the full swapchain image ITSELF (blit::stretch_band - a
+vs_stretch UV-remap variant of the proven fullscreen-triangle blit, band
+sourced from a backbuffer-desc scratch copy; falls back to the plain
+CopyResource on any failure). One-shot log: `xr: letterbox unsqueeze
+live (band A..B of H)`. Covers projection AND quad modes at once (both
+consume the captured image). Do not retry imageRect crops on VDXR.

--- a/docs/ENGINE_NOTES.md
+++ b/docs/ENGINE_NOTES.md
@@ -2053,3 +2053,32 @@ sourced from a backbuffer-desc scratch copy; falls back to the plain
 CopyResource on any failure). One-shot log: `xr: letterbox unsqueeze
 live (band A..B of H)`. Covers projection AND quad modes at once (both
 consume the captured image). Do not retry imageRect crops on VDXR.
+
+### Session 22 round 4 - flash-native cinematics, the sampler feedback trap, scanner dormancy
+
+- The round-3 "texture-less fills = bars" fingerprint was WRONG (one dump
+  line over-generalized): rendering just those fills in-frame with their
+  raw flash blend states blacked out scene content (the user's "can't see
+  both hands" regression). Superseded by the correct-by-construction rule:
+  while the letterbox holds, the WHOLE flash layer renders in-frame with
+  native state - the frame cannot differ from flat (verified: mid-sequence
+  flat screenshot is vanilla; authored hands + bars composed by the game) -
+  and the unsqueeze crops the bars for the headset. The HUD panel stays
+  empty for the duration (subtitles render in-frame like flat).
+- SAMPLER FEEDBACK TRAP: the letterbox watch originally sampled the
+  backbuffer at the present-detour TAIL - AFTER our own window HUD
+  composite painted panel content into the bar rows. With a FOCUSED
+  session the detector flapped off constantly and most captures reached
+  the eyes unstretched (the "bars still there" headset negatives).
+  letterbox_sample now runs at the detour HEAD: pure game pixels, before
+  overlay/mirror/composite. Rule: any backbuffer-content DETECTOR must
+  sample before our own writers.
+- WEAPON-RESOLVER DORMANCY: on saves with no resolvable weapon (early
+  game, wrench-only) the scan fallback still ran a multi-second full heap
+  walk every ~2048 frames FOREVER (backoff reduced cadence, never
+  stopped) - flat-felt as "the game freezes every couple of seconds";
+  log signature: [b1r] APlayerWeapon scan ... chosen=00000000 on a ~5 s
+  cadence with matching camera-heartbeat gaps. The scanner now goes fully
+  dormant after 3 straight failures; the cheap rig/learned reads keep
+  running and re-arm it. Verified: exactly 3 scans post-load, then a
+  1.000 s heartbeat metronome.

--- a/docs/ENGINE_NOTES.md
+++ b/docs/ENGINE_NOTES.md
@@ -1995,3 +1995,46 @@ flips to a pad glyph) - the restart is gone. The proxy-lane counter
 STAYS at 6 by design (the Steam overlay swallows that lane post-boot;
 it is not a poll-rate oracle). The marker machinery is deleted; the
 orphan vrinput.on file on existing installs is inert.
+
+### Session 22 round 2 - engine-cinematic letterbox (the plasmid FMV class)
+
+The user's "Big Daddy plasmid FMV" report (black bars mid-view + camera
+different from flat) is the ENGINE-CINEMATIC class, dump-decoded on their
+prepared Gatherer's Garden save (the Electro Bolt injection sequence):
+
+- The engine CLEARS the final target to opaque black (ClearRTV 0,0,0,1 -
+  event immediately before the tonemap) and draws the tonemap as a
+  vertically SHRUNKEN quad - full 1920x1080 viewport, shrunk GEOMETRY -
+  leaving the top/bottom of the clear unpainted. The bars are therefore
+  NOT draws (nothing to classify) and the band content is the FULL render
+  anamorphically squeezed (the world pass renders normal full-frame at
+  the option fov - the live watch read 130.0 exact, mismatch=0, through
+  the whole sequence).
+- CalcView keeps firing with strict GAMEPLAY and the AUTHORED camera
+  choreography in loc/rot (heartbeat showed authored ROLL -7773..-8189
+  during the wake-up shot). Pre-fix, the live head drive overwrote that
+  choreography (the user's "camera was different than flat"), and the
+  letterboxed frame projected across the whole claim (bars as floating
+  bands).
+- Sequence anatomy from the live transitions: letterbox ON (165/185 px
+  of 1080) -> full-screen blackout (correctly rejected by the
+  full-black guard: "top 1080") -> ON again (the balcony phase) -> ...
+  The boot attract also letterboxes briefly (222/285 px) - caught and
+  released cleanly.
+
+Shipped: the LETTERBOX WATCH (hud_capture): three 1-px backbuffer columns
+copied to a staging strip per present (async, DO_NOT_WAIT map - the
+fov-watch pattern); a row is "bar" only if EXACTLY black (<=2/255) in all
+three columns; >=4% height each side + rough symmetry + not-full-screen +
+5-interval stability = letterbox, transitions logged. Consumers: the VR
+runtime CROPS the submitted subImage (projection AND quad) to the band -
+the compositor stretches it back to the claimed fov, which exactly
+un-squeezes the anamorphic content (bars gone, geometry correct); the
+camera adapter suspends the LIVE head drive while the letterbox holds
+(authored camera plays, exactly the flat look - eye offsets still apply,
+so the cinematic stays stereo).
+
+Harness trap (session 22, marker retirement fallout): nothing pre-arms
+vrinput at boot anymore, and test presses only compose while vrinput is
+ON - boot.ps1 now sends `vrinput on` before its A-press loop; any manual
+boot flow must do the same.

--- a/docs/ENGINE_NOTES.md
+++ b/docs/ENGINE_NOTES.md
@@ -1948,3 +1948,50 @@ landing on the crash-site repro save after one replay (it drops to
 second in the LOAD list). A save LOAD produced NO view-state transition
 and NO fov-write OFF/ON churn (strict stayed true through the load
 screen on this box).
+
+### Session 22 part 2 - fullscreen-screen fingerprints and the per-kind routing
+
+Dump ground truth for the three misrouted kinds (all `dumpframe full 2`,
+clean boots, resource tables in the dumps):
+
+- **Loading screen**: ~87 non-indexed gameswf draws (flush 0x7B8EB5 in
+  every stack) straight onto the final LDR target, DSV bound but ZERO
+  DrawIndexed in the interval - no world pass, no tonemap, nothing for
+  the session-19 classifier to classify. Renders in-frame = full-FOV in
+  the headset.
+- **Hack minigame**: same family, measured 322 swf draws / 0 DrawIndexed
+  (the intro board; the world pass is fully absent for the whole hack
+  session even though the scene BUILD calls keep running - the build
+  draws nothing). The user's "basically the same as the loading screen"
+  was literally exact. The main menu is this family too (125 draws).
+- **Alcohol-blur composite**: the SECOND non-indexed draw on the tonemap
+  target (right after the tonemap), engine post path (no gameswf flush
+  in its stack), sampling a BACKBUFFER-SIZED texture (1920x1080 RGBA8) -
+  while every real HUD/flash draw samples 2048x2048 BC-compressed UI
+  atlases or nothing. The pre-tonemap 480x270 blur pyramid runs on its
+  own RTs and never touches the classifier.
+
+Shipped discriminators (hud_capture.cpp): screen-only interval =
+swf-draws >= 20 with no scene-vote leader (3-interval hysteresis,
+`[hud] screen-only interval ON/off` transitions - flat instrument);
+in-frame post effect = post-tonemap draw whose srv0 dimensions equal the
+target's (srv desc cache, same 8-slot pattern as the RT desc cache).
+Measured: postFx = 0 across normal gameplay (no false positives); the
+pause menu contributes ~1/interval (its fullscreen dim layer sampling
+the scene - correctly in-frame; the menu PANELS keep redirecting to the
+quad). Loading screens fire exactly one ON/off pair per load (87 and
+120-draw intervals measured on two different loads).
+
+### Session 22 part 3 - the first-boot probe fix, virgin-install measured
+
+compose_over now answers a FAILED slot-0 GetState with a neutral
+CONNECTED pad (constant packet 1) even while vrinput is off. Virgin
+boot (all inis + the old vrinput.on marker set aside): the main menu
+shows NO pad glyphs before any pad input (prompts key on last-used
+input, the session-9 model - the phantom pad alone does not flip them);
+after `vrinput on` mid-session the IAT lane immediately polls at ~680
+calls/s and a dpad press moves the UI (packet 1->3, the 2K-link prompt
+flips to a pad glyph) - the restart is gone. The proxy-lane counter
+STAYS at 6 by design (the Steam overlay swallows that lane post-boot;
+it is not a poll-rate oracle). The marker machinery is deleted; the
+orphan vrinput.on file on existing installs is inert.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -538,6 +538,16 @@ kill. Both prerequisites below are now MET.):**
       sticklog on` logs the FINAL composed pad at 10 Hz (post merge/pitchkill/turn) and
       last_composed_sticks() exists for the recorder; pair with `vrbody probe on` resid
       lines on a real headset walk. The capture + analysis are still open.
+- [ ] **Cinematic letterbox BARS (parked 2026-07-29, session 22 round 5, user's call:
+      ship without, fix next cycle)**: three in-headset rounds failed to remove the
+      bars (VDXR ignores projection imageRect; the capture-side unsqueeze provably
+      executed yet bars stayed - mechanism unresolved). Unsqueeze ships DEFAULT OFF
+      (`vrcine unsqueeze on`). Next tools: dump the EYE SWAPCHAIN content during
+      letterbox, rule out VD-side compositing, tight in-headset A/Bs per toggle.
+- [ ] **Suspend hands/aim/laser drives during cinematics (session 22 round 5)**: with
+      controllers awake the controllable rig overrides the authored cinematic hands
+      (authored hands only showed when the controllers were idle). Gate the drives on
+      the letterbox like the head drive; re-arm on exit.
 - [ ] Better overlay/config UI (user's call 2026-07-27: current UI is good - this is polish
       only: grouping, naming, hiding the debug-only controls behind an advanced toggle)
 - [ ] **World/viewmodel scale SPLIT (parked here 2026-07-27, session 16 part 3, user's

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -502,44 +502,42 @@ kill. Both prerequisites below are now MET.):**
       double-fires. The user play-tested timing the trigger to their swing and it felt
       right, so the gesture only needs to reproduce that timing. Hand poses per frame
       already exist (velocity = dP/dt); keep the trigger working as-is.
-- [ ] **Kill the first-boot restart (user's call 2026-07-28)**: the game latches its
-      one-shot XInput boot probe (6 calls, slot 0, never re-polled - session 9), so a
-      fresh install needs one restart after the first preset press (README notes it).
-      Fix: the wrapper answers the failed probe with success + a neutral zeroed pad, so
-      the game polls forever and `vrinput on` engages instantly, first boot included -
-      then the marker file AND the README note both retire. GATE FIRST with one flat
-      boot: phantom pad connected + vrinput off -> the menu prompts must stay
-      keyboard/mouse (session-9 evidence says prompts key on last-used input, not
-      connectivity; if that is wrong, fall back to flipping the game's latched
-      slot-connected flag instead - the probe call sites are catchable in the wrapper,
-      so the latch is a short disasm hop away).
-- [ ] Snap turn + smooth-turn speed slider (user's call 2026-07-28 post-v0.3.0), height/seated
-      recenter, optional vignette
-- [ ] **Cinematics in VR (user's headline for the next release, 2026-07-28)**: scripted-camera
-      scenes (the bathysphere descent) render WITHOUT stereo and fisheyed. Hypotheses:
-      scripted cameras bypass eventPlayerCalcView (no SR base cache = no per-eye offsets =
-      zero disparity) while the gfov-130 option write still applies to a ~75-deg-authored
-      camera (the fisheye). Direction: on the strict non-gameplay predicate, restore the game
-      FOV and fall back to the big-screen QUAD submission (the M2 path still in
-      on_present_end); re-arm projection on gameplay return. Closes the M3 "cutscene cameras
-      are head-driven" leftover too. User provides a descent save for flat replay.
-- [ ] **Fullscreen flash screens + effects need per-kind routing (user, 2026-07-28; hacking
-      CONFIRMED broken same evening)**: three misrouted kinds today - (a) the HACK minigame
-      and loading screens take the whole FOV ("barely see everything"), unreadable in VR:
-      they belong ON the readable quad like the pause menu; (b) the Big Daddy plasmid FMV
-      plays "in a box" sized by the HUD sliders: belongs on the cinema screen; (c) heavy
-      post-process (alcohol blur) also lands on the quad: belongs IN-FRAME per eye on the
-      camera, not on a HUD panel (the user's exact framing). All three are fullscreen
-      gameswf/tonemap-adjacent draws that hud_capture.cpp currently classifies one way.
-      Flat repros: vending-machine hack near the all-weapons save; drink alcohol for the
-      post-process case.
-- [ ] **Head-ROLL eye separation bug (user report 2026-07-28, root cause confirmed)**:
-      apply_eye_offset builds view-right from YAW ONLY - a rolled head keeps horizontal eye
-      separation = wrong disparity when tilting the head sideways. Fix: offset along the full
-      rotation's right axis (ue_rot_basis), SR + AER paths both.
+- [x] **Kill the first-boot restart** - DONE session 22 (2026-07-29): compose_over answers
+      a failed slot-0 GetState with a neutral connected pad while vrinput is off. Virgin
+      gate PASSED: menu prompts stayed KB/M with the phantom pad idle; `vrinput on`
+      mid-session put the IAT lane at ~680 polls/s with no restart. Marker file + README
+      note retired.
+- [x] Snap turn + smooth-turn speed slider - DONE session 22 (recenter-composite steps
+      carried by the body transfer, +-8192 units exact per 45-deg pulse; turnScale on the
+      composed stick; both persisted + overlay). Height/seated recenter, optional vignette
+      still open:
+- [ ] Height/seated recenter, optional vignette
+- [x] **Cinematics in VR** - DONE session 22 (2026-07-29), and BOTH on-file hypotheses were
+      disproven by measurement: the descent keeps CalcView firing (strict stays GAMEPLAY)
+      and the renderer consumes our camera - it renders its OWN 104-deg fov while the
+      option/claim says 130; the claim mismatch was the whole fisheye/no-fusion percept
+      (ENGINE_NOTES session 22). Shipped: a live rendered-fov watch (per-present cb0
+      tangent decode) + the cinematic fallback keyed on strict-false/staleness/
+      fov-mismatch/screen-only. DEFAULT = stereo projection with the claim fixed to the
+      measured fov (user's call - full stereo cinematics with head-look); the big-screen
+      quad is the overlay/vrcine toggle. In-headset verdict pending.
+- [x] **Fullscreen flash screens + effects per-kind routing** - DONE session 22: (a) hack +
+      loading (and the main menu) are PURE gameswf intervals with the world pass absent
+      (dump-proven 0 DrawIndexed) -> the new screen-only detector drops them to the
+      readable screen; (b) FMV-class screens ride the same leg; (c) the alcohol-blur
+      composite (post-tonemap draw sampling a backbuffer-sized texture) now stays
+      IN-FRAME per eye, never on the panel (postFx=0 false positives in gameplay).
+      In-headset verdict pending (incl. the Big Daddy FMV, no flat repro exists).
+- [x] **Head-ROLL eye separation bug** - DONE session 22: apply_eye_offset offsets along
+      the FULL rotation's right axis (ue_rot_basis) and the AER path shares the one
+      implementation. Eye delta measured (6.3,0,0)/(4.455,0,-4.454)/(0,0,-6.3) UU at
+      roll 0/45/90 - rotates exactly with the head, bit-identical at roll 0.
 - [ ] **Movement wonkiness investigation (user report 2026-07-28, deadzone 0 did not fix)**:
-      instrument first (vrrec a walk; log composed stick vs body yaw per frame), then decide
-      between bodyRate smoothing, a stick response curve, or hardware noise. Do not tune blind.
+      instrument first, then decide between bodyRate smoothing, a stick response curve, or
+      hardware noise. Do not tune blind. *Session 22 shipped the instrument* - `vrinput
+      sticklog on` logs the FINAL composed pad at 10 Hz (post merge/pitchkill/turn) and
+      last_composed_sticks() exists for the recorder; pair with `vrbody probe on` resid
+      lines on a real headset walk. The capture + analysis are still open.
 - [ ] Better overlay/config UI (user's call 2026-07-27: current UI is good - this is polish
       only: grouping, naming, hiding the debug-only controls behind an advanced toggle)
 - [ ] **World/viewmodel scale SPLIT (parked here 2026-07-27, session 16 part 3, user's

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -179,6 +179,36 @@ scroll behavior, and their controller cross-check. After the release: the
 CLEAN-MACHINE new-user flow session (user's ask - wipe, install from the
 release zip, fix whatever breaks until out-of-box works).
 
+### Session 22 round 5 (2026-07-29, pre-release) - LETTERBOX BARS PARKED OPEN, user's call
+
+Three in-headset rounds could not remove the cinematic letterbox bars
+(imageRect crop ignored by VDXR; the capture-side unsqueeze executed -
+`unsqueeze live` logged - but the user still saw bars; mechanism
+UNRESOLVED). The user called STOP: ship the release, tackle the bars next
+cycle. Shipping posture: the unsqueeze is DEFAULT OFF (`vrcine unsqueeze
+on` = the experiment lever); the letterbox DETECTOR, the authored-camera
+drive suspension and the flash-native in-frame rendering stay live (the
+parts the user verified; the flat frame is pixel-vanilla by construction).
+
+**Two documented open items for the next release:**
+1. **The bars themselves** - where do the user-visible bars actually come
+   from with the unsqueeze provably drawing? Next tools: capture the eye
+   swapchain content (not the backbuffer) during letterbox; check whether
+   VD's own compositing letterboxes; A/B `vrhud off` + `vrcine unsqueeze
+   on|off` in-headset with 30 s verdicts per toggle.
+2. **Hands drive during cinematics** - the user sees the CONTROLLABLE rig
+   hands instead of the authored cinematic hands whenever the controllers
+   are awake (the run where authored hands showed = controllers idle in
+   the lap; not a build regression). Fix: suspend the hands/aim/laser
+   drives while the letterbox holds, exactly like the head drive.
+
+Also fixed this round (user-found while flat-playing): the weapon
+resolver's scan fallback froze the game for seconds every ~2000 frames
+FOREVER on weaponless saves (early game) - now fully dormant after 3
+failures, re-armed by the cheap rig reads (3 scans then a 1.000 s
+heartbeat metronome, measured). This was the "game freezes every couple
+of seconds" report and it is exactly the new-user first-hour path.
+
 ## Previous state (2026-07-28, session 21 - RENDER SYNC: the fov audit came back clean, the fg scene decoded down to its ctor args, the fovA zoom-pull lever found, per-weapon profiles shipped - branch s21-render-sync)
 
 **Branch `s21-render-sync` off main (post-PR-#5). Three flat-gated commits:

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -124,6 +124,61 @@ analysis next session. Do not tune blind.
   SKIPS toward the crash - recover via the pause menu LOAD instead.
 - The old vrinput.on marker no longer pre-arms anything (code deleted).
 
+### Session 22 round 2 (same night) - THE HEADSET FEEDBACK ROUND
+
+**The user's verdicts, run 1:** no regression; stereo cinematics "amazing"
+(104-not-130 understood and accepted); alcohol blur "perfect"; hacking
+"amazing, works as intended" after the same-night head-lock fix (the first
+try was world-locked at the recenter facing - screen-only intervals now
+ride the head-locked view space like the pause panel); head-roll fixed;
+turn controls "perfect". Movement wonkiness ROOT-CAUSED BY THE USER: their
+controller's up+right stick diagonal is dead (all other directions fine;
+mod stick path audited clean - deadzone/clamp direction-agnostic); they
+will cross-check the hardware with another tester/game. Remaining asks all
+landed the same night:
+
+1. **The "Big Daddy plasmid FMV" class = ENGINE-CINEMATIC LETTERBOX**,
+   dump-decoded on their prepared Gatherer's Garden save: the engine
+   clears the final target opaque-black and tonemaps the scene into a
+   vertically SHRUNKEN quad - bars are unpainted clear (nothing to
+   classify), content is anamorphically squeezed, world renders full
+   130 (mismatch=0), CalcView stays strict-GAMEPLAY with the AUTHORED
+   camera choreography. Shipped the LETTERBOX WATCH (3-column exact-black
+   backbuffer sampling, async staging, 5-interval stability, full-black
+   fade guard) + two consumers: the submitted subImage (projection AND
+   quad) CROPS to the band - the compositor unsqueezes, bars gone,
+   geometry correct - and the live head drive SUSPENDS while the
+   letterbox holds (authored camera plays like flat; eye offsets stay =
+   stereo cinematics). Flat gates: the injection sequence's phases
+   tracked exactly (ON 165/185 px -> blackout REJECTED via the full-black
+   guard -> ON -> final off), boot attract caught/released (222/285),
+   90 s+ post-sequence gameplay soak with zero false positives, dumps 9.
+2. **The user's new L-hand calibration rescued via `vrpreset save`**
+   (they had not pressed save) and BAKED as code defaults: trim
+   -7.5/+37.0 (offsets unchanged). Their turn prefs (scale 2.56, snap on,
+   45 deg) persisted to their ini (not baked - shipped defaults stay
+   1.0/off/45).
+3. **Laser OFF by default + preset**: the preset no longer arms it; the
+   persisted `laserOn` ini key (written by "Save preset values") applies
+   the user's choice, so opting back in sticks. Virgin default = off.
+4. **F10 overlay hardening** (user: overlay vanished while scrolling,
+   dead until alt-tab): (a) backbuffer-identity watch recreates the RTV
+   when the game swaps buffers without ResizeBuffers (the "invisible
+   overlay, F10 toggles nothing visible" state); (b) the WndProc now
+   CONSUMES mouse/keyboard messages while ImGui wants them (the game was
+   fighting the overlay for the wheel/clicks); (c) new `vroverlay on|off`
+   seam = remote/emergency toggle. Root cause unconfirmed (not flat-
+   reproducible on demand) - the user re-checks scrolling next run.
+5. **Harness trap from the marker retirement**: nothing pre-arms vrinput
+   at boot and test presses only compose while it is ON - boot.ps1 now
+   sends `vrinput on` before its A-press loop (it timed out otherwise).
+
+**Still open before the release**: the user's in-headset re-verify of the
+letterbox class (their prepared save; both cinematic modes), the overlay
+scroll behavior, and their controller cross-check. After the release: the
+CLEAN-MACHINE new-user flow session (user's ask - wipe, install from the
+release zip, fix whatever breaks until out-of-box works).
+
 ## Previous state (2026-07-28, session 21 - RENDER SYNC: the fov audit came back clean, the fg scene decoded down to its ctor args, the fovA zoom-pull lever found, per-weapon profiles shipped - branch s21-render-sync)
 
 **Branch `s21-render-sync` off main (post-PR-#5). Three flat-gated commits:

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1889,6 +1889,11 @@ stereo|quad`), `vrcine off`, `vrhud off`, `vrinput snap on|off`.
    the board must now sit on the READABLE screen (not sprayed across
    the FOV). Loading screens same. Main menu after quit-to-menu: also
    on the screen - confirm it is navigable by controller.
+   *Headset round 1 (2026-07-29): worked but the screen was world-locked
+   at the recenter facing - the user had to turn back to it. FIXED same
+   night: screen-only intervals now ride the HEAD-LOCKED view space
+   (like the pause panel), centered wherever you look; cinematic scenes
+   keep the world-locked screen. Re-verify.*
 4. **THE BIG DADDY FMV** (when you next pass one - no flat repro): it
    should land on the screen, not in the small HUD box. Report either
    way.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,7 +2,129 @@
 
 > Handoff file. Rewrite "Current state" and "Next steps" every session; append to the session log.
 
-## Current state (2026-07-28, session 21 - RENDER SYNC: the fov audit came back clean, the fg scene decoded down to its ctor args, the fovA zoom-pull lever found, per-weapon profiles shipped - branch s21-render-sync)
+## Current state (2026-07-29, session 22 - CINEMATICS + FULLSCREEN ROUTING: the descent's real mechanism measured (both hypotheses wrong), live rendered-fov watch, stereo cinematics default, screen-only routing, first-boot restart killed, head-roll eyes, turn controls - branch s22-vr-polish)
+
+**Branch `s22-vr-polish` off main (post-v0.3.0). Two flat-gated feature
+commits + docs. Everything below is flat-verified on clean boots; the
+in-headset checklist at the bottom is the open gate for the next release
+(the user cuts it only after their manual test + explicit go).**
+
+### 1. CINEMATICS (plan item 1) - both on-file hypotheses DISPROVEN, the real fix shipped
+
+Measured on the user's crash-site save (two full descent replays,
+vrstereo on): **CalcView keeps firing the whole ride with a ShockPlayer
+view actor** (zero `view state` transitions - strict/staleness detectors
+never fire), **the renderer consumes our camera writes mid-scene** (world
+cb0 camera == CalcView heartbeat loc to the UU), and **the scene renders
+its OWN fov - 104.0 deg - while the option (and the projection claim)
+says 130** (dump decode: one tangent cluster 1.2800/0.7200 both eyes;
+control after arrival: exactly 2.1445/1.2063 = option 130). The 26-deg
+claim-over-render mismatch IS the fisheye AND the broken fusion. Full
+story + traps in ENGINE_NOTES session 22.
+
+Shipped (commit 9a85856): a **live rendered-fov watch** in hud_capture
+(per-present cb0 tangent decode off the first scene draw - async 80-byte
+staging copy, DO_NOT_WAIT map, zero stalls; `[hud] rendered-fov mismatch
+ON/off` transitions; `fovaudit live:` echo) and the **cinematic
+fallback** in on_present_end: predicate = strict-false | publish-stale |
+fov-mismatch | screen-only, 3-present hysteresis, `vrcine
+on|off|mode|status` + counters. While active: projection drops to the M2
+quad screen, eye offsets + live head drive suppress (renderer consumes
+them mid-scene - dump-proven, so the quad would jitter otherwise), the
+HUD quad/laser/HUD-gate all self-adjust per present. The FOV write is
+strict-gated with a BuildDetour-side restore for true CalcView-silent
+scenes; SR pass-2 gained a 100 ms base-age gate (stale-replay hazard).
+**DEFAULT = `mode stereo` (the user's call): fov-mismatch scenes KEEP the
+stereo projection and the claim follows the MEASURED fov - full stereo
+cinematics with head-look; the overlay toggle "Cinematics as stereo
+projection (off = big screen)" is the in-headset A/B.** Flat gates: one
+mismatch ON at the lever pull (104.0 vs 130.0), one off at arrival, live
+tangents == dump decode to 1e-4 in both states, zero false transitions
+across pause/loads, heartbeat 2x clean, dumps 9->9.
+
+### 2. FULLSCREEN SCREENS/EFFECTS (plan items 2+7) - per-kind routing, dump-grounded
+
+Evidence (dumps on file, fingerprints in ENGINE_NOTES): loading screens
+= ~87 pure-gameswf draws with ZERO DrawIndexed (no world pass, nothing
+classifies - hence full-FOV in headset); the HACK minigame = same family
+(322 draws, 0 DrawIndexed; the user's "same as the loading screen" was
+exact; the main menu = 125); the alcohol-blur composite = the second
+post-tonemap draw sampling a BACKBUFFER-SIZED texture from the engine
+post path, vs HUD draws sampling 2048x2048 BC atlases.
+
+Shipped (commit e4425e6): **screen-only interval detector** (swf draws
+with no scene-vote leader, hysteresis + logged transitions) feeding the
+cinematic fallback - hack/loading/menu/FMV-class screens go to the
+READABLE quad screen regardless of the stereo/quad mode; **in-frame
+post-effect skip** (post-tonemap draw with backbuffer-sized srv0 never
+redirects - srv desc cache, `postFx` counter in vrhud status). Flat
+gates: two save-loads produced exactly one screen-only ON/off pair each
+(87/120-draw intervals); the live hack board fired the detector with the
+user at the machine; postFx = 0 across normal gameplay (zero false
+positives), ~1/interval on the pause menu = its fullscreen DIM layer
+(correctly in-frame - the menu PANELS keep redirecting; flagged on the
+in-headset list as a look-check). The Big Daddy FMV has no flat repro -
+its routing verdict is on the headset checklist.
+
+### 3. FIRST-BOOT RESTART KILLED (plan item 3) - virgin-install gate PASSED
+
+compose_over answers a failed slot-0 GetState with a neutral CONNECTED
+pad while vrinput is off; the vrinput.on marker machinery is deleted
+(the orphan file is inert) and the README restart note is gone. Virgin
+boot (all inis + marker set aside, restored byte-verified after): main
+menu shows NO pad glyphs with the phantom pad idle (prompts key on
+last-used input - the session-9 model held); `vrinput on` mid-session
+put the IAT lane at ~680 polls/s instantly and a dpad press moved the UI
+- no restart. TRAP for counter-readers: the proxy-lane getstate[0]
+counter stays at 6 FOREVER by design (Steam overlay swallows that lane
+post-boot) - it is not a poll oracle; the IAT counter is.
+
+### 4. HEAD-ROLL EYE SEPARATION FIXED (plan item 4) - exact
+
+apply_eye_offset now offsets along the FULL rotation's right axis
+(ue_rot_basis); the AER path shares the one implementation. Flat gate
+(`fovaudit eyes`, simhead roll sweep): eye delta (6.300, 0, 0) at roll
+0 (bit-identical to the old formula by construction), (4.455, 0,
+-4.454) at 45, (0.000, 0, -6.300) at 90 - the separation rotates
+exactly with the head.
+
+### 5. TURN CONTROLS SHIPPED (plan item 5) - exact
+
+Smooth-turn scale on the composed stick X (pitchkill gate cluster -
+gameplay only, lifts in radials) + snap turn (0.65/0.30 edge hysteresis
+-> queued steps consumed at the camera's transfer point: recenter
+composite shifts, the M7.5 transfer carries the body). Flat gates: +1
+then -1 pulse moved camYaw 49152->57344->49152 = +-8192 units (+-45.00
+deg) EXACT round-trip, ONE step per pulse even on a 2 s full deflection;
+turnscale 2.0 turned test rx 8000 into composed 16000 exact. Knobs
+turnScale/snapTurn/snapAngleDeg persisted in vrpreset.ini + overlay
+("Smooth turn speed", "Snap turn", "Snap angle").
+
+### 6. MOVEMENT-WONKINESS INSTRUMENT (plan item 6) - shipped, investigation OPEN
+
+`vrinput sticklog on` logs the FINAL composed pad (post
+merge/pitchkill/turn) at 10 Hz; `last_composed_sticks()` exists for the
+recorder. The real capture wants a HEADSET walk (composed stick vs
+`vrbody probe on` resid lines) - flat synthetic sticks cannot reproduce
+controller noise or head-micro-steering. Queued on the checklist;
+analysis next session. Do not tune blind.
+
+### Session-22 harness notes (new traps)
+
+- **The descent ride WRITES a "Welcome to Rapture (AutoSave)"** that
+  becomes the newest save: after one replay, CONTINUE lands at the
+  arrival dock, NOT the crash-site repro (it drops to second in LOAD).
+- A save LOAD produces NO view-state transition and NO fov-write churn
+  (strict stays true through load screens on this box); loading screens
+  show up as screen-only ON/off pairs instead.
+- Flat fire tests need a pose source: with simhead/aim-test lanes
+  expired the fire seam counts skips (correct fail-soft), not subs -
+  re-arm `simhead` + `vraim test r` before counting subs.
+- The plane-intro trap refined: pressing START during the wallet scene
+  SKIPS toward the crash - recover via the pause menu LOAD instead.
+- The old vrinput.on marker no longer pre-arms anything (code deleted).
+
+## Previous state (2026-07-28, session 21 - RENDER SYNC: the fov audit came back clean, the fg scene decoded down to its ctor args, the fovA zoom-pull lever found, per-weapon profiles shipped - branch s21-render-sync)
 
 **Branch `s21-render-sync` off main (post-PR-#5). Three flat-gated commits:
 the FOV audit (negative result + permanent instruments), the fg scene-node
@@ -1613,75 +1735,26 @@ retired: xr_hello32 (32-bit) ran a complete OpenXR session on VDXR 1.0.10 with t
 (60 frames, RTX 4060 LUID match) - M2 is unblocked. DR-2 done. Repo public at
 https://github.com/mohamad-balouza/bioshock-vr. Em dashes banned repo-wide.
 
-## Next steps (SESSION 22 PLAN, user's list 2026-07-28 post-v0.3.0; order = their priority: cinematics first, then the smalls; new release after the cinematic/aim-adjacent fixes)
+## Next steps (post-session-22; the release gate is the in-headset checklist below)
 
-1. **CINEMATICS (the user's headline - "big issue for everyone").**
-   Symptom: the bathysphere descent (and other scripted-camera scenes)
-   renders WITHOUT stereo and fisheyed. Working hypotheses, both
-   code-grounded: (a) scripted cameras do not flow through
-   eventPlayerCalcView, so `g_srBaseValid` never arms - pass 2 gets no
-   eye offset = ZERO disparity while the pair still submits as a
-   projection layer; (b) our per-frame option write (gfov 130) still
-   applies to a camera authored for ~75 = the fisheye. Fix direction:
-   the strict non-gameplay predicate already exists (body/camera.cpp) -
-   when it drops, RESTORE the game FOV and fall back to the BIG-SCREEN
-   QUAD path (the M2 machinery still in on_present_end - projectionMode
-   false = quad) so cutscenes play on a comfortable virtual screen;
-   re-arm projection on gameplay return. The M3 leftover "cutscene
-   cameras are head-driven" closes with the same lever. THE USER'S SAVE
-   IS READY: the NEWEST save ("crash site") spawns next to the lever
-   that starts the descent - NOTE this means CONTINUE now lands there,
-   NOT at the all-weapons Medical Pavilion anchor (that one is second in
-   the LOAD list).
-2. **FULLSCREEN EFFECTS MISCLASSIFIED AS HUD (user item 8).** The Big
-   Daddy plasmid FMV plays "in a box" whose size follows the HUD sliders
-   = it is being captured by the HUD redirect onto the quad; heavy
-   post-process effects (alcohol blur) do the same. Root cause: they are
-   gameswf/fullscreen draws on the tonemap target after the tonemap =
-   exactly the current HUD classification (hud_capture.cpp). Fix:
-   classify FULLSCREEN-covering draws (viewport-sized geometry) as
-   in-frame effects - leave them in the game frame (per-eye, correct for
-   post effects) instead of redirecting to the quad; FMVs ideally join
-   the item-1 cinema-screen path. Flat repro exists without a cutscene:
-   drink alcohol (the save has bars nearby) and diff the classification.
-3. **First-boot restart fix (user item 1).** The game samples gamepad
-   presence once at startup; on a pad-free machine the first-ever boot
-   has dead controllers until a restart after the preset press. Fix
-   candidate: the xinput proxy answers slot 0 CONNECTED (neutral state)
-   from the very first query even before vrinput arms (passthrough when
-   a real pad exists). core/input/xinput_bridge.cpp.
-4. **Head-ROLL eye separation (user item 7, root cause CONFIRMED in
-   code).** `apply_eye_offset` (camera.cpp) builds view-right from YAW
-   ONLY - with the head rolled, real eyes stack vertically but the
-   virtual eyes stay horizontal = the "weird stereoscopy when turning
-   the head sideways". Fix: offset along the FULL rotation's right axis
-   (ue_rot_basis), both the SR and AER paths.
-5. **Smooth-turn speed slider + snap turn (user item 4).** Slider =
-   scale composed stick X in the input bridge. Snap = consume stick-X
-   edges and shift the recenter composite by N deg (the vrbody transfer
-   then carries the body instantly - the machinery exists); persisted
-   knobs + overlay controls.
-6. **Movement wonkiness investigation (user item 5).** Feels wonky even
-   at deadzone 0. Suspects: deadzone 0 itself (body now steers on every
-   head micro-motion - the cure may be a small bodyRate smoothing, knob
-   exists), the game's own stick response on composed values, or real
-   controller noise. Instrument first: vrrec a walk + log composed
-   stick vs body yaw; then tune, do not guess.
-7. **Hacking in VR - CONFIRMED BROKEN (user tested 2026-07-28 evening).**
-   NOT on the readable quad like shopping/pause: the hack minigame takes
-   the WHOLE FOV, "basically the same as the loading screen", barely
-   visible. Same misclassification family as item 2 above (fullscreen
-   flash screens) - fix them together: hack screen + loading screens +
-   FMVs belong on the readable quad/cinema screen, post-process effects
-   belong in-frame. Repro: the all-weapons save, short walk to the
-   vending machine.
-8. **Hands offset sliders (user item 6)**: already shipped ("Tuning
-   hand: L / R" six per-hand sliders + hands.ini persistence). Verify
-   presence/usability in-headset, nothing to build.
-
-Then (unchanged queue): pawn-eye anchoring, off-hand tracking +
-two-handed weapons, wrench gesture. The fovaudit-submit/poseaudit glance
-remains a free 30 s check on any headset run.
+1. **THE IN-HEADSET RUN (the release gate).** Everything in the
+   session-22 checklist below; headline verdicts: stereo cinematics vs
+   big screen (the overlay toggle - user picks the default that stays),
+   the hack/loading screens on the readable screen, the Big Daddy FMV
+   routing (no flat repro existed), alcohol blur in-frame, head-roll
+   stereo, snap/smooth turn feel. The next release cuts ONLY after the
+   user's explicit go.
+2. **Movement-wonkiness capture + analysis (instrument shipped, data
+   missing).** On a real headset walk: `vrinput sticklog on` + `vrbody
+   probe on` (+ optionally `vrrec start/stop`), walk + look for ~60 s,
+   send the log. Then decide bodyRate smoothing vs stick curve vs
+   hardware noise from the numbers - not blind.
+3. **If a scene class surfaces that defeats all four cinematic legs**
+   (strict/stale/fov-mismatch/screen-only): grab `dumpframe full 2` +
+   `vrcine status` during it - the counters + fingerprints classify it.
+4. Then (unchanged queue): pawn-eye anchoring, off-hand tracking +
+   two-handed weapons, wrench gesture. The fovaudit-submit/poseaudit
+   glance remains a free 30 s check on any headset run.
 
 **POLISH / POST-POLISH (user's call 2026-07-28 part 3 - explicitly not
 gameplay-critical):**
@@ -1788,7 +1861,59 @@ Carried-over backlog (numbering kept from session 17):
 13. **Parked in M9** (user's call 2026-07-24): IPD slider verification, small
     head-motion bobbing, the vrstereo off/re-arm state bug, HUD-in-both-eyes.
 
-### IN-HEADSET CHECKLIST - render sync + per-weapon profiles (session 21)
+### IN-HEADSET CHECKLIST - cinematics + routing + polish (session 22)
+
+Setup as always: Quest 3 + Virtual Desktop (VDXR), launch from Steam.
+**SAVE TRAP: CONTINUE now lands on the "Welcome to Rapture (AutoSave)"
+from the flat descent replays - your crash-site save is SECOND in LOAD,
+Medical Pavilion third.** Press **VR PRESET 1**. Live A/Bs: the
+"Cinematics as stereo projection" overlay checkbox (= `vrcine mode
+stereo|quad`), `vrcine off`, `vrhud off`, `vrinput snap on|off`.
+
+1. **Non-regression sweep (60 s, first).** Park the hand, look around,
+   stick-walk, turn past 90 both ways, two right-trigger pulls + an
+   Electro Bolt, pause menu once. NOTE the pause menu changed slightly
+   BY DESIGN: its fullscreen DIM layer now stays in the world (per eye)
+   while the panels stay on the readable quad - report if it reads
+   worse than before.
+2. **THE DESCENT (the headline).** Load "The Crash Site", pull the
+   lever, ride down TWICE - once per cinematic mode:
+   (a) DEFAULT stereo mode: the ride should be full stereo WITH
+   head-look and NO fisheye (the claim now follows the measured 104);
+   (b) untick "Cinematics as stereo projection": the ride plays on the
+   big virtual screen instead (world-locked, sized by the old Screen
+   distance/width sliders). PICK THE DEFAULT YOU WANT - one checkbox,
+   tell me the verdict. The log echoes `xr: cinematic quad ON/off` and
+   `[hud] rendered-fov mismatch ON/off` for me either way.
+3. **THE HACK (your confirmed-broken case).** Hack the vending machine:
+   the board must now sit on the READABLE screen (not sprayed across
+   the FOV). Loading screens same. Main menu after quit-to-menu: also
+   on the screen - confirm it is navigable by controller.
+4. **THE BIG DADDY FMV** (when you next pass one - no flat repro): it
+   should land on the screen, not in the small HUD box. Report either
+   way.
+5. **Alcohol blur:** drink something - the blur must be IN the world
+   (both eyes, on the camera), not on the HUD panel.
+6. **HEAD ROLL:** tilt your head to a shoulder while looking at
+   near-field geometry - stereo should stay comfortable/fused (pre-fix
+   it went weird sideways).
+7. **TURN CONTROLS:** feel the "Smooth turn speed" slider; then "Snap
+   turn" on - discrete 45-deg steps, one per flick, hands/body carried
+   exactly (no drift, no double-steps). Adjust the angle slider to
+   taste; "Save preset values" persists all three.
+8. **First-boot sanity (already virgin-gated flat):** controllers came
+   alive with the preset on THIS boot with no restart - just confirm
+   nothing about controller pickup felt different.
+9. **Hands offset sliders (verify-only):** "Tuning hand: L / R" + six
+   sliders exist and move the model per hand (shipped session 18).
+10. **The wonkiness capture (2 min, for next session):** `vrinput
+    sticklog on` + `vrbody probe on`, walk around normally ~60 s,
+    `vrinput sticklog off`. That log is next session's analysis input.
+11. **Anything off:** `vrcine off` kills the whole cinematic layer;
+    `vrhud force off` + `vrhud on` resets the HUD path; if a symptom
+    survives both, it predates this session.
+
+### PREVIOUS CHECKLIST - render sync + per-weapon profiles (session 21)
 
 Setup as always: Quest 3 + Virtual Desktop (VDXR), launch from Steam,
 CONTINUE = the NG+ Medical Pavilion anchor (TRAP: if the game boots into
@@ -2121,6 +2246,43 @@ and it resumes.
   (install.ps1 backs theirs up automatically).
 
 ## Session log (newest first)
+
+### 2026-07-29 - Session 22 (cinematics measured + fixed, fullscreen routing, first-boot fix, head-roll eyes, turn controls)
+
+- CINEMATICS (plan item 1): BOTH on-file hypotheses disproven by
+  measurement on the user's crash-site save (CalcView fires all ride,
+  strict stays GAMEPLAY, renderer consumes our camera to the UU) - the
+  real defect is the scene rendering its OWN 104-deg fov under a 130
+  claim. Shipped the live rendered-fov watch (per-present cb0 tangent
+  decode in hud_capture, zero-stall staging) + the cinematic fallback
+  (strict/stale/fov-mismatch/screen-only legs, hysteresis, vrcine seam +
+  overlay). Default = STEREO cinematics with the claim fixed to the
+  measured fov (user's call mid-session); big screen = the toggle. Two
+  descent replays flat-green. ENGINE_NOTES has the full derivation.
+- FULLSCREEN ROUTING (items 2+7): dumps fingerprinted all three kinds -
+  hack board = 322 gameswf draws / ZERO DrawIndexed (world absent),
+  loading = 87, alcohol blur = post-tonemap draw sampling a
+  backbuffer-sized texture. Shipped the screen-only interval detector
+  (-> readable screen) + the in-frame post-effect skip (srv0-size
+  discriminator; postFx=0 false positives). Live hack board verified
+  with the user at the machine; BD FMV verdict is on the headset list.
+- FIRST-BOOT RESTART (item 3): compose_over answers the dead boot probe
+  with a neutral connected pad; marker machinery deleted; README note
+  gone. Virgin-install gate PASSED (KB/M prompts untouched; IAT lane
+  ~680 polls/s after mid-session vrinput on; dpad moved the menu).
+- HEAD-ROLL EYES (item 4): apply_eye_offset -> full-rotation right axis
+  (ue_rot_basis), AER path unified. Eye delta rotates exactly with roll
+  (6.3/4.455/0 lateral at 0/45/90 deg), bit-identical at roll 0.
+- TURN CONTROLS (item 5): smooth-turn scale + snap turn (recenter-
+  composite steps via the body transfer). +-8192-unit exact steps, one
+  per pulse; scale 2.0 -> composed rx exact. Persisted + overlay.
+- WONKINESS (item 6): instrument shipped (sticklog + accessor); the
+  headset capture + analysis queued.
+- Harness: descent replays create a Welcome-to-Rapture AutoSave (CONTINUE
+  moved!); loads show as screen-only pairs, no view-state/fov churn;
+  fire tests need sim lanes re-armed or subs read as skips; user preset
+  inis backed up (backup-s22-20260728, sha256) and restored byte-exact
+  after the virgin test.
 
 ### 2026-07-28 - Session 21 (render sync: fov audit clean, the fg scene decoded, the fovA lever, per-weapon profiles)
 

--- a/src/core/framework/framework.h
+++ b/src/core/framework/framework.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define BVR_VERSION "0.1.0"
+#define BVR_VERSION "0.4.0"
 
 namespace bvr::framework {
 

--- a/src/core/gfx/blit.cpp
+++ b/src/core/gfx/blit.cpp
@@ -10,6 +10,7 @@ namespace {
 const char* kShader = R"(
 Texture2D tex0 : register(t0);
 SamplerState samp0 : register(s0);
+cbuffer StretchCB : register(b0) { float4 uvRemap; } // x = vOffset, y = vScale
 struct VSOut { float4 pos : SV_Position; float2 uv : TEXCOORD0; };
 VSOut vs_main(uint id : SV_VertexID) {
     // Fullscreen triangle, no vertex buffer.
@@ -17,6 +18,15 @@ VSOut vs_main(uint id : SV_VertexID) {
     float2 uv = float2((id << 1) & 2, id & 2);
     o.pos = float4(uv * float2(2, -2) + float2(-1, 1), 0, 1);
     o.uv = uv;
+    return o;
+}
+// Session 22: sample only a horizontal BAND of the source, stretched across
+// the full destination (the engine-cinematic letterbox unsqueeze).
+VSOut vs_stretch(uint id : SV_VertexID) {
+    VSOut o;
+    float2 uv = float2((id << 1) & 2, id & 2);
+    o.pos = float4(uv * float2(2, -2) + float2(-1, 1), 0, 1);
+    o.uv = float2(uv.x, uvRemap.x + uv.y * uvRemap.y);
     return o;
 }
 float4 ps_main(VSOut i) : SV_Target {
@@ -35,6 +45,8 @@ float4 ps_process(VSOut i) : SV_Target {
 )";
 
 ID3D11VertexShader* g_vs = nullptr;
+ID3D11VertexShader* g_vsStretch = nullptr;
+ID3D11Buffer* g_stretchCb = nullptr;
 ID3D11PixelShader* g_ps = nullptr;
 ID3D11PixelShader* g_psProcess = nullptr;
 ID3D11BlendState* g_blend = nullptr;
@@ -51,11 +63,14 @@ bool ensure_pipeline(ID3D11DeviceContext* ctx) {
     if (!dev) return false;
 
     ID3DBlob* vsb = nullptr;
+    ID3DBlob* vstb = nullptr;
     ID3DBlob* psb = nullptr;
     ID3DBlob* ppb = nullptr;
     ID3DBlob* err = nullptr;
     bool ok = SUCCEEDED(D3DCompile(kShader, strlen(kShader), nullptr, nullptr, nullptr,
                                    "vs_main", "vs_4_0", 0, 0, &vsb, &err)) &&
+              SUCCEEDED(D3DCompile(kShader, strlen(kShader), nullptr, nullptr, nullptr,
+                                   "vs_stretch", "vs_4_0", 0, 0, &vstb, &err)) &&
               SUCCEEDED(D3DCompile(kShader, strlen(kShader), nullptr, nullptr, nullptr,
                                    "ps_main", "ps_4_0", 0, 0, &psb, &err)) &&
               SUCCEEDED(D3DCompile(kShader, strlen(kShader), nullptr, nullptr, nullptr,
@@ -63,11 +78,22 @@ bool ensure_pipeline(ID3D11DeviceContext* ctx) {
     if (ok)
         ok = SUCCEEDED(dev->CreateVertexShader(vsb->GetBufferPointer(), vsb->GetBufferSize(),
                                                nullptr, &g_vs)) &&
+             SUCCEEDED(dev->CreateVertexShader(vstb->GetBufferPointer(), vstb->GetBufferSize(),
+                                               nullptr, &g_vsStretch)) &&
              SUCCEEDED(dev->CreatePixelShader(psb->GetBufferPointer(), psb->GetBufferSize(),
                                               nullptr, &g_ps)) &&
              SUCCEEDED(dev->CreatePixelShader(ppb->GetBufferPointer(), ppb->GetBufferSize(),
                                               nullptr, &g_psProcess));
+    if (ok) {
+        D3D11_BUFFER_DESC cbd{};
+        cbd.ByteWidth = 16;
+        cbd.Usage = D3D11_USAGE_DYNAMIC;
+        cbd.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+        cbd.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+        ok = SUCCEEDED(dev->CreateBuffer(&cbd, nullptr, &g_stretchCb));
+    }
     if (vsb) vsb->Release();
+    if (vstb) vstb->Release();
     if (psb) psb->Release();
     if (ppb) ppb->Release();
     if (err) {
@@ -116,9 +142,11 @@ namespace {
 
 bool draw_internal(ID3D11DeviceContext* ctx, ID3D11RenderTargetView* dst,
                    ID3D11ShaderResourceView* src, UINT dstW, UINT dstH,
-                   ID3D11PixelShader* ps, ID3D11BlendState* blend) {
+                   ID3D11PixelShader* ps, ID3D11BlendState* blend,
+                   ID3D11VertexShader* vs = nullptr) {
     if (!ctx || !dst || !src || !dstW || !dstH) return false;
     if (!ensure_pipeline(ctx)) return false;
+    if (!vs) vs = g_vs;
 
     // Backup the slices of state we touch (the game re-binds most of this per
     // frame, but the present chain must be transparent regardless).
@@ -141,6 +169,8 @@ bool draw_internal(ID3D11DeviceContext* ctx, ID3D11RenderTargetView* dst,
     ID3D11PixelShader* oldPs = nullptr;
     ctx->VSGetShader(&oldVs, nullptr, nullptr);
     ctx->PSGetShader(&oldPs, nullptr, nullptr);
+    ID3D11Buffer* oldVsCb = nullptr;
+    ctx->VSGetConstantBuffers(0, 1, &oldVsCb); // the engine lives in VS b0
     ID3D11ShaderResourceView* oldSrv = nullptr;
     ctx->PSGetShaderResources(0, 1, &oldSrv);
     ID3D11SamplerState* oldSamp = nullptr;
@@ -161,7 +191,8 @@ bool draw_internal(ID3D11DeviceContext* ctx, ID3D11RenderTargetView* dst,
     ctx->RSSetViewports(1, &vp);
     ctx->IASetInputLayout(nullptr);
     ctx->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    ctx->VSSetShader(g_vs, nullptr, 0);
+    ctx->VSSetShader(vs, nullptr, 0);
+    if (vs == g_vsStretch) ctx->VSSetConstantBuffers(0, 1, &g_stretchCb);
     ctx->PSSetShader(ps, nullptr, 0);
     ctx->PSSetShaderResources(0, 1, &src);
     ctx->PSSetSamplers(0, 1, &g_sampler);
@@ -173,6 +204,7 @@ bool draw_internal(ID3D11DeviceContext* ctx, ID3D11RenderTargetView* dst,
     ctx->RSSetState(oldRaster);
     if (nVp) ctx->RSSetViewports(1, &oldVp);
     ctx->VSSetShader(oldVs, nullptr, 0);
+    ctx->VSSetConstantBuffers(0, 1, &oldVsCb);
     ctx->PSSetShader(oldPs, nullptr, 0);
     ctx->PSSetShaderResources(0, 1, &oldSrv);
     ctx->PSSetSamplers(0, 1, &oldSamp);
@@ -180,6 +212,7 @@ bool draw_internal(ID3D11DeviceContext* ctx, ID3D11RenderTargetView* dst,
     ctx->IASetPrimitiveTopology(oldTopo);
     if (oldRtv) oldRtv->Release();
     if (oldDsv) oldDsv->Release();
+    if (oldVsCb) oldVsCb->Release();
     if (oldBlend) oldBlend->Release();
     if (oldDepth) oldDepth->Release();
     if (oldRaster) oldRaster->Release();
@@ -204,8 +237,26 @@ bool process(ID3D11DeviceContext* ctx, ID3D11RenderTargetView* dst,
     return draw_internal(ctx, dst, src, dstW, dstH, g_psProcess, nullptr);
 }
 
+bool stretch_band(ID3D11DeviceContext* ctx, ID3D11RenderTargetView* dst,
+                  ID3D11ShaderResourceView* src, UINT dstW, UINT dstH,
+                  float topFrac, float heightFrac) {
+    if (!ensure_pipeline(ctx)) return false;
+    D3D11_MAPPED_SUBRESOURCE m{};
+    if (FAILED(ctx->Map(g_stretchCb, 0, D3D11_MAP_WRITE_DISCARD, 0, &m))) return false;
+    float* f = static_cast<float*>(m.pData);
+    f[0] = topFrac;    // vOffset
+    f[1] = heightFrac; // vScale
+    f[2] = 0.0f;
+    f[3] = 0.0f;
+    ctx->Unmap(g_stretchCb, 0);
+    // Blend OFF (replace): the band overwrites the whole destination.
+    return draw_internal(ctx, dst, src, dstW, dstH, g_ps, nullptr, g_vsStretch);
+}
+
 void release() {
     if (g_vs) { g_vs->Release(); g_vs = nullptr; }
+    if (g_vsStretch) { g_vsStretch->Release(); g_vsStretch = nullptr; }
+    if (g_stretchCb) { g_stretchCb->Release(); g_stretchCb = nullptr; }
     if (g_ps) { g_ps->Release(); g_ps = nullptr; }
     if (g_psProcess) { g_psProcess->Release(); g_psProcess = nullptr; }
     if (g_blend) { g_blend->Release(); g_blend = nullptr; }

--- a/src/core/gfx/blit.h
+++ b/src/core/gfx/blit.h
@@ -28,6 +28,15 @@ bool alpha_premul(ID3D11DeviceContext* ctx, ID3D11RenderTargetView* dst,
 bool process(ID3D11DeviceContext* ctx, ID3D11RenderTargetView* dst,
              ID3D11ShaderResourceView* src, UINT dstW, UINT dstH);
 
+// Session 22: stretch a horizontal BAND of src ([topFrac .. topFrac +
+// heightFrac] in v) across the FULL destination, blending off. The
+// engine-cinematic letterbox unsqueeze: runtimes proved unreliable with
+// projection-layer imageRect crops (VDXR showed the bars regardless), so the
+// eye capture un-letterboxes the frame itself before submission.
+bool stretch_band(ID3D11DeviceContext* ctx, ID3D11RenderTargetView* dst,
+                  ID3D11ShaderResourceView* src, UINT dstW, UINT dstH,
+                  float topFrac, float heightFrac);
+
 // Release device objects (device loss / shutdown; recreated lazily).
 void release();
 

--- a/src/core/gfx/frame_inspector.cpp
+++ b/src/core/gfx/frame_inspector.cpp
@@ -454,7 +454,7 @@ Event& push_event(EventKind kind, const void* retAddr, void* espHint) {
 void STDMETHODCALLTYPE DrawIndexedDetour(ID3D11DeviceContext* ctx, UINT indexCount,
                                          UINT startIndex, INT baseVertex) {
     g_callCensus[CxDrawIndexed].fetch_add(1, std::memory_order_relaxed);
-    if (t_suppress == 0) bvr::hud::on_draw_indexed();
+    if (t_suppress == 0) bvr::hud::on_draw_indexed(ctx);
     if (should_record()) {
         ++t_suppress; // our own Get* calls must not recurse into recording
         Event& ev = push_event(EventKind::DrawIndexed, _ReturnAddress(),

--- a/src/core/gfx/hud_capture.cpp
+++ b/src/core/gfx/hud_capture.cpp
@@ -166,6 +166,7 @@ int g_lbStreak = 0;
 unsigned g_lbLastTop = 0, g_lbLastBot = 0; // last raw measurement (render thread)
 std::atomic<uint32_t> g_lbBars{0};         // packed top<<16 | bot, 0 = inactive
 std::atomic<unsigned> g_cLbIntervals{0};
+std::atomic<unsigned> g_cLbFills{0}; // bar/fade fills kept in-frame (round 3)
 
 bool ensure_lb_staging(ID3D11DeviceContext* ctx, UINT h) {
     if (g_lbStaging && g_lbH == h) return true;
@@ -539,6 +540,19 @@ ID3D11RenderTargetView* on_draw(ID3D11DeviceContext* ctx) {
     // BACKBUFFER-SIZED texture (gameswf samples UI atlases). They belong IN
     // the frame - per-eye correct by construction - so they never redirect
     // and never count as HUD content.
+    // Session 22 round 3 (user diagnosis: the cinematic bars sat ON the HUD
+    // panel, same dimensions and placement): during an engine letterbox the
+    // WHOLE flash layer renders into the frame natively - bars, fades and
+    // subtitles exactly as the flat game composes them (original blend
+    // states, no redirect, no panel). Correct by construction: the frame
+    // cannot differ from flat, and the unsqueeze then crops the bars. The
+    // panel stays empty for the duration (no redirected content = the quad
+    // copy and window composite idle on their own gates).
+    if (letterbox(nullptr, nullptr)) {
+        g_cLbFills.fetch_add(1, std::memory_order_relaxed);
+        return nullptr;
+    }
+
     {
         UINT sw = 0, sh = 0;
         if (srv0_size(ctx, &sw, &sh) && sw == g_curW && sh == g_curH) {
@@ -560,8 +574,8 @@ ID3D11RenderTargetView* on_draw(ID3D11DeviceContext* ctx) {
 }
 
 void on_present(ID3D11DeviceContext* ctx, IDXGISwapChain* swapchain) {
-    fov_watch_on_present(ctx);      // session 22: map last interval's cb0 copy
-    letterbox_watch(ctx, swapchain); // session 22 round 2: cinematic bars
+    (void)swapchain; // letterbox sampling moved to letterbox_sample (detour HEAD)
+    fov_watch_on_present(ctx); // session 22: map last interval's cb0 copy
 
     // Session 22 kind (a): screen-only interval verdict (hysteresis over
     // present intervals, transitions logged - the flat instrument). Computed
@@ -675,6 +689,16 @@ bool letterbox(unsigned* topPx, unsigned* botPx) {
     if (topPx) *topPx = packed >> 16;
     if (botPx) *botPx = packed & 0xFFFF;
     return true;
+}
+
+void letterbox_sample(ID3D11DeviceContext* ctx, IDXGISwapChain* swapchain) {
+    // Called at the HEAD of the present detour: the backbuffer holds the
+    // game's finished frame and NONE of our additions yet. Sampling at the
+    // tail read the frame AFTER the window HUD composite painted panel
+    // content into the bar rows - the detector flapped off whenever a
+    // session was FOCUSED, and most captures went to the eyes unstretched
+    // (the round-3 in-headset "bars still there" report).
+    letterbox_watch(ctx, swapchain);
 }
 
 unsigned postfx_count() {

--- a/src/core/gfx/hud_capture.cpp
+++ b/src/core/gfx/hud_capture.cpp
@@ -86,6 +86,64 @@ std::atomic<unsigned long long> g_fovStampMs{0};
 std::atomic<bool> g_fovMismatchOn{false};
 int g_fovMismatchStreak = 0;
 
+// ---- Session 22: per-kind routing state -------------------------------------
+// (a) Screen-only intervals: the hack minigame and loading screens draw PURE
+// gameswf with the world pass completely absent (dump-proven: 0 DrawIndexed,
+// 322/87 swf draws) - nothing classifies, so today they render in-frame
+// across the whole projection FOV. The detector below (swf draws with no
+// scene leader) publishes to the VR runtime, which drops those intervals to
+// the readable quad screen regardless of the cinematic stereo/quad mode.
+// (c) In-frame post effects: the alcohol-blur composite is a post-tonemap
+// non-indexed draw from the engine's post path sampling a BACKBUFFER-SIZED
+// texture (dump-proven), while gameswf HUD samples 2048x2048 UI atlases -
+// srv0 size is the discriminator; those draws stay in the frame.
+int g_swfDrawsThisInterval = 0;
+std::atomic<bool> g_screenOnlyOn{false};
+int g_screenOnlyStreak = 0;
+std::atomic<unsigned> g_cPostFx{0};
+struct SrvCacheEntry { ID3D11Resource* res; UINT w, h; };
+SrvCacheEntry g_srvCache[8] = {};
+int g_srvCacheCount = 0;
+
+// srv0 dimensions with the same per-interval identity cache the RT descs use
+// (the HUD run rebinds the same few atlases dozens of times per interval).
+bool srv0_size(ID3D11DeviceContext* ctx, UINT* w, UINT* h) {
+    ID3D11ShaderResourceView* srv = nullptr;
+    ctx->PSGetShaderResources(0, 1, &srv);
+    if (!srv) return false;
+    ID3D11Resource* res = nullptr;
+    srv->GetResource(&res);
+    srv->Release();
+    if (!res) return false;
+    res->Release(); // identity from here on (the PS binding holds the ref)
+    for (int i = 0; i < g_srvCacheCount; ++i) {
+        if (g_srvCache[i].res == res) {
+            *w = g_srvCache[i].w;
+            *h = g_srvCache[i].h;
+            return true;
+        }
+    }
+    UINT tw = 0, th = 0;
+    ID3D11Texture2D* tex = nullptr;
+    if (SUCCEEDED(res->QueryInterface(IID_PPV_ARGS(&tex)))) {
+        D3D11_TEXTURE2D_DESC d{};
+        tex->GetDesc(&d);
+        tw = d.Width;
+        th = d.Height;
+        tex->Release();
+    }
+    if (g_srvCacheCount < static_cast<int>(_countof(g_srvCache))) {
+        SrvCacheEntry& e = g_srvCache[g_srvCacheCount++];
+        e.res = res;
+        e.w = tw;
+        e.h = th;
+    }
+    if (!tw) return false;
+    *w = tw;
+    *h = th;
+    return true;
+}
+
 bool ensure_fov_staging(ID3D11DeviceContext* ctx) {
     if (g_fovStaging) return true;
     ID3D11Device* dev = nullptr;
@@ -327,6 +385,7 @@ void on_draw_indexed(ID3D11DeviceContext* ctx) {
 
 ID3D11RenderTargetView* on_draw(ID3D11DeviceContext* ctx) {
     if (!g_curRt || !g_curRtLdr) return nullptr;
+    ++g_swfDrawsThisInterval; // session 22: screen-only interval detector
 
     if (!g_hudTarget) {
         // Tonemap check: first non-indexed draw on an LDR target sampling the
@@ -346,6 +405,19 @@ ID3D11RenderTargetView* on_draw(ID3D11DeviceContext* ctx) {
 
     if (g_curRt != g_hudTarget) return nullptr;
 
+    // Session 22 kind (c): the engine's own post effects (alcohol blur) are
+    // also post-tonemap non-indexed draws here, but they sample a
+    // BACKBUFFER-SIZED texture (gameswf samples UI atlases). They belong IN
+    // the frame - per-eye correct by construction - so they never redirect
+    // and never count as HUD content.
+    {
+        UINT sw = 0, sh = 0;
+        if (srv0_size(ctx, &sw, &sh) && sw == g_curW && sh == g_curH) {
+            g_cPostFx.fetch_add(1, std::memory_order_relaxed);
+            return nullptr;
+        }
+    }
+
     // A non-indexed draw on the HUD target after the tonemap = gameswf.
     g_cHudDraws.fetch_add(1, std::memory_order_relaxed);
     g_hudThisInterval = true;
@@ -360,6 +432,28 @@ ID3D11RenderTargetView* on_draw(ID3D11DeviceContext* ctx) {
 
 void on_present(ID3D11DeviceContext* ctx) {
     fov_watch_on_present(ctx); // session 22: map last interval's cb0 copy
+
+    // Session 22 kind (a): screen-only interval verdict (hysteresis over
+    // present intervals, transitions logged - the flat instrument). Computed
+    // BEFORE the vote reset below. The 20-draw floor keeps single stray swf
+    // draws (subtitle fade, console line) from tripping it.
+    {
+        bool screenOnly = scene_leader() == nullptr && g_swfDrawsThisInterval >= 20;
+        if (screenOnly != g_screenOnlyOn.load(std::memory_order_relaxed)) {
+            if (++g_screenOnlyStreak >= 3) {
+                g_screenOnlyStreak = 0;
+                g_screenOnlyOn.store(screenOnly, std::memory_order_relaxed);
+                BVR_LOG("[hud] screen-only interval %s (swf draws %d, world pass %s)",
+                        screenOnly ? "ON (hack/loading/FMV-class screen)" : "off",
+                        g_swfDrawsThisInterval, screenOnly ? "absent" : "present");
+            }
+        } else {
+            g_screenOnlyStreak = 0;
+        }
+        g_swfDrawsThisInterval = 0;
+        g_srvCacheCount = 0;
+    }
+
     if (g_hudThisInterval) g_cIntervals.fetch_add(1, std::memory_order_relaxed);
     g_hadHudLastInterval = g_hudThisInterval;
     if (g_hudThisInterval && g_rtv && ctx) {
@@ -439,6 +533,14 @@ bool fov_watch(float* tanH, float* tanV, unsigned long long* ageMs) {
 
 bool fov_mismatch() {
     return g_fovMismatchOn.load(std::memory_order_relaxed);
+}
+
+bool screen_only() {
+    return g_screenOnlyOn.load(std::memory_order_relaxed);
+}
+
+unsigned postfx_count() {
+    return g_cPostFx.load(std::memory_order_relaxed);
 }
 
 ID3D11DepthStencilView* capture_dsv() {

--- a/src/core/gfx/hud_capture.cpp
+++ b/src/core/gfx/hud_capture.cpp
@@ -2,8 +2,12 @@
 
 #include "core/gfx/blit.h"
 #include "core/util/log.h"
+#include "core/vr/openxr_runtime.h" // rendered_hfov_deg (fov-watch comparison)
+
+#include <windows.h>
 
 #include <atomic>
+#include <cmath>
 #include <cstring>
 #include <map>
 
@@ -62,6 +66,100 @@ bool g_hadHudLastInterval = false;
 
 // Lifetime counters.
 std::atomic<unsigned> g_cHudDraws{0}, g_cRedirects{0}, g_cLeaks{0}, g_cIntervals{0};
+
+// ---- Session 22: live rendered-FOV watch (see hud_capture.h) ----------------
+// One 80-byte staging buffer: the first scene draw of an interval copies the
+// head of its VS b0 into it (CopySubresourceRegion, async); the copy is
+// mapped on a LATER present with DO_NOT_WAIT, so the pipeline never stalls.
+// Tangent layout (session 21, dump-verified): floats 12..18 hold the
+// screen-ray helper (2tanH, 0, -tanH, 0, 0, -2tanV, tanV); the two
+// derivations must agree or the block is not a perspective pass.
+constexpr UINT kFovCbBytes = 80; // floats 0..19
+ID3D11Buffer* g_fovStaging = nullptr;
+bool g_fovPending = false; // copied, not yet mapped
+int g_fovPendingAge = 0;   // presents since the copy
+int g_fovTriesThisInterval = 0;
+bool g_fovCapturedThisInterval = false;
+std::atomic<float> g_fovTanH{0.0f}, g_fovTanV{0.0f};
+std::atomic<unsigned long long> g_fovStampMs{0};
+// Mismatch verdict (render thread writes; hysteresis over present intervals).
+std::atomic<bool> g_fovMismatchOn{false};
+int g_fovMismatchStreak = 0;
+
+bool ensure_fov_staging(ID3D11DeviceContext* ctx) {
+    if (g_fovStaging) return true;
+    ID3D11Device* dev = nullptr;
+    ctx->GetDevice(&dev);
+    if (!dev) return false;
+    D3D11_BUFFER_DESC sd{};
+    sd.ByteWidth = kFovCbBytes;
+    sd.Usage = D3D11_USAGE_STAGING;
+    sd.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+    HRESULT hr = dev->CreateBuffer(&sd, nullptr, &g_fovStaging);
+    dev->Release();
+    return SUCCEEDED(hr) && g_fovStaging;
+}
+
+// Map attempt + mismatch bookkeeping, once per present (from on_present).
+void fov_watch_on_present(ID3D11DeviceContext* ctx) {
+    if (g_fovPending && ctx && g_fovStaging) {
+        ++g_fovPendingAge;
+        D3D11_MAPPED_SUBRESOURCE m{};
+        HRESULT hr = ctx->Map(g_fovStaging, 0, D3D11_MAP_READ,
+                              D3D11_MAP_FLAG_DO_NOT_WAIT, &m);
+        if (SUCCEEDED(hr)) {
+            const float* f = static_cast<const float*>(m.pData);
+            float tanH1 = f[12] * 0.5f, tanH2 = -f[14];
+            float tanV1 = -f[17] * 0.5f, tanV2 = f[18];
+            ctx->Unmap(g_fovStaging, 0);
+            g_fovPending = false;
+            bool ok = std::isfinite(tanH1) && std::isfinite(tanH2) &&
+                      std::isfinite(tanV1) && std::isfinite(tanV2) &&
+                      tanH1 > 0.05f && tanH1 < 20.0f && tanV1 > 0.05f &&
+                      fabsf(tanH1 - tanH2) <= 0.02f * tanH1 &&
+                      fabsf(tanV1 - tanV2) <= 0.02f * tanV1;
+            if (ok) {
+                g_fovTanH.store(tanH1, std::memory_order_relaxed);
+                g_fovTanV.store(tanV1, std::memory_order_relaxed);
+                g_fovStampMs.store(GetTickCount64(), std::memory_order_relaxed);
+            }
+            // Non-perspective/zero blocks fail silently - the stamp just ages.
+        } else if (g_fovPendingAge > 8) {
+            g_fovPending = false; // copy stuck (device weirdness) - recapture
+        }
+    }
+    g_fovCapturedThisInterval = false;
+    g_fovTriesThisInterval = 0;
+
+    // Rendered-vs-option verdict with a 3-interval hysteresis, logged on
+    // transition. Session-independent by design: this is the flat-testable
+    // instrument (the descent shows ON with no headset attached).
+    unsigned long long stamp = g_fovStampMs.load(std::memory_order_relaxed);
+    bool fresh = stamp && GetTickCount64() - stamp < 500;
+    float optHfov = bvr::vr::rendered_hfov_deg();
+    bool mm = false;
+    if (fresh && optHfov > 1.0f) {
+        float optTan = tanf(optHfov * 0.5f * 3.14159265f / 180.0f);
+        if (optTan > 0.01f) {
+            float r = g_fovTanH.load(std::memory_order_relaxed) / optTan;
+            mm = r < 0.90f || r > 1.10f;
+        }
+    }
+    if (mm != g_fovMismatchOn.load(std::memory_order_relaxed)) {
+        if (++g_fovMismatchStreak >= 3) {
+            g_fovMismatchStreak = 0;
+            g_fovMismatchOn.store(mm, std::memory_order_relaxed);
+            BVR_LOG("[hud] rendered-fov mismatch %s (rendered tanH %.4f = %.1f deg "
+                    "vs option %.1f deg)",
+                    mm ? "ON (scripted-camera fov)" : "off",
+                    g_fovTanH.load(std::memory_order_relaxed),
+                    2.0f * atanf(g_fovTanH.load(std::memory_order_relaxed)) * 57.29578f,
+                    optHfov);
+        }
+    } else {
+        g_fovMismatchStreak = 0;
+    }
+}
 
 ID3D11Resource* scene_leader() {
     Vote* best = nullptr;
@@ -179,7 +277,7 @@ void on_setrt(UINT numViews, ID3D11RenderTargetView* const* rtvs,
     }
 }
 
-void on_draw_indexed() {
+void on_draw_indexed(ID3D11DeviceContext* ctx) {
     if (!g_curRt) return;
     if (g_curRt == g_hudTarget && g_hudTarget) {
         // The fingerprint says the world never DrawIndexes the tonemap target
@@ -189,6 +287,29 @@ void on_draw_indexed() {
         return;
     }
     if (!g_curDsvBound) return;
+
+    // Session 22 fov watch: grab the first decodable scene draw's cb0 head
+    // (bounded attempts - early depth-only passes can bind small buffers).
+    if (!g_fovCapturedThisInterval && !g_fovPending && ctx &&
+        g_fovTriesThisInterval < 8) {
+        ++g_fovTriesThisInterval;
+        ID3D11Buffer* cb0 = nullptr;
+        ctx->VSGetConstantBuffers(0, 1, &cb0);
+        if (cb0) {
+            D3D11_BUFFER_DESC bd{};
+            cb0->GetDesc(&bd);
+            // 320 = the smallest world-pass cb tier that carries the ray block.
+            if (bd.ByteWidth >= 320 && ensure_fov_staging(ctx)) {
+                D3D11_BOX box{0, 0, 0, kFovCbBytes, 1, 1};
+                ctx->CopySubresourceRegion(g_fovStaging, 0, 0, 0, 0, cb0, 0, &box);
+                g_fovPending = true;
+                g_fovPendingAge = 0;
+                g_fovCapturedThisInterval = true;
+            }
+            cb0->Release();
+        }
+    }
+
     for (Vote& v : g_votes) {
         if (v.res == g_curRt) {
             ++v.n;
@@ -238,6 +359,7 @@ ID3D11RenderTargetView* on_draw(ID3D11DeviceContext* ctx) {
 }
 
 void on_present(ID3D11DeviceContext* ctx) {
+    fov_watch_on_present(ctx); // session 22: map last interval's cb0 copy
     if (g_hudThisInterval) g_cIntervals.fetch_add(1, std::memory_order_relaxed);
     g_hadHudLastInterval = g_hudThisInterval;
     if (g_hudThisInterval && g_rtv && ctx) {
@@ -306,6 +428,19 @@ void get_counters(unsigned* hudDraws, unsigned* redirects, unsigned* leaks,
     if (intervalsWithHud) *intervalsWithHud = g_cIntervals.load(std::memory_order_relaxed);
 }
 
+bool fov_watch(float* tanH, float* tanV, unsigned long long* ageMs) {
+    unsigned long long s = g_fovStampMs.load(std::memory_order_relaxed);
+    if (!s) return false;
+    if (tanH) *tanH = g_fovTanH.load(std::memory_order_relaxed);
+    if (tanV) *tanV = g_fovTanV.load(std::memory_order_relaxed);
+    if (ageMs) *ageMs = GetTickCount64() - s;
+    return true;
+}
+
+bool fov_mismatch() {
+    return g_fovMismatchOn.load(std::memory_order_relaxed);
+}
+
 ID3D11DepthStencilView* capture_dsv() {
     return g_dsv;
 }
@@ -366,6 +501,9 @@ void release_resources() {
     g_blendVariants.clear();
     g_texW = g_texH = 0;
     g_processedThisInterval = false;
+    if (g_fovStaging) { g_fovStaging->Release(); g_fovStaging = nullptr; }
+    g_fovPending = false;
+    g_fovCapturedThisInterval = false;
 }
 
 } // namespace bvr::hud

--- a/src/core/gfx/hud_capture.cpp
+++ b/src/core/gfx/hud_capture.cpp
@@ -144,6 +144,135 @@ bool srv0_size(ID3D11DeviceContext* ctx, UINT* w, UINT* h) {
     return true;
 }
 
+// ---- Session 22 round 2: letterbox watch -------------------------------------
+// Engine cinematics (plasmid FMV sequences) clear the FINAL target to opaque
+// black and tonemap the scene into a vertically SHRUNKEN quad (dump: ClearRTV
+// (0,0,0,1) + a full-viewport draw whose geometry covers only the middle
+// band). The bars are unpainted clear - there is no draw to classify - and
+// the band content is the full render anamorphically squeezed. Watch: three
+// thin columns of the backbuffer copied to a staging strip per present
+// (async, DO_NOT_WAIT map a present later - the fov-watch pattern); a row is
+// "bar" only if EXACTLY black across all three columns. Symmetric stable
+// top/bottom runs = letterbox: the VR runtime crops the submitted subImage
+// to the band (the compositor unsqueezes it back to the claimed fov - bars
+// gone, geometry correct) and the adapter suspends the live head drive so
+// the authored camera choreography plays (the flat-screen look, in stereo).
+constexpr int kLbCols = 3;
+ID3D11Texture2D* g_lbStaging = nullptr;
+UINT g_lbH = 0, g_lbSrcW = 0, g_lbSrcH = 0;
+bool g_lbPending = false;
+int g_lbPendingAge = 0;
+int g_lbStreak = 0;
+unsigned g_lbLastTop = 0, g_lbLastBot = 0; // last raw measurement (render thread)
+std::atomic<uint32_t> g_lbBars{0};         // packed top<<16 | bot, 0 = inactive
+std::atomic<unsigned> g_cLbIntervals{0};
+
+bool ensure_lb_staging(ID3D11DeviceContext* ctx, UINT h) {
+    if (g_lbStaging && g_lbH == h) return true;
+    if (g_lbStaging) {
+        g_lbStaging->Release();
+        g_lbStaging = nullptr;
+    }
+    ID3D11Device* dev = nullptr;
+    ctx->GetDevice(&dev);
+    if (!dev) return false;
+    D3D11_TEXTURE2D_DESC sd{};
+    sd.Width = kLbCols;
+    sd.Height = h;
+    sd.MipLevels = 1;
+    sd.ArraySize = 1;
+    sd.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+    sd.SampleDesc.Count = 1;
+    sd.Usage = D3D11_USAGE_STAGING;
+    sd.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+    HRESULT hr = dev->CreateTexture2D(&sd, nullptr, &g_lbStaging);
+    dev->Release();
+    if (SUCCEEDED(hr)) g_lbH = h;
+    return SUCCEEDED(hr) && g_lbStaging;
+}
+
+void letterbox_watch(ID3D11DeviceContext* ctx, IDXGISwapChain* swapchain) {
+    // Map last present's copy first (never blocks).
+    if (g_lbPending && g_lbStaging) {
+        ++g_lbPendingAge;
+        D3D11_MAPPED_SUBRESOURCE m{};
+        HRESULT hr = ctx->Map(g_lbStaging, 0, D3D11_MAP_READ,
+                              D3D11_MAP_FLAG_DO_NOT_WAIT, &m);
+        if (SUCCEEDED(hr)) {
+            const uint8_t* base = static_cast<const uint8_t*>(m.pData);
+            UINT h = g_lbH;
+            auto rowBlack = [&](UINT r) {
+                const uint8_t* p = base + r * m.RowPitch;
+                for (int c = 0; c < kLbCols; ++c)
+                    if (p[c * 4] > 2 || p[c * 4 + 1] > 2 || p[c * 4 + 2] > 2)
+                        return false;
+                return true;
+            };
+            UINT top = 0;
+            while (top < h && rowBlack(top)) ++top;
+            UINT bot = 0;
+            while (bot < h - top && rowBlack(h - 1 - bot)) ++bot;
+            ctx->Unmap(g_lbStaging, 0);
+            g_lbPending = false;
+
+            UINT minBar = h / 25;                 // >= 4% each
+            bool full = top + bot >= h;           // black screen (fade/loading)
+            UINT hi = top > bot ? top : bot;
+            bool symmetric = (top > bot ? top - bot : bot - top) <= hi / 4 + 8;
+            bool isLb = !full && top >= minBar && bot >= minBar && symmetric;
+            // Stability: consecutive agreeing verdicts (bars within 3 px)
+            // before switching state - the clear can flicker at scene cuts.
+            bool active = g_lbBars.load(std::memory_order_relaxed) != 0;
+            bool agrees = isLb == active;
+            if (isLb && (top > g_lbLastTop + 3 || g_lbLastTop > top + 3 ||
+                         bot > g_lbLastBot + 3 || g_lbLastBot > bot + 3))
+                agrees = active && false; // moving bars: treat as disagreement
+            g_lbLastTop = top;
+            g_lbLastBot = bot;
+            if (!agrees) {
+                if (++g_lbStreak >= 5) {
+                    g_lbStreak = 0;
+                    g_lbBars.store(isLb ? ((top & 0xFFFF) << 16) | (bot & 0xFFFF) : 0,
+                                   std::memory_order_relaxed);
+                    if (isLb) g_cLbIntervals.fetch_add(1, std::memory_order_relaxed);
+                    BVR_LOG("[hud] letterbox %s (top %u px, bottom %u px of %u)",
+                            isLb ? "ON (engine cinematic bars)" : "off", top, bot, h);
+                }
+            } else {
+                g_lbStreak = 0;
+                if (isLb) // track slow bar animation while active
+                    g_lbBars.store(((top & 0xFFFF) << 16) | (bot & 0xFFFF),
+                                   std::memory_order_relaxed);
+            }
+        } else if (g_lbPendingAge > 8) {
+            g_lbPending = false;
+        }
+    }
+
+    // Queue this present's copy: three 1-px columns at 1/4, 1/2, 3/4 width.
+    if (g_lbPending || !swapchain) return;
+    ID3D11Texture2D* bb = nullptr;
+    if (FAILED(swapchain->GetBuffer(0, IID_PPV_ARGS(&bb))) || !bb) return;
+    D3D11_TEXTURE2D_DESC bd{};
+    bb->GetDesc(&bd);
+    if ((bd.Format == DXGI_FORMAT_R8G8B8A8_UNORM ||
+         bd.Format == DXGI_FORMAT_R8G8B8A8_UNORM_SRGB ||
+         bd.Format == DXGI_FORMAT_B8G8R8A8_UNORM) &&
+        ensure_lb_staging(ctx, bd.Height)) {
+        g_lbSrcW = bd.Width;
+        g_lbSrcH = bd.Height;
+        for (int c = 0; c < kLbCols; ++c) {
+            UINT x = bd.Width * (c + 1) / 4;
+            D3D11_BOX box{x, 0, 0, x + 1, bd.Height, 1};
+            ctx->CopySubresourceRegion(g_lbStaging, 0, static_cast<UINT>(c), 0, 0,
+                                       bb, 0, &box);
+        }
+        g_lbPending = true;
+        g_lbPendingAge = 0;
+    }
+    bb->Release();
+}
+
 bool ensure_fov_staging(ID3D11DeviceContext* ctx) {
     if (g_fovStaging) return true;
     ID3D11Device* dev = nullptr;
@@ -430,8 +559,9 @@ ID3D11RenderTargetView* on_draw(ID3D11DeviceContext* ctx) {
     return g_rtv;
 }
 
-void on_present(ID3D11DeviceContext* ctx) {
-    fov_watch_on_present(ctx); // session 22: map last interval's cb0 copy
+void on_present(ID3D11DeviceContext* ctx, IDXGISwapChain* swapchain) {
+    fov_watch_on_present(ctx);      // session 22: map last interval's cb0 copy
+    letterbox_watch(ctx, swapchain); // session 22 round 2: cinematic bars
 
     // Session 22 kind (a): screen-only interval verdict (hysteresis over
     // present intervals, transitions logged - the flat instrument). Computed
@@ -539,6 +669,14 @@ bool screen_only() {
     return g_screenOnlyOn.load(std::memory_order_relaxed);
 }
 
+bool letterbox(unsigned* topPx, unsigned* botPx) {
+    uint32_t packed = g_lbBars.load(std::memory_order_relaxed);
+    if (!packed) return false;
+    if (topPx) *topPx = packed >> 16;
+    if (botPx) *botPx = packed & 0xFFFF;
+    return true;
+}
+
 unsigned postfx_count() {
     return g_cPostFx.load(std::memory_order_relaxed);
 }
@@ -606,6 +744,9 @@ void release_resources() {
     if (g_fovStaging) { g_fovStaging->Release(); g_fovStaging = nullptr; }
     g_fovPending = false;
     g_fovCapturedThisInterval = false;
+    if (g_lbStaging) { g_lbStaging->Release(); g_lbStaging = nullptr; }
+    g_lbH = 0;
+    g_lbPending = false;
 }
 
 } // namespace bvr::hud

--- a/src/core/gfx/hud_capture.h
+++ b/src/core/gfx/hud_capture.h
@@ -110,6 +110,10 @@ unsigned postfx_count();
 // submitted subImage to the band (the compositor unsqueezes - bars gone) and
 // the camera adapter suspends the live head drive (authored camera plays).
 bool letterbox(unsigned* topPx, unsigned* botPx);
+// Backbuffer sampling for the watch - MUST run at the HEAD of the present
+// detour (pure game frame; sampling after our window composite made the
+// detector flap whenever a session was FOCUSED - round-3 headset negative).
+void letterbox_sample(ID3D11DeviceContext* ctx, IDXGISwapChain* swapchain);
 
 // Free device objects (device loss / resize; recreated lazily).
 void release_resources();

--- a/src/core/gfx/hud_capture.h
+++ b/src/core/gfx/hud_capture.h
@@ -92,6 +92,16 @@ void get_counters(unsigned* hudDraws, unsigned* redirects, unsigned* leaks,
 bool fov_watch(float* tanH, float* tanV, unsigned long long* ageMs);
 bool fov_mismatch();
 
+// Session 22 per-kind routing:
+//   screen_only   true while intervals are PURE gameswf with the world pass
+//                 absent (hack minigame, loading screens, FMV-class screens -
+//                 dump-proven 0 DrawIndexed). The VR runtime drops these to
+//                 the readable quad screen. Hysteresis'd; transitions logged.
+//   postfx_count  lifetime count of post-tonemap draws left IN-FRAME because
+//                 they sample a backbuffer-sized texture (alcohol blur etc.).
+bool screen_only();
+unsigned postfx_count();
+
 // Free device objects (device loss / resize; recreated lazily).
 void release_resources();
 

--- a/src/core/gfx/hud_capture.h
+++ b/src/core/gfx/hud_capture.h
@@ -32,7 +32,7 @@ namespace bvr::hud {
 // Called from the frame_inspector detours (render thread, before forwarding).
 void on_setrt(UINT numViews, ID3D11RenderTargetView* const* rtvs,
               ID3D11DepthStencilView* dsv);
-void on_draw_indexed();
+void on_draw_indexed(ID3D11DeviceContext* ctx);
 // Returns the RTV to substitute for this draw (bind it together with
 // capture_dsv() - gameswf masks stencil against it), or null to leave the
 // game's binding alone. `ctx` is used to lazily create the RT and to inspect
@@ -73,6 +73,24 @@ bool force();
 // Telemetry for `vrhud status` (per second, reset on read... no - lifetime).
 void get_counters(unsigned* hudDraws, unsigned* redirects, unsigned* leaks,
                   unsigned* intervalsWithHud);
+
+// ---- Session 22: live rendered-FOV watch -------------------------------------
+// Scripted cameras (the bathysphere descent) render their OWN fov - 104 deg
+// measured by dump decode - while the FOV option (and therefore the projection
+// layer's claim) still reads 130. The claim mismatch is the in-headset
+// "fisheye + broken fusion" percept, and rendered-vs-option is the live
+// cutscene detector. Once per present interval the first scene draw's VS b0
+// is partially copied to a tiny staging buffer and mapped a present LATER
+// (DO_NOT_WAIT, zero pipeline stalls); tangents decode from the screen-ray
+// block at floats 12..18 (the session-21 layout that decode-framedump.ps1
+// verifies offline).
+//   fov_watch     latest decoded tangents; false until the first decode
+//   fov_mismatch  hysteresis'd rendered-vs-option verdict (compares against
+//                 bvr::vr::rendered_hfov_deg(), logs transitions - the
+//                 flat-testable instrument; the VR runtime keys the cinematic
+//                 quad fallback on it)
+bool fov_watch(float* tanH, float* tanV, unsigned long long* ageMs);
+bool fov_mismatch();
 
 // Free device objects (device loss / resize; recreated lazily).
 void release_resources();

--- a/src/core/gfx/hud_capture.h
+++ b/src/core/gfx/hud_capture.h
@@ -47,8 +47,9 @@ void fix_blend_alpha(ID3D11DeviceContext* ctx);
 
 // Present boundary (render thread, called at the END of the present detour,
 // after every consumer of the RT ran): clears the RT for the next interval
-// and rolls the per-interval classifier state.
-void on_present(ID3D11DeviceContext* ctx);
+// and rolls the per-interval classifier state. The swapchain feeds the
+// letterbox watch (may be null - the watch just idles).
+void on_present(ID3D11DeviceContext* ctx, IDXGISwapChain* swapchain);
 
 // The captured HUD as a shader resource (null when nothing was redirected
 // this interval or the RT does not exist). Serves the PROCESSED copy - rgb
@@ -101,6 +102,14 @@ bool fov_mismatch();
 //                 they sample a backbuffer-sized texture (alcohol blur etc.).
 bool screen_only();
 unsigned postfx_count();
+
+// Session 22 round 2: engine-cinematic letterbox (plasmid FMV sequences
+// clear the final target black and tonemap the scene into a shrunken middle
+// band - no draws to classify, the bars are unpainted clear). True while
+// bars are live; outputs their pixel heights. The VR runtime crops the
+// submitted subImage to the band (the compositor unsqueezes - bars gone) and
+// the camera adapter suspends the live head drive (authored camera plays).
+bool letterbox(unsigned* topPx, unsigned* botPx);
 
 // Free device objects (device loss / resize; recreated lazily).
 void release_resources();

--- a/src/core/hooks/d3d11_hook.cpp
+++ b/src/core/hooks/d3d11_hook.cpp
@@ -87,7 +87,7 @@ HRESULT WINAPI PresentDetour(IDXGISwapChain* swapchain, UINT syncInterval, UINT 
             ID3D11DeviceContext* context = nullptr;
             device->GetImmediateContext(&context);
             if (context) {
-                hud::on_present(context);
+                hud::on_present(context, swapchain);
                 context->Release();
             }
             device->Release();

--- a/src/core/hooks/d3d11_hook.cpp
+++ b/src/core/hooks/d3d11_hook.cpp
@@ -75,6 +75,21 @@ HRESULT WINAPI PresentDetour(IDXGISwapChain* swapchain, UINT syncInterval, UINT 
     // overlay/VR draws for the rest of the detour so they never enter a dump.
     frame_inspector::on_present(swapchain);
     frame_inspector::ScopedSuppress suppress;
+    // Letterbox sampling BEFORE any of our additions touch the backbuffer
+    // (overlay draw, mirror re-blit, window HUD composite) - the frame here
+    // is pure game pixels (session 22 round 3).
+    {
+        ID3D11Device* device = nullptr;
+        if (SUCCEEDED(swapchain->GetDevice(IID_PPV_ARGS(&device))) && device) {
+            ID3D11DeviceContext* context = nullptr;
+            device->GetImmediateContext(&context);
+            if (context) {
+                hud::letterbox_sample(context, swapchain);
+                context->Release();
+            }
+            device->Release();
+        }
+    }
     vr::on_present_begin(swapchain); // xrWaitFrame paces the game while a session runs
     overlay::on_present(swapchain);
     vr::on_present_end(swapchain);   // copies the finished frame (incl. overlay) to the quad

--- a/src/core/input/xinput_bridge.cpp
+++ b/src/core/input/xinput_bridge.cpp
@@ -51,6 +51,22 @@ std::atomic<bool> g_vrGameplay{false};
 std::atomic<uint64_t> g_vrGameplayLastMs{0};
 constexpr uint64_t kVrGameplayStaleMs = 500;
 
+// Session 22 turn controls. Smooth scale multiplies the composed stick X
+// (turn speed); snap mode instead consumes stick-X edges into queued steps
+// the camera adapter applies to the recenter composite (the M7.5 transfer
+// then carries the body). Both respect the same gates as the pitch kill
+// (vr-gameplay fresh, lifted while a grip/bumper holds a radial open).
+std::atomic<float> g_turnScale{1.0f};
+std::atomic<bool> g_snapTurn{false};
+std::atomic<float> g_snapAngleDeg{45.0f};
+std::atomic<int> g_snapPending{0}; // +right/-left, drained by take_snap_steps
+bool g_snapArmed = true;           // edge re-arm state; g_mutex holds it
+// Session 22 movement instrumentation: rate-limited composed-stick log
+// ("vrinput sticklog on|off") - the wonkiness investigation pairs it with
+// the vrbody probe's resid line.
+std::atomic<bool> g_stickLog{false};
+uint64_t g_lastStickLogMs = 0; // g_mutex
+
 // Self-expiring test slots: the command seam polls at 1 Hz, so a "hold" must
 // outlive its command inside the DLL. deadline == 0 means empty.
 struct TimedStick { int16_t x = 0, y = 0; uint64_t deadline = 0; };
@@ -92,36 +108,13 @@ int bit_index(uint16_t bit) {
 
 // The game probes XInput exactly ONCE at boot (6 GetState calls for index 0,
 // 1 each for 1-3) and never re-polls a slot that reported disconnected - not
-// on WM_DEVICECHANGE, not on an interval (verified live 2026-07-24). So the
-// enable flag must already be set when that probe runs, which is before the
-// command seam's first poll. A marker file persisted across boots and read at
-// DLL attach closes the gap: once the user opts in, every later boot reports
-// a connected pad to the probe and the game polls at frame rate from then on.
-// Mid-session "vrinput on" after a disconnected boot probe needs a relaunch.
-bool marker_path(wchar_t out[MAX_PATH]) {
-    wchar_t base[MAX_PATH];
-    if (!GetEnvironmentVariableW(L"LOCALAPPDATA", base, MAX_PATH)) return false;
-    swprintf_s(out, MAX_PATH, L"%s\\BioshockVR\\vrinput.on", base);
-    return true;
-}
-
-void persist_enabled(bool on) {
-    wchar_t path[MAX_PATH];
-    if (!marker_path(path)) return;
-    if (on) {
-        HANDLE f = CreateFileW(path, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS,
-                               FILE_ATTRIBUTE_NORMAL, nullptr);
-        if (f != INVALID_HANDLE_VALUE) CloseHandle(f);
-    } else {
-        DeleteFileW(path);
-    }
-}
-
-bool read_persisted_enabled() {
-    wchar_t path[MAX_PATH];
-    if (!marker_path(path)) return false;
-    return GetFileAttributesW(path) != INVALID_FILE_ATTRIBUTES;
-}
+// on WM_DEVICECHANGE, not on an interval (verified live 2026-07-24). Session
+// 22 retires the old vrinput.on marker-file workaround: compose_over now
+// answers a FAILED slot-0 query with a neutral CONNECTED pad even while
+// vrinput is off, so the probe latches "connected" on every install and a
+// later `vrinput on` engages with no restart (the first-boot-restart fix,
+// ROADMAP M9). Slots 1-3 keep reporting disconnected; a real pad on slot 0
+// passes through untouched.
 
 // Merge b over a: buttons OR, triggers max, stick axes per-axis larger
 // magnitude wins with ties going to `a` - deterministic and order-free.
@@ -179,6 +172,14 @@ void compose_over(DWORD userIndex, XINPUT_STATE* xs, DWORD* result) {
         }
         g_lastTriggers.store(t, std::memory_order_relaxed);
         g_lastButtons.store(b, std::memory_order_relaxed);
+        // Session 22 first-boot fix: a failed slot-0 query answers as a
+        // neutral CONNECTED pad (constant packet number = "no new input"),
+        // so the game's one-shot boot probe never latches slot 0 dead.
+        if (*result != ERROR_SUCCESS) {
+            memset(xs, 0, sizeof(XINPUT_STATE));
+            xs->dwPacketNumber = 1;
+            *result = ERROR_SUCCESS;
+        }
         return;
     }
 
@@ -199,12 +200,43 @@ void compose_over(DWORD userIndex, XINPUT_STATE* xs, DWORD* result) {
     // selection (session 19 part 2 - the wheel was unselectable). The game
     // side snapshots the PC pitch at bumper-down and restores it at release,
     // so the look-pitch the wheel state also accumulates cannot stick.
-    if (g_pitchKill.load(std::memory_order_relaxed) &&
-        g_vrGameplay.load(std::memory_order_relaxed) &&
-        now - g_vrGameplayLastMs.load(std::memory_order_relaxed) <= kVrGameplayStaleMs &&
-        !(out.buttons &
-          (XINPUT_GAMEPAD_LEFT_SHOULDER | XINPUT_GAMEPAD_RIGHT_SHOULDER)))
-        out.ry = 0;
+    bool turnGate = g_vrGameplay.load(std::memory_order_relaxed) &&
+                    now - g_vrGameplayLastMs.load(std::memory_order_relaxed) <=
+                        kVrGameplayStaleMs &&
+                    !(out.buttons &
+                      (XINPUT_GAMEPAD_LEFT_SHOULDER | XINPUT_GAMEPAD_RIGHT_SHOULDER));
+    if (g_pitchKill.load(std::memory_order_relaxed) && turnGate) out.ry = 0;
+
+    // Session 22 turn controls (same gate cluster as the pitch kill; radial
+    // states keep the raw stick).
+    if (turnGate) {
+        if (g_snapTurn.load(std::memory_order_relaxed)) {
+            // Snap owns the turn axis: edge-detect with the proven 0.65/0.30
+            // hysteresis, queue a step, and zero rx to the game.
+            constexpr int16_t kOn = 21299, kOff = 9830;
+            int16_t rx = out.rx;
+            if (g_snapArmed) {
+                if (rx >= kOn) {
+                    g_snapPending.fetch_add(1, std::memory_order_relaxed);
+                    g_snapArmed = false;
+                } else if (rx <= -kOn) {
+                    g_snapPending.fetch_sub(1, std::memory_order_relaxed);
+                    g_snapArmed = false;
+                }
+            } else if (rx > -kOff && rx < kOff) {
+                g_snapArmed = true;
+            }
+            out.rx = 0;
+        } else {
+            float s = g_turnScale.load(std::memory_order_relaxed);
+            if (s != 1.0f) {
+                float v = static_cast<float>(out.rx) * s;
+                out.rx = static_cast<int16_t>(v > 32767.0f    ? 32767
+                                              : v < -32768.0f ? -32768
+                                                              : lroundf(v));
+            }
+        }
+    }
     if (g_packetBump || memcmp(&out, &g_lastComposed, sizeof out) != 0) {
         ++g_packet;
         g_packetBump = false;
@@ -217,6 +249,14 @@ void compose_over(DWORD userIndex, XINPUT_STATE* xs, DWORD* result) {
                              static_cast<uint16_t>(static_cast<uint16_t>(out.rt) << 8),
                          std::memory_order_relaxed);
     g_lastButtons.store(out.buttons, std::memory_order_relaxed);
+
+    // Session 22 wonkiness instrumentation: the FINAL composed pad, post
+    // merge/pitchkill/turn - what the game actually consumes.
+    if (g_stickLog.load(std::memory_order_relaxed) && now - g_lastStickLogMs >= 100) {
+        g_lastStickLogMs = now;
+        BVR_LOG("[input] stick composed lx=%d ly=%d rx=%d ry=%d pkt=%u",
+                out.lx, out.ly, out.rx, out.ry, g_packet);
+    }
 
     if (!g_loggedFirstCompose.exchange(true, std::memory_order_relaxed))
         BVR_LOG("input: first synthetic compose served (packet %u)", g_packet);
@@ -445,12 +485,6 @@ void init() {
     BVR_LOG("input: bridge registered with proxy seam (module %p)", proxy);
 
     install_dll_hooks(); // retried lazily from commands if the DLLs load later
-
-    if (read_persisted_enabled()) {
-        g_enabled.store(true, std::memory_order_relaxed);
-        BVR_LOG("input: vrinput pre-armed from marker - boot probe will see a "
-                "connected pad");
-    }
 }
 
 bool hijack_import_slot(void** slot) {
@@ -479,7 +513,6 @@ void set_enabled(bool on) {
         std::lock_guard<std::mutex> lock(g_mutex);
         g_packetBump = true;
     }
-    persist_enabled(on); // sticky across boots - see the boot-probe note above
     BVR_LOG("input: vrinput %s", on ? "ON (synthetic gamepad live)" : "off (passthrough)");
 }
 
@@ -527,6 +560,38 @@ void last_composed_bumpers(bool* lb, bool* rb) {
     if (rb) *rb = (b & XINPUT_GAMEPAD_RIGHT_SHOULDER) != 0;
 }
 
+void last_composed_sticks(int16_t* lx, int16_t* ly, int16_t* rx, int16_t* ry) {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    if (lx) *lx = g_lastComposed.lx;
+    if (ly) *ly = g_lastComposed.ly;
+    if (rx) *rx = g_lastComposed.rx;
+    if (ry) *ry = g_lastComposed.ry;
+}
+
+float turn_scale() { return g_turnScale.load(std::memory_order_relaxed); }
+void set_turn_scale(float s) {
+    if (s < 0.1f) s = 0.1f;
+    if (s > 4.0f) s = 4.0f;
+    g_turnScale.store(s, std::memory_order_relaxed);
+}
+
+bool snap_turn() { return g_snapTurn.load(std::memory_order_relaxed); }
+void set_snap_turn(bool on) {
+    bool was = g_snapTurn.exchange(on, std::memory_order_relaxed);
+    if (was != on)
+        BVR_LOG("input: snap turn %s (stick X %s)", on ? "ON" : "off",
+                on ? "edges queue discrete steps" : "smooth");
+}
+
+float snap_angle_deg() { return g_snapAngleDeg.load(std::memory_order_relaxed); }
+void set_snap_angle_deg(float d) {
+    if (d < 5.0f) d = 5.0f;
+    if (d > 180.0f) d = 180.0f;
+    g_snapAngleDeg.store(d, std::memory_order_relaxed);
+}
+
+int take_snap_steps() { return g_snapPending.exchange(0, std::memory_order_relaxed); }
+
 void handle_command(const char* args) {
     install_dll_hooks(); // lazy retry in case xinput1_4 loaded after init
 
@@ -556,6 +621,32 @@ void handle_command(const char* args) {
                     g_vrGameplay.load(std::memory_order_relaxed) ? "ACTIVE" : "inactive",
                     static_cast<unsigned long long>(age));
         }
+    } else if (strcmp(verb, "turnscale") == 0) {
+        float s = 0.0f;
+        if (sscanf_s(rest, "%f", &s) == 1) {
+            set_turn_scale(s);
+            BVR_LOG("input: turn scale %.2f", turn_scale());
+        } else {
+            BVR_LOG("input: turn scale %.2f (vrinput turnscale <0.1..4>)", turn_scale());
+        }
+    } else if (strcmp(verb, "snap") == 0) {
+        if (strncmp(rest, "on", 2) == 0) set_snap_turn(true);
+        else if (strncmp(rest, "off", 3) == 0) set_snap_turn(false);
+        else
+            BVR_LOG("input: snap %s angle %.0f deg pending %d "
+                    "(vrinput snap on|off, vrinput snapangle <deg>)",
+                    snap_turn() ? "ON" : "off", snap_angle_deg(),
+                    g_snapPending.load(std::memory_order_relaxed));
+    } else if (strcmp(verb, "snapangle") == 0) {
+        float d = 0.0f;
+        if (sscanf_s(rest, "%f", &d) == 1) {
+            set_snap_angle_deg(d);
+            BVR_LOG("input: snap angle %.0f deg", snap_angle_deg());
+        }
+    } else if (strcmp(verb, "sticklog") == 0) {
+        bool on = strncmp(rest, "on", 2) == 0;
+        g_stickLog.store(on, std::memory_order_relaxed);
+        BVR_LOG("input: stick log %s (composed pad @10 Hz)", on ? "ON" : "off");
     } else if (strcmp(verb, "test") == 0) {
         char what[16] = {};
         consumed = 0;
@@ -640,6 +731,18 @@ void draw_debug_ui() {
     bool pk = g_pitchKill.load(std::memory_order_relaxed);
     if (ImGui::Checkbox("Kill right-stick pitch under VR", &pk))
         set_pitch_kill(pk);
+
+    // Session 22 turn controls.
+    float ts = g_turnScale.load(std::memory_order_relaxed);
+    if (ImGui::SliderFloat("Smooth turn speed", &ts, 0.2f, 3.0f, "%.2f"))
+        set_turn_scale(ts);
+    bool st = g_snapTurn.load(std::memory_order_relaxed);
+    if (ImGui::Checkbox("Snap turn (discrete steps)", &st)) set_snap_turn(st);
+    if (st) {
+        float sa = g_snapAngleDeg.load(std::memory_order_relaxed);
+        if (ImGui::SliderFloat("Snap angle (deg)", &sa, 15.0f, 90.0f, "%.0f"))
+            set_snap_angle_deg(sa);
+    }
 
     // GetState poll rate, sampled ~1/s (render thread only).
     static uint64_t lastMs = 0;

--- a/src/core/input/xinput_bridge.h
+++ b/src/core/input/xinput_bridge.h
@@ -63,6 +63,23 @@ void last_composed_triggers(uint8_t* lt, uint8_t* rt);
 // fix latches hand attribution from these too.
 void last_composed_bumpers(bool* lb, bool* rb);
 
+// Session 22: the FINAL composed sticks the game consumed (post merge/
+// pitchkill/turn controls) - the movement-wonkiness instrument reads them.
+void last_composed_sticks(int16_t* lx, int16_t* ly, int16_t* rx, int16_t* ry);
+
+// Session 22 turn controls (persisted via vrpreset.ini; overlay sliders).
+// Smooth scale multiplies composed stick X under the vr-gameplay gate; snap
+// mode consumes stick-X edges into discrete steps the camera adapter drains
+// with take_snap_steps() and applies to the recenter composite (the body
+// transfer carries the body - camera.cpp).
+float turn_scale();
+void set_turn_scale(float s);
+bool snap_turn();
+void set_snap_turn(bool on);
+float snap_angle_deg();
+void set_snap_angle_deg(float d);
+int take_snap_steps(); // +right/-left steps queued since the last drain
+
 // Install the bridge's composing XInputGetState wrapper into an import slot
 // (e.g. the game module's IAT entry for xinput1_3 ordinal 2). The slot's
 // previous target becomes the passthrough, so a hook chain already wrapping
@@ -74,6 +91,7 @@ bool hijack_import_slot(void** slot);
 // Seam command handler: args after the "vrinput" verb (game thread).
 //   on | off | status
 //   pitchkill on|off|status
+//   turnscale <0.1..4> | snap on|off | snapangle <deg> | sticklog on|off
 //   test stick l|r <x> <y> [holdMs]   raw -32768..32767
 //   test trig  l|r <0..255> [holdMs]
 //   test press <A|B|X|Y|LB|RB|START|BACK|LS|RS|DU|DD|DL|DR> [holdMs]

--- a/src/core/ui/overlay.cpp
+++ b/src/core/ui/overlay.cpp
@@ -14,6 +14,8 @@
 #include <imgui_impl_dx11.h>
 #include <imgui_impl_win32.h>
 
+#include <atomic>
+
 extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND, UINT, WPARAM, LPARAM);
 
 namespace bvr::overlay {
@@ -21,15 +23,27 @@ namespace {
 
 bool g_initialized = false;
 bool g_visible = false;
+std::atomic<int> g_visibleRequest{-1}; // session 22: seam toggle (-1 = none)
 ID3D11Device* g_device = nullptr;
 ID3D11DeviceContext* g_context = nullptr;
 ID3D11RenderTargetView* g_rtv = nullptr;
+ID3D11Texture2D* g_rtvBackbuffer = nullptr; // identity only, never deref'd
 HWND g_window = nullptr;
 WNDPROC g_originalWndProc = nullptr;
 
 LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam) {
-    if (g_visible && ImGui_ImplWin32_WndProcHandler(hwnd, msg, wparam, lparam))
-        return TRUE;
+    if (g_visible) {
+        ImGui_ImplWin32_WndProcHandler(hwnd, msg, wparam, lparam);
+        // Session 22 (user report: overlay unusable while scrolling): while
+        // ImGui owns the mouse/keyboard, CONSUME those messages instead of
+        // letting the game fight the overlay for them (the wheel doubled as
+        // weapon-cycle, clicks re-captured the cursor mid-drag).
+        ImGuiIO& io = ImGui::GetIO();
+        bool mouseMsg = msg >= WM_MOUSEFIRST && msg <= WM_MOUSELAST;
+        bool keyMsg = msg >= WM_KEYFIRST && msg <= WM_KEYLAST;
+        if ((mouseMsg && io.WantCaptureMouse) || (keyMsg && io.WantCaptureKeyboard))
+            return TRUE;
+    }
     return CallWindowProcW(g_originalWndProc, hwnd, msg, wparam, lparam);
 }
 
@@ -38,6 +52,7 @@ bool CreateRenderTarget(IDXGISwapChain* swapchain) {
     if (FAILED(swapchain->GetBuffer(0, IID_PPV_ARGS(&backbuffer))))
         return false;
     HRESULT hr = g_device->CreateRenderTargetView(backbuffer, nullptr, &g_rtv);
+    g_rtvBackbuffer = SUCCEEDED(hr) ? backbuffer : nullptr;
     backbuffer->Release();
     return SUCCEEDED(hr);
 }
@@ -95,10 +110,25 @@ void on_present(IDXGISwapChain* swapchain) {
         g_initialized = Init(swapchain);
         if (!g_initialized) return;
     }
+    // Session 22 (user report: overlay gone until an alt-tab): if the game
+    // swaps its backbuffer object WITHOUT a ResizeBuffers (fullscreen-state
+    // churn), a held RTV keeps drawing into the dead buffer - F10 toggles an
+    // overlay nobody can see. Track the buffer identity and re-create.
+    {
+        ID3D11Texture2D* bb = nullptr;
+        if (SUCCEEDED(swapchain->GetBuffer(0, IID_PPV_ARGS(&bb)))) {
+            if (g_rtv && bb != g_rtvBackbuffer) {
+                g_rtv->Release();
+                g_rtv = nullptr;
+                BVR_LOG("overlay: backbuffer identity changed - RTV re-created");
+            }
+            bb->Release();
+        }
+    }
     if (!g_rtv && !CreateRenderTarget(swapchain)) return;
 
     // F10, edge-triggered (Insert was the original choice, but not every
-    // keyboard has it)
+    // keyboard has it); the seam request lane covers harness toggling.
     static bool wasDown = false;
     bool isDown = (GetAsyncKeyState(VK_F10) & 0x8000) != 0;
     if (isDown && !wasDown) {
@@ -106,6 +136,11 @@ void on_present(IDXGISwapChain* swapchain) {
         ImGui::GetIO().MouseDrawCursor = g_visible;
     }
     wasDown = isDown;
+    int req = g_visibleRequest.exchange(-1, std::memory_order_relaxed);
+    if (req >= 0) {
+        g_visible = req != 0;
+        ImGui::GetIO().MouseDrawCursor = g_visible;
+    }
 
     if (!g_visible) return;
 
@@ -123,6 +158,11 @@ void on_resize() {
         g_rtv->Release();
         g_rtv = nullptr;
     }
+    g_rtvBackbuffer = nullptr;
+}
+
+void set_visible(bool on) {
+    g_visibleRequest.store(on ? 1 : 0, std::memory_order_relaxed);
 }
 
 } // namespace bvr::overlay

--- a/src/core/ui/overlay.h
+++ b/src/core/ui/overlay.h
@@ -10,4 +10,9 @@ namespace bvr::overlay {
 void on_present(IDXGISwapChain* swapchain);
 void on_resize(); // drop backbuffer references before ResizeBuffers
 
+// Session 22: programmatic visibility (any thread; applied on the next
+// present). The `vroverlay on|off` seam command - the harness cannot press
+// F10, and it doubles as the user's recovery if a keyboard state wedges.
+void set_visible(bool on);
+
 } // namespace bvr::overlay

--- a/src/core/vr/openxr_runtime.cpp
+++ b/src/core/vr/openxr_runtime.cpp
@@ -1394,6 +1394,22 @@ void on_present_end(IDXGISwapChain* swapchain) {
                 sub.swapchain = g_swapchains[target];
                 sub.imageRect = {{0, 0},
                                  {static_cast<int32_t>(g_swapW), static_cast<int32_t>(g_swapH)}};
+                // Session 22 round 2: engine cinematics letterbox the frame
+                // (scene anamorphically squeezed into a middle band over an
+                // opaque-black clear). Crop the submission to the band - the
+                // compositor stretches it back to the claimed fov, so the
+                // bars vanish and the geometry comes out correct. Applies to
+                // the projection AND the quad path (both consume `sub`; the
+                // quad keeps its full-aspect size = the same unsqueeze).
+                {
+                    unsigned lbTop = 0, lbBot = 0;
+                    if (bvr::hud::letterbox(&lbTop, &lbBot) &&
+                        lbTop + lbBot < g_swapH) {
+                        sub.imageRect.offset.y = static_cast<int32_t>(lbTop);
+                        sub.imageRect.extent.height =
+                            static_cast<int32_t>(g_swapH - lbTop - lbBot);
+                    }
+                }
 
                 if (projectionMode) {
                     // fov = the symmetric fov the game rendered with (hfov

--- a/src/core/vr/openxr_runtime.cpp
+++ b/src/core/vr/openxr_runtime.cpp
@@ -1198,6 +1198,73 @@ float xr_quat_yaw_deg(float qx, float qy, float qz, float qw) {
     return atan2f(-f[0], -f[2]) * 57.29578f;
 }
 
+// Session 22 letterbox unsqueeze (see capture_frame): engine cinematics
+// squeeze the scene into a middle band over black; runtimes proved
+// unreliable with projection-layer imageRect crops (VDXR kept the bars),
+// so the eye capture un-letterboxes the frame ITSELF - band stretched
+// across the full image by our own blit, plain copy everywhere else.
+ID3D11Texture2D* g_lbScratch = nullptr;
+ID3D11ShaderResourceView* g_lbScratchSrv = nullptr;
+std::atomic<bool> g_loggedLbStretch{false};
+
+void release_lb_scratch() {
+    if (g_lbScratchSrv) { g_lbScratchSrv->Release(); g_lbScratchSrv = nullptr; }
+    if (g_lbScratch) { g_lbScratch->Release(); g_lbScratch = nullptr; }
+}
+
+void capture_frame(ID3D11Texture2D* dst, ID3D11Texture2D* backbuffer) {
+    unsigned lbTop = 0, lbBot = 0;
+    if (bvr::hud::letterbox(&lbTop, &lbBot) && lbTop + lbBot < g_swapH) {
+        D3D11_TEXTURE2D_DESC bd{};
+        backbuffer->GetDesc(&bd);
+        if (g_lbScratch) {
+            D3D11_TEXTURE2D_DESC sd{};
+            g_lbScratch->GetDesc(&sd);
+            if (sd.Width != bd.Width || sd.Height != bd.Height ||
+                sd.Format != bd.Format)
+                release_lb_scratch();
+        }
+        if (!g_lbScratch && g_device) {
+            D3D11_TEXTURE2D_DESC sd = bd;
+            sd.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+            sd.Usage = D3D11_USAGE_DEFAULT;
+            sd.CPUAccessFlags = 0;
+            sd.MiscFlags = 0;
+            sd.MipLevels = 1;
+            if (FAILED(g_device->CreateTexture2D(&sd, nullptr, &g_lbScratch)) ||
+                FAILED(g_device->CreateShaderResourceView(g_lbScratch, nullptr,
+                                                          &g_lbScratchSrv)))
+                release_lb_scratch();
+        }
+        if (g_lbScratch && g_lbScratchSrv) {
+            // XR swapchain images can be typeless - view with the created
+            // format first, null-desc as the fallback.
+            ID3D11RenderTargetView* rtv = nullptr;
+            D3D11_RENDER_TARGET_VIEW_DESC rd{};
+            rd.Format = static_cast<DXGI_FORMAT>(g_swapFormat);
+            rd.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2D;
+            if (FAILED(g_device->CreateRenderTargetView(dst, &rd, &rtv)))
+                g_device->CreateRenderTargetView(dst, nullptr, &rtv);
+            if (rtv) {
+                g_context->CopyResource(g_lbScratch, backbuffer);
+                float h = static_cast<float>(g_swapH);
+                bool ok = bvr::blit::stretch_band(
+                    g_context, rtv, g_lbScratchSrv, g_swapW, g_swapH,
+                    static_cast<float>(lbTop) / h,
+                    static_cast<float>(g_swapH - lbTop - lbBot) / h);
+                rtv->Release();
+                if (ok) {
+                    if (!g_loggedLbStretch.exchange(true))
+                        BVR_LOG("xr: letterbox unsqueeze live (band %u..%u of %u)",
+                                lbTop, g_swapH - lbBot, g_swapH);
+                    return;
+                }
+            }
+        }
+    }
+    g_context->CopyResource(dst, backbuffer);
+}
+
 void on_present_end(IDXGISwapChain* swapchain) {
     if (!g_frameOpen) {
         // No XR frame this present (session gone, or the pace guard skipped
@@ -1353,8 +1420,10 @@ void on_present_end(IDXGISwapChain* swapchain) {
                 wi.timeout = XR_INFINITE_DURATION;
                 if (XR_SUCCEEDED(xrWaitSwapchainImage(g_swapchains[target], &wi))) {
                     // Same size + same typeless family (guaranteed at creation),
-                    // so a straight GPU copy carries the frame - overlay included.
-                    g_context->CopyResource(g_images[target][index].texture, backbuffer);
+                    // so a straight GPU copy carries the frame - overlay
+                    // included. Under an engine letterbox the copy becomes an
+                    // unsqueeze blit instead (session 22, capture_frame).
+                    capture_frame(g_images[target][index].texture, backbuffer);
                 }
                 XrSwapchainImageReleaseInfo ri{XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO};
                 xrReleaseSwapchainImage(g_swapchains[target], &ri);
@@ -1394,22 +1463,6 @@ void on_present_end(IDXGISwapChain* swapchain) {
                 sub.swapchain = g_swapchains[target];
                 sub.imageRect = {{0, 0},
                                  {static_cast<int32_t>(g_swapW), static_cast<int32_t>(g_swapH)}};
-                // Session 22 round 2: engine cinematics letterbox the frame
-                // (scene anamorphically squeezed into a middle band over an
-                // opaque-black clear). Crop the submission to the band - the
-                // compositor stretches it back to the claimed fov, so the
-                // bars vanish and the geometry comes out correct. Applies to
-                // the projection AND the quad path (both consume `sub`; the
-                // quad keeps its full-aspect size = the same unsqueeze).
-                {
-                    unsigned lbTop = 0, lbBot = 0;
-                    if (bvr::hud::letterbox(&lbTop, &lbBot) &&
-                        lbTop + lbBot < g_swapH) {
-                        sub.imageRect.offset.y = static_cast<int32_t>(lbTop);
-                        sub.imageRect.extent.height =
-                            static_cast<int32_t>(g_swapH - lbTop - lbBot);
-                    }
-                }
 
                 if (projectionMode) {
                     // fov = the symmetric fov the game rendered with (hfov
@@ -1608,6 +1661,7 @@ void on_resize() {
     // Recreated at the new backbuffer size on the next frame.
     destroy_swapchains();
     release_mirror();
+    release_lb_scratch(); // size-tied; also self-heals on desc mismatch
     if (g_backbufferRtv) {
         g_backbufferRtv->Release();
         g_backbufferRtv = nullptr;

--- a/src/core/vr/openxr_runtime.cpp
+++ b/src/core/vr/openxr_runtime.cpp
@@ -1203,15 +1203,26 @@ float xr_quat_yaw_deg(float qx, float qy, float qz, float qw) {
 // unreliable with projection-layer imageRect crops (VDXR kept the bars),
 // so the eye capture un-letterboxes the frame ITSELF - band stretched
 // across the full image by our own blit, plain copy everywhere else.
-ID3D11Texture2D* g_lbScratch = nullptr;
+ID3D11Texture2D* g_lbScratch = nullptr;        // backbuffer copy, SRV source
 ID3D11ShaderResourceView* g_lbScratchSrv = nullptr;
+ID3D11Texture2D* g_lbStretched = nullptr;      // our RTV target, then copied
+ID3D11RenderTargetView* g_lbStretchedRtv = nullptr;
 std::atomic<bool> g_loggedLbStretch{false};
+std::atomic<bool> g_loggedLbFail{false};
 
 void release_lb_scratch() {
     if (g_lbScratchSrv) { g_lbScratchSrv->Release(); g_lbScratchSrv = nullptr; }
     if (g_lbScratch) { g_lbScratch->Release(); g_lbScratch = nullptr; }
+    if (g_lbStretchedRtv) { g_lbStretchedRtv->Release(); g_lbStretchedRtv = nullptr; }
+    if (g_lbStretched) { g_lbStretched->Release(); g_lbStretched = nullptr; }
 }
 
+// The stretch never touches the RUNTIME's image with a view: backbuffer ->
+// scratch (SRV) -> stretch-blit -> OUR stretched tex (RTV) -> CopyResource
+// into the XR image - the same copy the normal path has always used (same
+// R8G8B8A8 typeless family as the swapchain's SRGB format, bit-preserving,
+// no double-encode). Every failure logs ONCE and falls back to the plain
+// copy (bars visible but nothing worse).
 void capture_frame(ID3D11Texture2D* dst, ID3D11Texture2D* backbuffer) {
     unsigned lbTop = 0, lbBot = 0;
     if (bvr::hud::letterbox(&lbTop, &lbBot) && lbTop + lbBot < g_swapH) {
@@ -1226,40 +1237,51 @@ void capture_frame(ID3D11Texture2D* dst, ID3D11Texture2D* backbuffer) {
         }
         if (!g_lbScratch && g_device) {
             D3D11_TEXTURE2D_DESC sd = bd;
-            sd.BindFlags = D3D11_BIND_SHADER_RESOURCE;
             sd.Usage = D3D11_USAGE_DEFAULT;
             sd.CPUAccessFlags = 0;
             sd.MiscFlags = 0;
             sd.MipLevels = 1;
-            if (FAILED(g_device->CreateTexture2D(&sd, nullptr, &g_lbScratch)) ||
-                FAILED(g_device->CreateShaderResourceView(g_lbScratch, nullptr,
-                                                          &g_lbScratchSrv)))
+            sd.ArraySize = 1;
+            sd.SampleDesc.Count = 1;
+            sd.SampleDesc.Quality = 0;
+            sd.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+            HRESULT h1 = g_device->CreateTexture2D(&sd, nullptr, &g_lbScratch);
+            HRESULT h2 = g_lbScratch ? g_device->CreateShaderResourceView(
+                                           g_lbScratch, nullptr, &g_lbScratchSrv)
+                                     : E_FAIL;
+            sd.BindFlags = D3D11_BIND_RENDER_TARGET;
+            HRESULT h3 = SUCCEEDED(h2)
+                             ? g_device->CreateTexture2D(&sd, nullptr, &g_lbStretched)
+                             : E_FAIL;
+            HRESULT h4 = g_lbStretched ? g_device->CreateRenderTargetView(
+                                             g_lbStretched, nullptr, &g_lbStretchedRtv)
+                                       : E_FAIL;
+            if (FAILED(h1) || FAILED(h2) || FAILED(h3) || FAILED(h4)) {
+                if (!g_loggedLbFail.exchange(true))
+                    BVR_LOG("xr: letterbox stretch resources FAILED "
+                            "(fmt %d, hr %08X/%08X/%08X/%08X) - bars stay",
+                            static_cast<int>(bd.Format),
+                            static_cast<unsigned>(h1), static_cast<unsigned>(h2),
+                            static_cast<unsigned>(h3), static_cast<unsigned>(h4));
                 release_lb_scratch();
-        }
-        if (g_lbScratch && g_lbScratchSrv) {
-            // XR swapchain images can be typeless - view with the created
-            // format first, null-desc as the fallback.
-            ID3D11RenderTargetView* rtv = nullptr;
-            D3D11_RENDER_TARGET_VIEW_DESC rd{};
-            rd.Format = static_cast<DXGI_FORMAT>(g_swapFormat);
-            rd.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2D;
-            if (FAILED(g_device->CreateRenderTargetView(dst, &rd, &rtv)))
-                g_device->CreateRenderTargetView(dst, nullptr, &rtv);
-            if (rtv) {
-                g_context->CopyResource(g_lbScratch, backbuffer);
-                float h = static_cast<float>(g_swapH);
-                bool ok = bvr::blit::stretch_band(
-                    g_context, rtv, g_lbScratchSrv, g_swapW, g_swapH,
-                    static_cast<float>(lbTop) / h,
-                    static_cast<float>(g_swapH - lbTop - lbBot) / h);
-                rtv->Release();
-                if (ok) {
-                    if (!g_loggedLbStretch.exchange(true))
-                        BVR_LOG("xr: letterbox unsqueeze live (band %u..%u of %u)",
-                                lbTop, g_swapH - lbBot, g_swapH);
-                    return;
-                }
             }
+        }
+        if (g_lbScratch && g_lbScratchSrv && g_lbStretched && g_lbStretchedRtv) {
+            g_context->CopyResource(g_lbScratch, backbuffer);
+            float h = static_cast<float>(g_swapH);
+            bool ok = bvr::blit::stretch_band(
+                g_context, g_lbStretchedRtv, g_lbScratchSrv, g_swapW, g_swapH,
+                static_cast<float>(lbTop) / h,
+                static_cast<float>(g_swapH - lbTop - lbBot) / h);
+            if (ok) {
+                g_context->CopyResource(dst, g_lbStretched);
+                if (!g_loggedLbStretch.exchange(true))
+                    BVR_LOG("xr: letterbox unsqueeze live (band %u..%u of %u)",
+                            lbTop, g_swapH - lbBot, g_swapH);
+                return;
+            }
+            if (!g_loggedLbFail.exchange(true))
+                BVR_LOG("xr: letterbox stretch blit FAILED - bars stay");
         }
     }
     g_context->CopyResource(dst, backbuffer);

--- a/src/core/vr/openxr_runtime.cpp
+++ b/src/core/vr/openxr_runtime.cpp
@@ -144,9 +144,11 @@ std::atomic<uint64_t> g_gameplayView{0};
 std::atomic<bool> g_cineEnabled{true};
 std::atomic<bool> g_cineActive{false}; // written by the render thread only
 // "vrcine mode stereo": during fov-mismatch scenes keep the projection and
-// claim the MEASURED fov instead of the option (stereo cinematics; the
-// strict-false/stale legs still drop to the quad). Default off = quad.
-std::atomic<bool> g_cineStereo{false};
+// claim the MEASURED fov instead of the option (stereo cinematics with
+// head-look; screen-only and strict-false/stale intervals still drop to the
+// quad - a 2D board has no stereo content). DEFAULT per the user's call
+// 2026-07-29: stereo; "vrcine mode quad" / the overlay toggle is the A/B.
+std::atomic<bool> g_cineStereo{true};
 int g_cineStreak = 0;                  // render thread only (hysteresis)
 std::atomic<uint32_t> g_cineEnters{0}, g_cineExits{0}, g_cinePresents{0};
 constexpr uint64_t kCineStaleMs = 300;
@@ -1253,8 +1255,9 @@ void on_present_end(IDXGISwapChain* swapchain) {
         bool strict = (pv & 1) != 0;
         bool stale = stampMs == 0 || GetTickCount64() - stampMs > kCineStaleMs;
         bool fovMm = bvr::hud::fov_mismatch();
+        bool screenOnly = bvr::hud::screen_only(); // hack/loading/FMV screens
         bool stereoCine = g_cineStereo.load(std::memory_order_relaxed);
-        bool wantCine = stale || !strict || (fovMm && !stereoCine);
+        bool wantCine = stale || !strict || screenOnly || (fovMm && !stereoCine);
         bool active = g_cineActive.load(std::memory_order_relaxed);
         if (wantCine != active) {
             if (++g_cineStreak >= kCineHysteresis) {
@@ -1265,9 +1268,10 @@ void on_present_end(IDXGISwapChain* swapchain) {
                     g_cineEnters.fetch_add(1, std::memory_order_relaxed);
                 else
                     g_cineExits.fetch_add(1, std::memory_order_relaxed);
-                BVR_LOG("xr: cinematic quad %s (strict=%d stale=%d fovMismatch=%d)",
+                BVR_LOG("xr: cinematic quad %s (strict=%d stale=%d fovMismatch=%d "
+                        "screenOnly=%d)",
                         active ? "ON" : "off", strict ? 1 : 0, stale ? 1 : 0,
-                        fovMm ? 1 : 0);
+                        fovMm ? 1 : 0, screenOnly ? 1 : 0);
             }
         } else {
             g_cineStreak = 0;
@@ -1612,8 +1616,14 @@ void draw_debug_ui() {
         if (ImGui::Checkbox("SR pair pacing (one waitFrame per eye pair)", &pair))
             g_srPairPacing.store(pair, std::memory_order_relaxed);
         bool cine = g_cineEnabled.load(std::memory_order_relaxed);
-        if (ImGui::Checkbox("Cinematic fallback (cutscenes on the big screen)", &cine))
+        if (ImGui::Checkbox("Cinematic auto-detect (cutscenes/screens)", &cine))
             g_cineEnabled.store(cine, std::memory_order_relaxed);
+        if (cine) {
+            bool stereoC = g_cineStereo.load(std::memory_order_relaxed);
+            if (ImGui::Checkbox("Cinematics as stereo projection (off = big screen)",
+                                &stereoC))
+                g_cineStereo.store(stereoC, std::memory_order_relaxed);
+        }
         if (aer) {
             ImGui::SameLine();
             bool swap = g_aerSwapEyes.load(std::memory_order_relaxed);
@@ -1868,7 +1878,7 @@ void handle_cine_command(const char* args) {
         bool haveFov = bvr::hud::fov_watch(&t, &tv, &fovAge);
         BVR_LOG("xr: cine %s mode=%s active=%d | enters %u exits %u presents %u | "
                 "published strict=%d age=%llums | rendered tanH=%.4f age=%llums "
-                "mismatch=%d (vrcine on|off|mode quad|mode stereo|status)",
+                "mismatch=%d screenOnly=%d (vrcine on|off|mode quad|mode stereo|status)",
                 g_cineEnabled.load(std::memory_order_relaxed) ? "ON" : "off",
                 g_cineStereo.load(std::memory_order_relaxed) ? "stereo" : "quad",
                 g_cineActive.load(std::memory_order_relaxed) ? 1 : 0,
@@ -1878,7 +1888,7 @@ void handle_cine_command(const char* args) {
                 pv ? static_cast<int>(pv & 1) : -1,
                 static_cast<unsigned long long>(ageMs),
                 haveFov ? t : 0.0f, haveFov ? fovAge : 0,
-                bvr::hud::fov_mismatch() ? 1 : 0);
+                bvr::hud::fov_mismatch() ? 1 : 0, bvr::hud::screen_only() ? 1 : 0);
     }
 }
 

--- a/src/core/vr/openxr_runtime.cpp
+++ b/src/core/vr/openxr_runtime.cpp
@@ -1469,7 +1469,17 @@ void on_present_end(IDXGISwapChain* swapchain) {
                         BVR_LOG("xr: alternate-eye stereo live (both eyes hold offset images)");
                 } else {
                     float width = g_screenWidthM.load(std::memory_order_relaxed);
-                    quad.space = g_space;
+                    // Session 22 (user feedback, first headset run): SCREEN-ONLY
+                    // intervals (hack minigame, loading screens - world-less 2D
+                    // boards) ride the HEAD-LOCKED view space, exactly like the
+                    // pause-menu panel, so the board is centered on wherever the
+                    // player is looking instead of the recenter-origin facing.
+                    // Cinematic scenes (fov-mismatch/strict legs) and the plain
+                    // camera-off screen keep the world-locked space unchanged.
+                    bool headLock = g_cineActive.load(std::memory_order_relaxed) &&
+                                    bvr::hud::screen_only() &&
+                                    g_viewSpace != XR_NULL_HANDLE;
+                    quad.space = headLock ? g_viewSpace : g_space;
                     quad.eyeVisibility = XR_EYE_VISIBILITY_BOTH;
                     quad.subImage = sub;
                     quad.pose.orientation.w = 1.0f;

--- a/src/core/vr/openxr_runtime.cpp
+++ b/src/core/vr/openxr_runtime.cpp
@@ -132,6 +132,25 @@ std::atomic<float> g_claimFovDeg{100.0f};
 // a head-driven camera can never appear on the flat quad screen.
 std::atomic<bool> g_projectionReady{false};
 int g_lastLayer = 0; // 0 none, 1 quad, 2 projection (render thread only)
+
+// Session 22 cinematic fallback: the adapter's strict gameplay-view verdict,
+// packed {tickMs << 1 | strict} so one relaxed load is coherent (a two-atomic
+// pair would race between value and stamp). Zero = never published. Staleness
+// IS the cutscene signal: scripted cameras bypass CalcView, so the publisher
+// simply stops. The 300 ms render threshold sits BELOW the game side's 400 ms
+// FOV restore on purpose - the quad showing a 130-FOV image for ~100 ms is
+// invisible; a projection layer over a restored-75 render would not be.
+std::atomic<uint64_t> g_gameplayView{0};
+std::atomic<bool> g_cineEnabled{true};
+std::atomic<bool> g_cineActive{false}; // written by the render thread only
+// "vrcine mode stereo": during fov-mismatch scenes keep the projection and
+// claim the MEASURED fov instead of the option (stereo cinematics; the
+// strict-false/stale legs still drop to the quad). Default off = quad.
+std::atomic<bool> g_cineStereo{false};
+int g_cineStreak = 0;                  // render thread only (hysteresis)
+std::atomic<uint32_t> g_cineEnters{0}, g_cineExits{0}, g_cinePresents{0};
+constexpr uint64_t kCineStaleMs = 300;
+constexpr int kCineHysteresis = 3;
 std::atomic<bool> g_loggedFirstProjection{false};
 std::atomic<bool> g_loggedFirstStereo{false};
 uint64_t g_lastProjBlockedLogMs = 0;
@@ -143,7 +162,7 @@ uint64_t g_lastProjBlockedLogMs = 0;
 // blocks. The pose audit (default off) additionally logs the yaw the layer
 // is tagged with vs the yaw the game thread last consumed from the head-pose
 // funnel - a generation-skew instrument, in-headset only (flat has no session).
-constexpr const char* kFovSrcNames[3] = {"readback", "fallback", "manual"};
+constexpr const char* kFovSrcNames[4] = {"readback", "fallback", "manual", "live"};
 std::atomic<float> g_auditTanH{0.0f};
 std::atomic<float> g_auditTanV{0.0f};
 std::atomic<int> g_auditFovSrc{-1};
@@ -1218,6 +1237,61 @@ void on_present_end(IDXGISwapChain* swapchain) {
     bool projectionMode = g_cameraMode.load(std::memory_order_relaxed) &&
                           g_projectionReady.load(std::memory_order_relaxed) && hfovDeg > 0.0f;
 
+    // Session 22 cinematic fallback: drop to the M2 quad screen while the
+    // published gameplay verdict is false (scripted view actor, menu
+    // attract), stale (a camera path bypassing CalcView), or the live fov
+    // watch says the game renders a DIFFERENT fov than the option/claim (the
+    // bathysphere descent: renders 104, claims 130 - measured; the scripted
+    // camera still CalcViews there). Everything downstream self-adjusts per
+    // present: the HUD quad, laser layers, and the HUD redirect gate all key
+    // on projectionMode/srFrame, and reset_aer clears the held eye images
+    // once srFrame drops. "vrcine mode stereo" instead keeps the projection
+    // through fov-mismatch scenes and claims the MEASURED fov.
+    if (g_cineEnabled.load(std::memory_order_relaxed) && projectionMode) {
+        uint64_t pv = g_gameplayView.load(std::memory_order_relaxed);
+        uint64_t stampMs = pv >> 1;
+        bool strict = (pv & 1) != 0;
+        bool stale = stampMs == 0 || GetTickCount64() - stampMs > kCineStaleMs;
+        bool fovMm = bvr::hud::fov_mismatch();
+        bool stereoCine = g_cineStereo.load(std::memory_order_relaxed);
+        bool wantCine = stale || !strict || (fovMm && !stereoCine);
+        bool active = g_cineActive.load(std::memory_order_relaxed);
+        if (wantCine != active) {
+            if (++g_cineStreak >= kCineHysteresis) {
+                g_cineStreak = 0;
+                active = wantCine;
+                g_cineActive.store(active, std::memory_order_relaxed);
+                if (active)
+                    g_cineEnters.fetch_add(1, std::memory_order_relaxed);
+                else
+                    g_cineExits.fetch_add(1, std::memory_order_relaxed);
+                BVR_LOG("xr: cinematic quad %s (strict=%d stale=%d fovMismatch=%d)",
+                        active ? "ON" : "off", strict ? 1 : 0, stale ? 1 : 0,
+                        fovMm ? 1 : 0);
+            }
+        } else {
+            g_cineStreak = 0;
+        }
+        if (active) {
+            projectionMode = false;
+            g_cinePresents.fetch_add(1, std::memory_order_relaxed);
+        } else if (fovMm && stereoCine) {
+            // Claim-fix stereo cinematics: tag the layer with the fov the
+            // game ACTUALLY renders (live watch), not the ignored option.
+            float t = 0.0f;
+            unsigned long long age = 0;
+            if (bvr::hud::fov_watch(&t, nullptr, &age) && age < 500 && t > 0.05f) {
+                hfovDeg = 2.0f * atanf(t) * 57.29578f;
+                hfovSrc = 3; // "live"
+            }
+        }
+    } else {
+        g_cineStreak = 0;
+        if (g_cineActive.load(std::memory_order_relaxed) &&
+            !g_cineEnabled.load(std::memory_order_relaxed))
+            g_cineActive.store(false, std::memory_order_relaxed); // kill switch
+    }
+
     // SequentialReentry (rung 2): one tag pop per Present, ALWAYS - the ring
     // must drain even in quad mode so a mode change cannot leave stale tags.
     // A tagged present carries a known eye (game thread pushed the sign at
@@ -1537,6 +1611,9 @@ void draw_debug_ui() {
         bool pair = g_srPairPacing.load(std::memory_order_relaxed);
         if (ImGui::Checkbox("SR pair pacing (one waitFrame per eye pair)", &pair))
             g_srPairPacing.store(pair, std::memory_order_relaxed);
+        bool cine = g_cineEnabled.load(std::memory_order_relaxed);
+        if (ImGui::Checkbox("Cinematic fallback (cutscenes on the big screen)", &cine))
+            g_cineEnabled.store(cine, std::memory_order_relaxed);
         if (aer) {
             ImGui::SameLine();
             bool swap = g_aerSwapEyes.load(std::memory_order_relaxed);
@@ -1595,6 +1672,12 @@ void draw_debug_ui() {
         ImGui::Text("mirror: %s | %u left holds, %u re-blits",
                     g_mirror.load(std::memory_order_relaxed) ? "left eye" : "OFF",
                     g_mirrorHolds.load(std::memory_order_relaxed), mirrorBlits);
+    uint32_t cineEnters = g_cineEnters.load(std::memory_order_relaxed);
+    if (cineEnters || g_cineActive.load(std::memory_order_relaxed))
+        ImGui::Text("cinematic: %s | enters %u exits %u presents %u",
+                    g_cineActive.load(std::memory_order_relaxed) ? "ACTIVE (quad)" : "off",
+                    cineEnters, g_cineExits.load(std::memory_order_relaxed),
+                    g_cinePresents.load(std::memory_order_relaxed));
 
     input_draw_debug_ui(); // M5 action-layer status line
 
@@ -1757,6 +1840,56 @@ void set_pose_audit(bool on) {
                            on ? "ON" : "off");
 }
 
+void publish_gameplay_view(bool strictGameplay) {
+    g_gameplayView.store((GetTickCount64() << 1) | (strictGameplay ? 1u : 0u),
+                         std::memory_order_relaxed);
+}
+
+void handle_cine_command(const char* args) {
+    if (strncmp(args, "mode stereo", 11) == 0) {
+        g_cineStereo.store(true, std::memory_order_relaxed);
+        BVR_LOG("xr: cinematic mode STEREO (fov-mismatch scenes keep the projection, "
+                "claim = measured fov; strict-false/stale still drop to the quad)");
+    } else if (strncmp(args, "mode quad", 9) == 0) {
+        g_cineStereo.store(false, std::memory_order_relaxed);
+        BVR_LOG("xr: cinematic mode QUAD (fov-mismatch scenes drop to the big screen)");
+    } else if (strncmp(args, "on", 2) == 0) {
+        g_cineEnabled.store(true, std::memory_order_relaxed);
+        BVR_LOG("xr: cinematic fallback ON (non-gameplay views drop to the quad screen)");
+    } else if (strncmp(args, "off", 3) == 0) {
+        g_cineEnabled.store(false, std::memory_order_relaxed);
+        BVR_LOG("xr: cinematic fallback OFF (pre-session-22: cutscenes submit as a "
+                "mis-claimed projection layer)");
+    } else {
+        uint64_t pv = g_gameplayView.load(std::memory_order_relaxed);
+        uint64_t ageMs = pv ? GetTickCount64() - (pv >> 1) : 0;
+        float t = 0.0f, tv = 0.0f;
+        unsigned long long fovAge = 0;
+        bool haveFov = bvr::hud::fov_watch(&t, &tv, &fovAge);
+        BVR_LOG("xr: cine %s mode=%s active=%d | enters %u exits %u presents %u | "
+                "published strict=%d age=%llums | rendered tanH=%.4f age=%llums "
+                "mismatch=%d (vrcine on|off|mode quad|mode stereo|status)",
+                g_cineEnabled.load(std::memory_order_relaxed) ? "ON" : "off",
+                g_cineStereo.load(std::memory_order_relaxed) ? "stereo" : "quad",
+                g_cineActive.load(std::memory_order_relaxed) ? 1 : 0,
+                g_cineEnters.load(std::memory_order_relaxed),
+                g_cineExits.load(std::memory_order_relaxed),
+                g_cinePresents.load(std::memory_order_relaxed),
+                pv ? static_cast<int>(pv & 1) : -1,
+                static_cast<unsigned long long>(ageMs),
+                haveFov ? t : 0.0f, haveFov ? fovAge : 0,
+                bvr::hud::fov_mismatch() ? 1 : 0);
+    }
+}
+
+bool cinematic_active() {
+    return g_cineActive.load(std::memory_order_relaxed);
+}
+
+float rendered_hfov_deg() {
+    return g_renderedHfov.load(std::memory_order_relaxed);
+}
+
 int current_eye_sign() {
     return g_aerEyeSign.load(std::memory_order_relaxed);
 }
@@ -1842,6 +1975,10 @@ void fov_audit(float* tanH, float* tanV, int* src, unsigned* swapW, unsigned* sw
     if (swapH) *swapH = 0;
 }
 void set_pose_audit(bool) {}
+void publish_gameplay_view(bool) {}
+void handle_cine_command(const char*) {}
+bool cinematic_active() { return false; }
+float rendered_hfov_deg() { return 0.0f; }
 int current_eye_sign() { return 0; }
 void sr_push_eye(int) {}
 void set_laser(const LaserConfig&) {}

--- a/src/core/vr/openxr_runtime.cpp
+++ b/src/core/vr/openxr_runtime.cpp
@@ -1203,6 +1203,12 @@ float xr_quat_yaw_deg(float qx, float qy, float qz, float qw) {
 // unreliable with projection-layer imageRect crops (VDXR kept the bars),
 // so the eye capture un-letterboxes the frame ITSELF - band stretched
 // across the full image by our own blit, plain copy everywhere else.
+// v0.4.0 ships the unsqueeze DEFAULT OFF ("vrcine unsqueeze on" re-arms):
+// three in-headset rounds could not make it remove the bars (mechanism
+// unresolved - parked for the next release) and a mistimed crop is a
+// content-loss risk. Detection, the drive suspension and the flash-native
+// frame all stay live - they are the parts the user verified.
+std::atomic<bool> g_lbUnsqueeze{false};
 ID3D11Texture2D* g_lbScratch = nullptr;        // backbuffer copy, SRV source
 ID3D11ShaderResourceView* g_lbScratchSrv = nullptr;
 ID3D11Texture2D* g_lbStretched = nullptr;      // our RTV target, then copied
@@ -1225,7 +1231,8 @@ void release_lb_scratch() {
 // copy (bars visible but nothing worse).
 void capture_frame(ID3D11Texture2D* dst, ID3D11Texture2D* backbuffer) {
     unsigned lbTop = 0, lbBot = 0;
-    if (bvr::hud::letterbox(&lbTop, &lbBot) && lbTop + lbBot < g_swapH) {
+    if (g_lbUnsqueeze.load(std::memory_order_relaxed) &&
+        bvr::hud::letterbox(&lbTop, &lbBot) && lbTop + lbBot < g_swapH) {
         D3D11_TEXTURE2D_DESC bd{};
         backbuffer->GetDesc(&bd);
         if (g_lbScratch) {
@@ -1958,7 +1965,13 @@ void publish_gameplay_view(bool strictGameplay) {
 }
 
 void handle_cine_command(const char* args) {
-    if (strncmp(args, "mode stereo", 11) == 0) {
+    if (strncmp(args, "unsqueeze on", 12) == 0) {
+        g_lbUnsqueeze.store(true, std::memory_order_relaxed);
+        BVR_LOG("xr: letterbox unsqueeze ON (experimental - bars mechanism unresolved)");
+    } else if (strncmp(args, "unsqueeze off", 13) == 0) {
+        g_lbUnsqueeze.store(false, std::memory_order_relaxed);
+        BVR_LOG("xr: letterbox unsqueeze off");
+    } else if (strncmp(args, "mode stereo", 11) == 0) {
         g_cineStereo.store(true, std::memory_order_relaxed);
         BVR_LOG("xr: cinematic mode STEREO (fov-mismatch scenes keep the projection, "
                 "claim = measured fov; strict-false/stale still drop to the quad)");

--- a/src/core/vr/openxr_runtime.h
+++ b/src/core/vr/openxr_runtime.h
@@ -137,6 +137,30 @@ void fov_audit(float* tanH, float* tanV, int* src, unsigned* swapW, unsigned* sw
 // next-cheapest suspect for a yaw-dependent lateral drift after the fov.
 void set_pose_audit(bool on);
 
+// --- Session 22: cinematic quad fallback --------------------------------------
+// The adapter publishes the strict gameplay-view verdict once per CalcView.
+// The projection layer drops to the M2 quad screen (3-present hysteresis both
+// edges) while ANY of: the verdict reads false (menu attract, scripted view
+// actor); the publish goes STALE (a camera path that bypasses CalcView); or
+// the live fov watch reports the game rendering a DIFFERENT fov than the
+// option (the bathysphere descent: renders 104, option/claim 130 - the
+// measured cause of the "fisheye + no fusion" cutscene percept; the scripted
+// camera still flows through CalcView there, so only this leg catches it).
+// "vrcine on|off|status" is the live A/B; "vrcine mode stereo" keeps the
+// projection during fov-mismatch scenes and fixes the CLAIM to the measured
+// fov instead (stereo cinematics - opt-in experiment, default quad).
+void publish_gameplay_view(bool strictGameplay);
+void handle_cine_command(const char* args);
+// True while the quad fallback is ACTIVE (render thread state). The adapter
+// suppresses the per-eye offsets while it holds (both presents must carry
+// the same image or the quad jitters by an IPD - the renderer consumes
+// CalcView's camera even in scripted scenes, dump-proven) and skips the live
+// head drive (head-steering a scripted camera wobbles the screen content).
+bool cinematic_active();
+// The hfov (deg) the adapter last read back from the engine's FOV option -
+// the projection claim source, and the fov watch's comparison baseline.
+float rendered_hfov_deg();
+
 // --- M4 rung 1: AlternateEye stereo -----------------------------------------
 // Which eye the NEXT game frame should render for: -1 left, +1 right, 0 =
 // AlternateEye off (render centered, exactly the M3 behavior). The adapter's

--- a/src/game/bioshock1r/aim.cpp
+++ b/src/game/bioshock1r/aim.cpp
@@ -889,7 +889,14 @@ void update_weapon_profile(const FrameContext& ctx) {
     bool haveRig = hands::current_holdable(&w);
     if (!haveRig) {
         w = hands::weapon_actor();
-        if (!w) w = hands::resolve_weapon_actor(ctx);
+        // Session 22: the SCAN fallback goes fully DORMANT after 3 straight
+        // failures - the reduced cadence still meant a multi-second heap
+        // walk every ~2000 frames FOREVER on saves with no resolvable
+        // weapon (the early game; user-felt as "the game freezes every
+        // couple of seconds" at the Gatherer's Garden). The cheap rig and
+        // learned-actor reads above keep running at the throttled cadence
+        // and re-arm the scanner the moment they see anything.
+        if (!w && nullResolves < 3) w = hands::resolve_weapon_actor(ctx);
     }
     nullResolves = (haveRig || w) ? 0 : nullResolves + 1;
     if (w == g_weaponKeyActor) return;

--- a/src/game/bioshock1r/aim.cpp
+++ b/src/game/bioshock1r/aim.cpp
@@ -66,12 +66,13 @@ std::atomic<bool> g_useAimPose{true};
 std::atomic<bool> g_muzzleRay{false};
 // Per-hand since session 16 part 3 (user request): each controller's wrist
 // posture wants its own trim. 0 = left (plasmid), 1 = right (weapon).
-// Defaults = the user's in-headset calibration, v0.3.0 bake (session 21
-// part 4, their explicit ask: the saved preset becomes the defaults). The
+// Defaults = the user's in-headset calibration (their explicit ask: the
+// saved preset becomes the defaults). Left trim re-baked session 22
+// (2026-07-29 headset run: -7.5/+37.0, "better than before"). The
 // right-hand TRIM stays 0 - the per-weapon profiles own the right hand;
 // its POS offsets below carry the generic baseline.
-std::atomic<float> g_pitchOffsetDeg[2] = {-6.8f, 0.0f};
-std::atomic<float> g_yawOffsetDeg[2] = {30.0f, 0.0f};
+std::atomic<float> g_pitchOffsetDeg[2] = {-7.5f, 0.0f};
+std::atomic<float> g_yawOffsetDeg[2] = {37.0f, 0.0f};
 // Per-hand aim-ray ORIGIN offsets in cm (session 18 part 2, user request):
 // the model offsets move the MESH about its pivot, so a tuned model can sit
 // right while the ray no longer runs along the barrel. These move the RAY
@@ -1507,6 +1508,8 @@ float trim_pitch_deg(int hand) {
 float trim_yaw_deg(int hand) {
     return g_yawOffsetDeg[hand == 0 ? 0 : 1].load(std::memory_order_relaxed);
 }
+
+bool laser_enabled() { return g_laser.load(std::memory_order_relaxed); }
 
 float pos_fwd_cm(int hand) {
     return g_posFwdCm[hand == 0 ? 0 : 1].load(std::memory_order_relaxed);

--- a/src/game/bioshock1r/aim.h
+++ b/src/game/bioshock1r/aim.h
@@ -91,6 +91,11 @@ float pos_right_cm(int hand);
 float pos_up_cm(int hand);
 void set_pos_offset(int hand, float fwdCm, float rightCm, float upCm);
 
+// Session 22: the laser is OFF by default (user's call - it was a
+// calibration tool; profiles are calibrated now). The preset applies the
+// persisted vrpreset.ini choice (`laserOn`), so opting back in sticks.
+bool laser_enabled();
+
 // True while substitution is armed (master switch + a usable hand ray).
 bool active();
 

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -203,15 +203,22 @@ float* fov_ptr(void* pc) {
     return reinterpret_cast<float*>(static_cast<uint8_t*>(pc) + patterns::kFovLiveOffset);
 }
 
-// Half-IPD shift along view-right of `rot`, sign -1 = left eye. Same math the
-// AER path uses, shared by both SequentialReentry passes.
+// Half-IPD shift along view-right of `rot`, sign -1 = left eye. Shared by
+// both SequentialReentry passes and the AER path. Session 22: the right axis
+// comes from the FULL rotation (ue_rot_basis) - the old yaw-only right kept
+// the virtual eyes horizontal while real eyes stack vertically under head
+// roll (the "weird stereoscopy when tilting the head sideways" report). At
+// roll 0 the basis row reduces to (-sin yaw, cos yaw, 0), bit-identical to
+// the old formula - the neutral-roll rendering is unchanged by construction.
 void apply_eye_offset(FVector* loc, const FRotator& rot, int sign) {
-    float yawRad = static_cast<float>(rot.yaw) / kRotUnitsPerRadian;
+    float fwd[3], right[3], up[3];
+    ue_rot_basis(rot, fwd, right, up);
     float halfIpdUu = static_cast<float>(sign) *
                       (g_ipdMm.load(std::memory_order_relaxed) / 2000.0f) *
                       g_worldScale.load(std::memory_order_relaxed);
-    loc->x += -sinf(yawRad) * halfIpdUu;
-    loc->y += cosf(yawRad) * halfIpdUu;
+    loc->x += right[0] * halfIpdUu;
+    loc->y += right[1] * halfIpdUu;
+    loc->z += right[2] * halfIpdUu;
 }
 
 // Automated-test seam: %LOCALAPPDATA%\BioshockVR\command.txt is polled at 1 Hz
@@ -374,6 +381,21 @@ void apply_command(const char* cmd, const char* args) {
         // "fovaudit pose on|off" arms the tagged-vs-consumed yaw log (headset).
         if (strncmp(args, "pose", 4) == 0) {
             bvr::vr::set_pose_audit(strstr(args + 4, "on") != nullptr);
+        } else if (strncmp(args, "eyes", 4) == 0) {
+            // Session 22 head-roll gate: the per-eye camera stash and their
+            // delta vector. Under `simhead 0 0 <roll>` the delta must rotate
+            // with the roll (|z| -> halfIpd at 90 deg); pre-fix it stayed
+            // horizontal at every roll.
+            uint64_t nowMs = GetTickCount64();
+            BVR_LOG("[b1r] eyecam L=(%.3f %.3f %.3f) R=(%.3f %.3f %.3f) "
+                    "d=(%.3f %.3f %.3f) ageL=%llums ageR=%llums",
+                    g_eyeCamLoc[0].x, g_eyeCamLoc[0].y, g_eyeCamLoc[0].z,
+                    g_eyeCamLoc[1].x, g_eyeCamLoc[1].y, g_eyeCamLoc[1].z,
+                    g_eyeCamLoc[1].x - g_eyeCamLoc[0].x,
+                    g_eyeCamLoc[1].y - g_eyeCamLoc[0].y,
+                    g_eyeCamLoc[1].z - g_eyeCamLoc[0].z,
+                    static_cast<unsigned long long>(nowMs - g_eyeCamStampMs[0]),
+                    static_cast<unsigned long long>(nowMs - g_eyeCamStampMs[1]));
         } else {
             int32_t* opt = patterns::hfov_option_ptr();
             float tanH = 0.0f, tanV = 0.0f;
@@ -520,9 +542,10 @@ void apply_command(const char* cmd, const char* args) {
             unsigned hd = 0, rd = 0, lk = 0, iv = 0;
             bvr::hud::get_counters(&hd, &rd, &lk, &iv);
             BVR_LOG("[hud] status: %s force=%d | hudDraws=%u redirects=%u leaks=%u "
-                    "hudIntervals=%u (vrhud on|off|force on|force off|status)",
+                    "hudIntervals=%u | postFx=%u screenOnly=%d "
+                    "(vrhud on|off|force on|force off|status)",
                     bvr::hud::enabled() ? "ON" : "off", bvr::hud::force() ? 1 : 0, hd, rd,
-                    lk, iv);
+                    lk, iv, bvr::hud::postfx_count(), bvr::hud::screen_only() ? 1 : 0);
         }
     } else if (strcmp(cmd, "vrxhair") == 0) {
         // M8 part 2: the flat-screen crosshair. Default HIDDEN; "on" re-shows.
@@ -575,6 +598,9 @@ void save_vr_preset() {
     fprintf(f, "aimPosRUp=%.1f\n", aim::pos_up_cm(1));
     fprintf(f, "bodyRate=%.2f\n", body::rate_per_sec());
     fprintf(f, "bodyDeadzoneDeg=%.1f\n", body::deadzone_deg());
+    fprintf(f, "turnScale=%.2f\n", bvr::input::turn_scale());
+    fprintf(f, "snapTurn=%d\n", bvr::input::snap_turn() ? 1 : 0);
+    fprintf(f, "snapAngleDeg=%.0f\n", bvr::input::snap_angle_deg());
     fprintf(f, "crosshairVisible=%d\n",
             g_crosshairVisible.load(std::memory_order_relaxed) ? 1 : 0);
     {
@@ -630,6 +656,9 @@ void load_vr_preset_values() {
         else if (strcmp(key, "aimPosRUp") == 0) pru = v;
         else if (strcmp(key, "bodyRate") == 0) bodyRate = v;
         else if (strcmp(key, "bodyDeadzoneDeg") == 0) bodyDz = v;
+        else if (strcmp(key, "turnScale") == 0) bvr::input::set_turn_scale(v);
+        else if (strcmp(key, "snapTurn") == 0) bvr::input::set_snap_turn(v != 0.0f);
+        else if (strcmp(key, "snapAngleDeg") == 0) bvr::input::set_snap_angle_deg(v);
         else if (strcmp(key, "crosshairVisible") == 0)
             g_crosshairVisible.store(v != 0.0f, std::memory_order_relaxed);
         else if (strcmp(key, "hudQuadDistM") == 0) hudD = v;
@@ -928,14 +957,9 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
         // SequentialReentry stereo (rung 2), which applies both eye offsets
         // itself at the end of this body.
         int eyeSign = scenedraw::stereo_active() ? 0 : bvr::vr::current_eye_sign();
-        if (eyeSign != 0) {
-            float finalYawRad = static_cast<float>(rot->yaw) / kRotUnitsPerRadian;
-            float halfIpdUu =
-                static_cast<float>(eyeSign) *
-                (g_ipdMm.load(std::memory_order_relaxed) / 2000.0f) * scale;
-            loc->x += -sinf(finalYawRad) * halfIpdUu;
-            loc->y += cosf(finalYawRad) * halfIpdUu;
-        }
+        // Session 22: routed through apply_eye_offset so SR and AER share ONE
+        // implementation (full-rotation right axis, head-roll correct).
+        if (eyeSign != 0) apply_eye_offset(loc, *rot, eyeSign);
 
         vrFov = g_forceHeadsetFov.load(std::memory_order_relaxed)
                     ? bvr::vr::suggested_hfov_deg()
@@ -1223,6 +1247,22 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
         // These two are the same integer, which is what makes the invariant a
         // theorem instead of a tolerance.
         if (moved) g_recenterYawUnits = wrap_rot(g_recenterYawUnits + moved);
+    }
+
+    // Session 22 snap turn: shift the recenter composite by one step per
+    // queued edge - subtracting from recenterYaw raises the residual exactly
+    // like a physical head turn, and the M7.5 transfer above carries the
+    // body on the following frames (instant at the shipped rate 0). The
+    // composite invariant is untouched by construction; effect lands next
+    // CalcView (this frame's residual was already consumed).
+    if (g_haveRecenter && vrDrove) {
+        if (int steps = bvr::input::take_snap_steps()) {
+            int32_t units = static_cast<int32_t>(
+                lroundf(bvr::input::snap_angle_deg() * kRotUnitsPerDegree * steps));
+            g_recenterYawUnits = wrap_rot(g_recenterYawUnits - units);
+            BVR_LOG("[b1r] snap turn %+d step(s) (%.0f deg each)", steps,
+                    bvr::input::snap_angle_deg());
+        }
     }
 }
 

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -87,6 +87,17 @@ std::atomic<bool> g_vrPresetSavePending{false};
 std::atomic<bool> g_crosshairVisible{false}; // `vrxhair on` re-shows it
 int g_crosshairApplied = -1;                 // last state pushed (-1 = never)
 uint64_t g_crosshairAssertMs = 0;            // game thread only
+// Session 22 round 5 (user ask, pre-release): the pad SOFT LOCK-ON (aim
+// magnetism - GamepadPlayerInput.SoftLockOnRadius, found in the reticle
+// script source) drags aim toward targets because our motion controllers
+// register as a gamepad. Default DISABLED in VR via the same engine-SET
+// mechanism as the crosshair; re-asserted on the same slow cadence. NOTE:
+// unchecking only stops the assert - the game's own radius returns on the
+// next game restart (SET edits are memory-only and the original default is
+// not readable through this seam).
+std::atomic<bool> g_lockOnDisabled{true};
+int g_lockOnApplied = -1;
+uint64_t g_lockOnAssertMs = 0;
 std::atomic<bool>  g_recenterRequested{true};  // auto-recenter on first drive
 std::atomic<bool>  g_vrDriving{false};         // telemetry for the UI
 std::atomic<bool>  g_forceHeadsetFov{false};   // session 4: now writes the REAL control (the
@@ -610,6 +621,8 @@ void save_vr_preset() {
     fprintf(f, "snapTurn=%d\n", bvr::input::snap_turn() ? 1 : 0);
     fprintf(f, "snapAngleDeg=%.0f\n", bvr::input::snap_angle_deg());
     fprintf(f, "laserOn=%d\n", aim::laser_enabled() ? 1 : 0);
+    fprintf(f, "lockOnDisabled=%d\n",
+            g_lockOnDisabled.load(std::memory_order_relaxed) ? 1 : 0);
     fprintf(f, "crosshairVisible=%d\n",
             g_crosshairVisible.load(std::memory_order_relaxed) ? 1 : 0);
     {
@@ -670,6 +683,8 @@ void load_vr_preset_values() {
         else if (strcmp(key, "snapAngleDeg") == 0) bvr::input::set_snap_angle_deg(v);
         else if (strcmp(key, "laserOn") == 0)
             aim::handle_command(v != 0.0f ? "laser on" : "laser off");
+        else if (strcmp(key, "lockOnDisabled") == 0)
+            g_lockOnDisabled.store(v != 0.0f, std::memory_order_relaxed);
         else if (strcmp(key, "crosshairVisible") == 0)
             g_crosshairVisible.store(v != 0.0f, std::memory_order_relaxed);
         else if (strcmp(key, "hudQuadDistM") == 0) hudD = v;
@@ -721,6 +736,24 @@ void assert_crosshair(uint64_t now) {
     g_crosshairAssertMs = now;
     console_exec::run_engine(want ? "set ShockPlayer bReticleDisabled False"
                                   : "set ShockPlayer bReticleDisabled True");
+}
+
+// Session 22: zero the pad soft lock-on radius while disabled (default).
+// Only asserts the DISABLED state - see the declaration note (the game's
+// own value returns on restart when the user re-enables it).
+void assert_lockon(uint64_t now) {
+    int want = g_lockOnDisabled.load(std::memory_order_relaxed) ? 1 : 0;
+    bool due = want != g_lockOnApplied ||
+               (want == 1 && now - g_lockOnAssertMs >= 15000);
+    if (!due) return;
+    bool first = g_lockOnApplied != want;
+    g_lockOnApplied = want;
+    g_lockOnAssertMs = now;
+    if (want)
+        console_exec::run_engine("set GamepadPlayerInput SoftLockOnRadius 0");
+    else if (first)
+        BVR_LOG("[b1r] pad lock-on re-enabled: the game's own radius returns "
+                "on the next game restart");
 }
 
 void poll_command_file(uint64_t now) {
@@ -837,6 +870,7 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
     // (self-throttles to once per present; no-op while vrinput is off).
     input_drive::on_frame(now);
     assert_crosshair(now); // M8 part 2: flat crosshair hidden by default
+    assert_lockon(now);    // session 22: pad aim magnetism off by default
     if (g_logCamera.load(std::memory_order_relaxed)) {
         if (g_lastHeartbeatMs == 0) {
             g_lastHeartbeatMs = now;
@@ -1442,6 +1476,9 @@ void draw_debug_ui() {
         bool xhair = g_crosshairVisible.load(std::memory_order_relaxed);
         if (ImGui::Checkbox("Flat-screen crosshair (default off in VR)", &xhair))
             g_crosshairVisible.store(xhair, std::memory_order_relaxed);
+        bool lockoff = g_lockOnDisabled.load(std::memory_order_relaxed);
+        if (ImGui::Checkbox("Lock-on disabled (pad aim magnetism off)", &lockoff))
+            g_lockOnDisabled.store(lockoff, std::memory_order_relaxed);
         atomic_slider("World scale (UU per m)", g_worldScale, 10.0f, 200.0f);
         atomic_slider("IPD (mm)", g_ipdMm, 55.0f, 75.0f);
         atomic_slider("Head offset up (UU)", g_headOffUpUu, -150.0f, 150.0f);

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -179,6 +179,18 @@ SimHead g_simHead;
 bool g_srBaseValid = false;
 FVector g_srBaseLoc{};
 FRotator g_srBaseRot{};
+// Session 22: age + eye-offset latch for the pass-2 replay. The stamp kills
+// the stale-base hazard - CalcView can go silent for minutes during scripted
+// scenes, and pass 2 must never replay a pre-cutscene camera. The latch
+// carries pass-1's strict-gameplay decision so a non-gameplay pair renders
+// both eyes IDENTICAL (the quad screen shows one image; an IPD offset
+// between its two source presents would jitter it).
+uint64_t g_srBaseStampMs = 0;
+bool g_srBaseEyed = false;
+// Last normal-pass CalcView tick (game thread). Scripted cameras bypass
+// CalcView entirely, so staleness here is the cutscene signal for the
+// BuildDetour-side FOV restore and the second-build skip.
+uint64_t g_lastCalcViewMs = 0;
 
 // Session 21 fg view-sync stash: the final per-eye camera (post eye offset)
 // of the current pair. Game thread only (1t); freshness-gated by stamp so a
@@ -211,6 +223,11 @@ void apply_eye_offset(FVector* loc, const FRotator& rot, int sign) {
 // "recenter", "fovaudit [pose on|off]" (session 21: option vs submitted vs
 // option-derived fov side by side; `pose on` arms the tagged-vs-consumed
 // yaw log for the headset).
+// "vrcine on|off|mode quad|mode stereo|status" (session 22: cinematic quad
+// fallback - scripted scenes and menus drop the projection layer to the
+// big-screen quad; the detector is strict-view/staleness/rendered-vs-option
+// fov mismatch; "mode stereo" keeps the projection through fov-mismatch
+// scenes and claims the measured fov; status prints counters + fov watch).
 // Discovery commands (route to core/debug/value_scan; game thread only):
 //   memscan <f>  memrescan <f>  memlist [n]  memread <idx>
 //   memscani <u>  memrescani <u>   (integer-typed variants)
@@ -379,8 +396,21 @@ void apply_command(const char* cmd, const char* args) {
                     src == 0   ? "readback"
                     : src == 1 ? "fallback"
                     : src == 2 ? "manual"
+                    : src == 3 ? "live"
                                : "none",
                     sw, sh, optTanH, optTanV);
+            // Session 22 live fov watch: what the game is ACTUALLY rendering
+            // right now (decoded per present from the first scene draw's cb0).
+            float liveTanH = 0.0f, liveTanV = 0.0f;
+            unsigned long long liveAge = 0;
+            if (bvr::hud::fov_watch(&liveTanH, &liveTanV, &liveAge))
+                BVR_LOG("[b1r] fovaudit live: rendered tanH=%.4f tanV=%.4f (%.1f deg) "
+                        "age=%llums | mismatch=%d cineActive=%d",
+                        liveTanH, liveTanV, 2.0f * atanf(liveTanH) * kRadToDeg,
+                        liveAge, bvr::hud::fov_mismatch() ? 1 : 0,
+                        bvr::vr::cinematic_active() ? 1 : 0);
+            else
+                BVR_LOG("[b1r] fovaudit live: no decoded scene tangents yet");
         }
     } else if (strcmp(cmd, "fsweep") == 0) {
         float lo = 0.0f, hi = 0.0f;
@@ -473,6 +503,8 @@ void apply_command(const char* cmd, const char* args) {
         bvr::vr::handle_pace_command(args); // M8 disconnect-stall guard
     } else if (strcmp(cmd, "vrmirror") == 0) {
         bvr::vr::handle_mirror_command(args); // M8 single-eye desktop mirror
+    } else if (strcmp(cmd, "vrcine") == 0) {
+        bvr::vr::handle_cine_command(args); // session 22 cinematic quad fallback
     } else if (strcmp(cmd, "vrhud") == 0) {
         // Session 19 HUD capture: gameswf HUD redirected off the game frame
         // (clean eyes) and shown as a floating quad in stereo.
@@ -696,10 +728,14 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
     float reentryYawDeg = 0.0f;
     if (scenedraw::second_pass_for_current_thread(&reentryYawDeg)) {
         g_original(self, edx, viewActor, loc, rot);
-        if (scenedraw::stereo_active() && g_srBaseValid && loc && rot) {
+        // Session 22: the 100 ms age gate keeps a resuming CalcView from
+        // replaying a base armed before a scene (pass 2 always follows its
+        // pass 1 within one tick; anything older is a stale pair).
+        if (scenedraw::stereo_active() && g_srBaseValid && loc && rot &&
+            GetTickCount64() - g_srBaseStampMs <= 100) {
             *loc = g_srBaseLoc;
             *rot = g_srBaseRot;
-            apply_eye_offset(loc, *rot, +1);
+            if (g_srBaseEyed) apply_eye_offset(loc, *rot, +1);
             g_eyeCamLoc[1] = *loc; // fg view-sync stash, RIGHT eye
             g_eyeCamRot[1] = *rot;
             g_eyeCamStampMs[1] = GetTickCount64();
@@ -750,6 +786,7 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
     }
 
     uint64_t now = GetTickCount64();
+    g_lastCalcViewMs = now; // session 22: cutscene-silence detector
     poll_command_file(now);
     // Overlay preset buttons land here (game thread; the overlay draws on
     // the render thread and only sets the pending flags).
@@ -788,6 +825,16 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
     // The same quantity in rotator units - what M7.5 transfers to the body.
     int32_t residualUnits = 0;
     int32_t gameYawUnitsRaw = rot ? rot->yaw : 0; // the engine's own body yaw
+
+    // Session 22: the strict gameplay-view verdict (body.cpp predicate, no
+    // menu-attract escape hatch) now gates the live head drive, the FOV
+    // write, and the eye offsets, so it is computed up front - it used to
+    // live in the FrameContext publish below. Published to the render thread
+    // too: the cinematic quad fallback keys on it (and on its staleness -
+    // scripted cameras bypass CalcView entirely).
+    bool strictGameplay = body::is_gameplay_view(viewActor ? *viewActor : nullptr);
+    bvr::vr::publish_gameplay_view(strictGameplay);
+
     bvr::vr::HeadPose hp{};
     bool driveHead = false;
     bool liveHead = false;
@@ -810,7 +857,13 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
         hp.qz = q[2];
         hp.qw = q[3];
         driveHead = true;
-    } else if (bvr::vr::vr_camera_mode() && bvr::vr::get_head_pose(hp)) {
+    } else if (strictGameplay && !bvr::vr::cinematic_active() &&
+               bvr::vr::vr_camera_mode() && bvr::vr::get_head_pose(hp)) {
+        // Session 22: the live lane is gated on the strict view AND the
+        // cinematic fallback - the HMD must not steer scripted/menu cameras
+        // (their content lands on the quad screen, and head-steering it
+        // would wobble the whole screen). The sim and replay lanes above
+        // stay ungated for flat tests.
         driveHead = true;
         liveHead = true;
     }
@@ -908,8 +961,13 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
     // source). Precedence: VR forced headset fov > manual gfov. One-shot
     // save/restore so the user's option value returns untouched.
     if (optionFov) {
-        bool wantVr = vrDrove && vrFov > 0.0f;
-        bool wantManual = g_gameFovWrite.load(std::memory_order_relaxed);
+        // Session 22: both wants are gated on the strict view, so leaving
+        // gameplay (scripted camera that still CalcViews, menus) restores the
+        // authored FOV through the existing latch and re-arms on return. The
+        // CalcView-SILENT case (descent) cannot reach this code - scenedraw's
+        // BuildDetour calls restore_game_fov_if_stale() for it.
+        bool wantVr = strictGameplay && vrDrove && vrFov > 0.0f;
+        bool wantManual = strictGameplay && g_gameFovWrite.load(std::memory_order_relaxed);
         if (wantVr || wantManual) {
             if (!g_wasWritingGameFov) {
                 g_savedGameFov = *optionFov;
@@ -978,11 +1036,10 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
         fc.pc = self;
         g_lastViewActor.store(fc.viewActor, std::memory_order_relaxed);
 
-        // Strict gameplay-view (body.cpp predicate, no menu-attract escape
-        // hatch), published to the input bridge as the stick-pitch-kill gate
+        // Strict gameplay-view (hoisted above the drive lanes since session
+        // 22), published to the input bridge as the stick-pitch-kill gate
         // and logged on transition - the harness's generic "in gameplay"
         // signal (boot.ps1 watches for this line; any save, any level).
-        bool strictGameplay = body::is_gameplay_view(fc.viewActor);
         bvr::input::publish_vr_gameplay(vrDrove && strictGameplay);
         static int s_lastViewState = -1;
         int viewState = strictGameplay ? 1 : 0;
@@ -1087,7 +1144,14 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
         g_srBaseLoc = *loc;
         g_srBaseRot = *rot;
         g_srBaseValid = true;
-        apply_eye_offset(loc, *rot, -1);
+        g_srBaseStampMs = now;
+        // Session 22: while the cinematic quad fallback holds (or the view is
+        // not strict gameplay), both eyes stay IDENTICAL - the quad shows one
+        // image per present and an IPD offset would jitter it. The renderer
+        // consumes CalcView's camera even in scripted scenes (dump-proven),
+        // so this suppression is load-bearing, not belt-and-suspenders.
+        g_srBaseEyed = strictGameplay && !bvr::vr::cinematic_active();
+        if (g_srBaseEyed) apply_eye_offset(loc, *rot, -1);
         g_eyeCamLoc[0] = *loc; // fg view-sync stash, LEFT eye
         g_eyeCamRot[0] = *rot;
         g_eyeCamStampMs[0] = GetTickCount64();
@@ -1201,6 +1265,25 @@ bool fg_fov_match_active() {
 
 bool hook_live() {
     return g_hookLive.load(std::memory_order_relaxed);
+}
+
+// Session 22: scripted cameras bypass eventPlayerCalcView, so the FOV write's
+// normal restore path (inside CalcViewDetour) cannot run during them. The
+// scene-build detour - which keeps firing on the same game thread - calls
+// these instead. Re-arm is automatic on the first CalcView after the scene.
+bool calcview_silent(uint64_t staleMs) {
+    return g_lastCalcViewMs != 0 && GetTickCount64() - g_lastCalcViewMs > staleMs;
+}
+
+void restore_game_fov_if_stale(uint64_t staleMs) {
+    if (!g_wasWritingGameFov || !calcview_silent(staleMs)) return;
+    int32_t* optionFov = patterns::hfov_option_ptr();
+    if (!optionFov) return;
+    *optionFov = g_savedGameFov;
+    g_wasWritingGameFov = false;
+    BVR_LOG("[b1r] game fov write OFF (restored option %d - calcview silent %llu ms)",
+            g_savedGameFov,
+            static_cast<unsigned long long>(GetTickCount64() - g_lastCalcViewMs));
 }
 
 void get_recenter_state(bvr::vr::HeadPose* pose, int32_t* yawUnits, float* worldScale) {

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -546,11 +546,14 @@ void apply_command(const char* cmd, const char* args) {
         } else {
             unsigned hd = 0, rd = 0, lk = 0, iv = 0;
             bvr::hud::get_counters(&hd, &rd, &lk, &iv);
+            unsigned lbT = 0, lbB = 0;
+            bool lb = bvr::hud::letterbox(&lbT, &lbB);
             BVR_LOG("[hud] status: %s force=%d | hudDraws=%u redirects=%u leaks=%u "
-                    "hudIntervals=%u | postFx=%u screenOnly=%d "
+                    "hudIntervals=%u | postFx=%u screenOnly=%d letterbox=%d(%u/%u) "
                     "(vrhud on|off|force on|force off|status)",
                     bvr::hud::enabled() ? "ON" : "off", bvr::hud::force() ? 1 : 0, hd, rd,
-                    lk, iv, bvr::hud::postfx_count(), bvr::hud::screen_only() ? 1 : 0);
+                    lk, iv, bvr::hud::postfx_count(), bvr::hud::screen_only() ? 1 : 0,
+                    lb ? 1 : 0, lbT, lbB);
         }
     } else if (strcmp(cmd, "vrxhair") == 0) {
         // M8 part 2: the flat-screen crosshair. Default HIDDEN; "on" re-shows.

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -7,6 +7,7 @@
 #include "core/debug/value_scan.h"
 #include "core/gfx/frame_inspector.h"
 #include "core/gfx/hud_capture.h"
+#include "core/ui/overlay.h"
 #include "core/input/xinput_bridge.h"
 #include "core/util/log.h"
 #include "game/bioshock1r/aim.h"
@@ -527,6 +528,10 @@ void apply_command(const char* cmd, const char* args) {
         bvr::vr::handle_mirror_command(args); // M8 single-eye desktop mirror
     } else if (strcmp(cmd, "vrcine") == 0) {
         bvr::vr::handle_cine_command(args); // session 22 cinematic quad fallback
+    } else if (strcmp(cmd, "vroverlay") == 0) {
+        bool on = strncmp(args, "on", 2) == 0;
+        bvr::overlay::set_visible(on);
+        BVR_LOG("[b1r] overlay %s (seam request)", on ? "ON" : "off");
     } else if (strcmp(cmd, "vrhud") == 0) {
         // Session 19 HUD capture: gameswf HUD redirected off the game frame
         // (clean eyes) and shown as a floating quad in stereo.
@@ -601,6 +606,7 @@ void save_vr_preset() {
     fprintf(f, "turnScale=%.2f\n", bvr::input::turn_scale());
     fprintf(f, "snapTurn=%d\n", bvr::input::snap_turn() ? 1 : 0);
     fprintf(f, "snapAngleDeg=%.0f\n", bvr::input::snap_angle_deg());
+    fprintf(f, "laserOn=%d\n", aim::laser_enabled() ? 1 : 0);
     fprintf(f, "crosshairVisible=%d\n",
             g_crosshairVisible.load(std::memory_order_relaxed) ? 1 : 0);
     {
@@ -659,6 +665,8 @@ void load_vr_preset_values() {
         else if (strcmp(key, "turnScale") == 0) bvr::input::set_turn_scale(v);
         else if (strcmp(key, "snapTurn") == 0) bvr::input::set_snap_turn(v != 0.0f);
         else if (strcmp(key, "snapAngleDeg") == 0) bvr::input::set_snap_angle_deg(v);
+        else if (strcmp(key, "laserOn") == 0)
+            aim::handle_command(v != 0.0f ? "laser on" : "laser off");
         else if (strcmp(key, "crosshairVisible") == 0)
             g_crosshairVisible.store(v != 0.0f, std::memory_order_relaxed);
         else if (strcmp(key, "hudQuadDistM") == 0) hudD = v;
@@ -686,7 +694,8 @@ void apply_vr_preset() {
     aim::handle_command("on");         // controller aim (R weapon / L plasmid)
     aim::handle_command("pose aim");   // the runtime AIM pose
     aim::handle_command("origin on");  // ray starts at the hand
-    aim::handle_command("laser on");
+    // Session 22: the laser no longer arms here - OFF by default (user's
+    // call), applied from the persisted `laserOn` ini key in the load below.
     hands::handle_command("on");       // viewmodel follows the controller
     hands::handle_command("pose aim"); // align to the AIM ray
     body::handle_command("on");        // M7.5: stick-forward = look direction
@@ -887,12 +896,16 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
         hp.qw = q[3];
         driveHead = true;
     } else if (strictGameplay && !bvr::vr::cinematic_active() &&
+               !bvr::hud::letterbox(nullptr, nullptr) &&
                bvr::vr::vr_camera_mode() && bvr::vr::get_head_pose(hp)) {
         // Session 22: the live lane is gated on the strict view AND the
         // cinematic fallback - the HMD must not steer scripted/menu cameras
         // (their content lands on the quad screen, and head-steering it
-        // would wobble the whole screen). The sim and replay lanes above
-        // stay ungated for flat tests.
+        // would wobble the whole screen). Round 2: also suspended while the
+        // engine letterbox is up (plasmid FMV sequences) so the AUTHORED
+        // camera choreography plays exactly like flat - stereo stays (the
+        // eye offsets ride the authored camera). The sim and replay lanes
+        // above stay ungated for flat tests.
         driveHead = true;
         liveHead = true;
     }

--- a/src/game/bioshock1r/camera.h
+++ b/src/game/bioshock1r/camera.h
@@ -37,6 +37,18 @@ void set_recenter_state(const bvr::vr::HeadPose& pose, int32_t yawUnits, float w
 // no fresh stash exists (stereo off, drive idle > 200 ms, or never driven).
 bool driven_eye_cam(int eye, float loc[3], int32_t rot[3]);
 
+// Session 22 cinematic fallback, called from scenedraw's BuildDetour (same
+// game thread): scripted cameras bypass eventPlayerCalcView, so the FOV
+// write's normal restore path cannot run during them.
+//   calcview_silent          true once the normal CalcView pass has been
+//                            quiet for more than staleMs (0 = never fired
+//                            reads as NOT silent - conservative at boot)
+//   restore_game_fov_if_stale  one-shot restore of the FOV option the write
+//                            latched; re-arms automatically when CalcView
+//                            resumes (the latch lives in CalcViewDetour)
+bool calcview_silent(uint64_t staleMs);
+void restore_game_fov_if_stale(uint64_t staleMs);
+
 // Full ImGui section: hook status, telemetry, and all debug controls.
 // Called from the overlay through IGameAdapter::drawDebugUi().
 void draw_debug_ui();

--- a/src/game/bioshock1r/scenedraw.cpp
+++ b/src/game/bioshock1r/scenedraw.cpp
@@ -631,6 +631,17 @@ void maybe_second_build(void* ecx, void* edx, void* a1, void* a2, void* a3,
     }
     if (!want) return;
 
+    // Session 22: with CalcView silent (scripted scene) pass 2 would just
+    // re-render an identical camera - no eye offsets arm, and the cinematic
+    // fallback is showing the quad. Skip the wasted double build (and its
+    // blocking waitFrame). Same-thread ordering makes this exact: a stalled
+    // game thread stalls builds too, so silence here can only mean the engine
+    // is deliberately skipping CalcView.
+    if (camera::calcview_silent(400)) {
+        g_stereoSkips.fetch_add(1, std::memory_order_relaxed);
+        return;
+    }
+
     // Stall guard 1 (reactive): no present since the previous build means the
     // render thread is paused (unfocused) or wedged - do not stack a second
     // frame onto a stalled pipeline.
@@ -732,6 +743,15 @@ void __fastcall BuildDetour(void* ecx, void* edx, void* a1, void* a2, void* a3,
         static_cast<uint32_t>(bvr::d3d11_hook::present_count());
     uint32_t presentDelta = presentLow - g_lastBuildPresentLow;
     g_lastBuildPresentLow = presentLow;
+
+    // Session 22: scripted cameras (bathysphere descent) bypass CalcView, so
+    // the FOV write's restore path never runs there - do it from here, the
+    // game-thread hook that keeps firing during scenes, BEFORE the build so
+    // this very frame renders at the authored FOV. Re-arm is automatic when
+    // CalcView resumes (camera.cpp owns the latch). 400 ms sits ABOVE the
+    // render side's 300 ms quad fallback on purpose (quad-over-forced-FOV for
+    // ~100 ms is invisible; projection-over-restored-FOV would not be).
+    if (depth == 0) camera::restore_game_fov_if_stale(400);
 
     // Stereo eye tag for pass 1 (LEFT), pushed BEFORE the original: the
     // pass's Present strictly follows (async via the pump in threaded mode,

--- a/tools/boot.ps1
+++ b/tools/boot.ps1
@@ -44,6 +44,12 @@ if (-not $game) { "FAIL: game window never appeared"; exit 1 }
 [W]::SetForegroundWindow($game.MainWindowHandle) | Out-Null
 Start-Sleep -Seconds 3
 
+# Session 22: the vrinput.on marker retired with the first-boot probe fix, so
+# nothing pre-arms vrinput at boot anymore - and the test-press slots only
+# compose while vrinput is ON. Arm it before the press loop.
+& "$repo\tools\game-cmd.ps1" "vrinput on" | Out-Null
+Start-Sleep -Seconds 2
+
 # Phase 2: A-press loop until the strict gameplay-view transition logs. The
 # line fires once per menu->gameplay transition, so search the whole log (it
 # is truncated at DLL attach, small, and the one-shot line would scroll out


### PR DESCRIPTION
## What this ships

**Cinematics (the headline).** Both on-file hypotheses about the bathysphere descent were disproven by flat measurement: CalcView keeps firing with a ShockPlayer view the whole ride and the renderer consumes our camera writes - the real defect is the scene rendering its OWN fov (104.0 measured) while the projection layer claims the FOV option (130). The 26-deg claim-over-render mismatch is the fisheye AND the broken stereo fusion. Shipped:
- a live rendered-FOV watch in hud_capture (per-present cb0 tangent decode, async staging, zero stalls, transitions logged - fully flat-testable)
- a cinematic fallback in on_present_end keyed on strict-view / publish-staleness / fov-mismatch / screen-only, with 3-present hysteresis, `vrcine` seam + overlay controls
- default = STEREO cinematics (the projection stays up with the claim fixed to the measured fov - head-look works); the big-screen quad is one overlay toggle away

**Fullscreen routing.** Dump-fingerprinted all three misrouted kinds: hack minigame + loading screens are PURE gameswf intervals with the world pass absent (322/87 draws, zero DrawIndexed) -> new screen-only detector drops them to the readable screen; the alcohol-blur composite samples a backbuffer-sized texture -> stays in-frame per eye (postFx counter shows zero false positives in gameplay).

**First-boot restart killed.** compose_over answers the game's one-shot boot probe with a neutral connected pad; marker file + README restart note retired. Virgin-install gate passed: KB/M prompts untouched, IAT lane polls ~680/s after a mid-session `vrinput on`, no restart.

**Head-roll eye separation.** apply_eye_offset offsets along the full rotation's right axis (ue_rot_basis; AER path unified). Eye delta measured (6.3,0,0)/(4.455,0,-4.454)/(0,0,-6.3) UU at roll 0/45/90.

**Turn controls.** Smooth-turn speed scale + snap turn (recenter-composite steps carried by the body transfer; +-8192-unit exact steps, one per pulse). Persisted + overlay.

**Movement-wonkiness instrument.** `vrinput sticklog` + last_composed_sticks(); the headset capture and analysis are queued.

## Flat gates (all green, clean boots)
- Descent: one rendered-fov mismatch ON at the lever (104.0 vs 130.0), one off at arrival, live tangents match dump decode to 1e-4, zero false transitions across pause/loads, two replays
- Screen-only: exactly one ON/off pair per save load (87/120-draw intervals); live hack board fired it with the user at the machine
- Virgin boot: prompts KB/M, probe answered, no-restart engage proven by IAT counters + menu reaction
- Eye delta / snap steps / turn scale: exact to the digit (see STATUS)
- Stereo heartbeat clean (presents = 2x builds, guardskips 0), fire seam subs exact with sim lanes armed, crash dumps 9 -> 9, user inis restored byte-identical after the virgin test

## Not in this PR
The in-headset verdicts (stereo-vs-screen cinematic default, BD FMV routing, pause-dim look, turn feel) - the release cuts only after the user's manual test and explicit go.
