### PR TITLE
s25: BS2 FOV - readback + forced-headset write, fisheye/world-drag fixed

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -568,3 +568,29 @@ runtime.
   machinery, and only the parts proven necessary. First application: the FOV work must
   start by testing whether BS2's native FOV propagation already keeps the viewmodel
   correct across FOV values - if it does, BS1's entire fg apparatus stays unported.
+
+- **2026-07-29 (session 25, M10): discovery tooling DUPLICATED into b2r per the
+  duplicate-now policy - value-scan command routes verbatim, the vtable heap scanner
+  with one deliberate divergence.** The memscan-family/dumpframe routes are ~70 lines of
+  address-free forwarding copied into b2r's dispatcher; moving the dispatcher to a
+  shared home was re-rejected because it would edit released bioshock1r/camera.cpp and
+  add a shared TU for no behavioral gain (stays on the seam-leak list). The b2r copy of
+  `scan_for_vtable_object` is BS1's shape plus a NEW `vtscan <hexRva>` probe command
+  (one-shot candidate-vtable verifier, logs every live match), and the b2r settings
+  locator bakes in 3-miss DORMANCY from day one - BS1's settings scanner predates the
+  session-22 dormancy lesson and only rate-limits. Re-arm signal: view-state changes.
+
+- **2026-07-29 (session 25, M10): BS2 FOV design - honest claim unconditionally, the
+  write levers gated and default OFF, and NO foreground machinery.** Readback: every
+  CalcView reads `UShockUserSettings+0x4C` into `vr::set_rendered_hfov`; a missing
+  object claims 0, core's explicit "no readback" signal (falls back to the headset
+  target - bit-identical to pre-readback behavior, so the bring-up path never
+  regresses). Write: BS1's write-block shape (`vrfov` forced-headset wants strict
+  gameplay AND an actively driving HMD; `gfov` manual wants strict gameplay; one-shot
+  save/restore of the user's option), but the CalcView-silent stale-restore ticks from
+  the ProcessEvent detour (gate: one bool read every 64th event) because BS2 has no
+  scenedraw hook. Both levers DEFAULT OFF per the every-lever-off rule. The native-path
+  check came FIRST per the s24 directive and returned the decisive verdict: poking the
+  option re-lensed the drill viewmodel WITH the world (screenshots, ENGINE_NOTES) - so
+  fovA/fovB/kFgEyeComp/vrfgfov stay unported, and BS2's FOV milestone is readback +
+  write + nothing else.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -592,7 +592,10 @@ kill. Both prerequisites below are now MET.):**
       the milestone. Every core/adapter seam leak found → ARCHITECTURE decision log.
       (M3-level: session 24, one session as budgeted - flat 6DOF integer-exact, in-headset
       PASSED (fisheye/world-drag = the expected FOV-claim gap); seam-leak inventory in the
-      decision log. Still open: M4-level stereo, FOV readback/write.)
+      decision log. FOV readback/write: session 25, flat-complete - HorizontalFOV derived
+      fresh at UShockUserSettings+0x4C, claim == rendered, vrfov/gfov default OFF, and the
+      native-path check killed the entire BS1 fg-porting question (viewmodel follows the
+      world FOV natively). Awaiting in-headset FOV acceptance. Still open: M4-level stereo.)
 
 ## Post-v1 backlog (not scheduled)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -592,10 +592,11 @@ kill. Both prerequisites below are now MET.):**
       the milestone. Every core/adapter seam leak found → ARCHITECTURE decision log.
       (M3-level: session 24, one session as budgeted - flat 6DOF integer-exact, in-headset
       PASSED (fisheye/world-drag = the expected FOV-claim gap); seam-leak inventory in the
-      decision log. FOV readback/write: session 25, flat-complete - HorizontalFOV derived
-      fresh at UShockUserSettings+0x4C, claim == rendered, vrfov/gfov default OFF, and the
-      native-path check killed the entire BS1 fg-porting question (viewmodel follows the
-      world FOV natively). Awaiting in-headset FOV acceptance. Still open: M4-level stereo.)
+      decision log. FOV readback/write: session 25, COMPLETE - HorizontalFOV derived fresh
+      at UShockUserSettings+0x4C, claim == rendered, vrfov/gfov default OFF, the native-path
+      check killed the entire BS1 fg-porting question (viewmodel follows the world FOV
+      natively), and the in-headset acceptance PASSED same day: fisheye gone, world-drag
+      gone, restore edges exercised. Still open: M4-level stereo - the milestone's last leg.)
 
 ## Post-v1 backlog (not scheduled)
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -4,11 +4,19 @@
 
 ## Current state (2026-07-29, session 25 - M10: BS2 FOV DONE flat - readback claim == rendered, forced-headset-FOV write default OFF, discovery tooling ported, crash-dump loop fixed - branch s25-m10-bs2-fov)
 
-**The BS2 FOV-claim mismatch is closed on the flat side.** `UShockUserSettings.HorizontalFOV`
-derived fresh at **+0x4C** (BS1's +0x8C reads 3 on BS2 - the never-copy rule earned its keep),
-readback wired into `vr::set_rendered_hfov` every CalcView, `vrfov`/`gfov` write levers landed
-DEFAULT OFF, capabilities now 0x3. In-headset acceptance (fisheye + world-drag gone) is the
-one open gate - checklist in docs/bioshock2/TESTING.md.
+**The BS2 FOV-claim mismatch is CLOSED - in-headset ACCEPTED (user, Quest 3 / VDXR).**
+`UShockUserSettings.HorizontalFOV` derived fresh at **+0x4C** (BS1's +0x8C reads 3 on BS2 -
+the never-copy rule earned its keep), readback wired into `vr::set_rendered_hfov` every
+CalcView, `vrfov`/`gfov` write levers landed DEFAULT OFF, capabilities now 0x3. User verdict:
+**fisheye GONE, world-drag GONE**; viewmodel unremarkable (nothing looked wrong = the
+no-fg-defect flat finding holds in-headset); the Esc-pause save/restore edges were exercised
+repeatedly in-headset (the 19:37 ON/OFF cycles in the session log ARE the user's pause tests
+- each pause restored option 100, each resume re-armed). vrfov wrote 131 on this rig
+(headset-derived, effectively BS1's 130); the manual gfov lever now defaults to 130 for BS1
+parity. Two user observations correctly deferred: world scale cannot be judged or perceived
+in mono (slider works - flat-proved - but perceived size needs stereo's IPD ratio; already
+the session-24 call), and vrstereo/SR does not exist on BS2 yet (that IS the next
+milestone).
 
 ### 1. THE HEADLINE: BS2's foreground follows the world FOV natively - BS1's fg apparatus stays unported
 
@@ -73,17 +81,17 @@ native first, test whether the BS1 problem exists, port only what is proven nece
 entry in the ARCHITECTURE decision log + CLAUDE.md hard rules. Session 25's fg verdict is the
 first applied case.
 
-1. **User session for the FOV acceptance** (checklist in docs/bioshock2/TESTING.md): flat
-   gameplay gates (`gfov 120` ON/OFF edges, Esc stale-restore, slider min/max endpoints for
-   ENGINE_NOTES), then in-headset: fisheye + world-drag gone with `vrfov` off, image fills
-   the headset with `vrfov` on, viewmodel correct (the in-headset native confirmation).
-   Then PR s25-m10-bs2-fov -> main, merge when green.
-2. **BS2 M4 stereo**: re-derive the scene-build seam + render-queue substrate; same shapes as
-   BS1 expected (frame submit ret 0xC + SetEvent tail, render pump WFSO loop, scene build ret
-   0x10), different RVAs, E9-stub hop on every census - and per the policy, check first
-   whether BS2's renderer offers a less invasive doubling path before assuming
-   SequentialReentry's exact BS1 shape. `dumpframe full 2` decode-check on BS2 is a cheap
-   first probe.
+1. **BS2 M4 stereo** (the user's top ask - "jitter 3D" parallax already reads well in mono,
+   and world-scale tuning is blocked on it): re-derive the render substrate. Session-25
+   recon says BS1's STATIC submit-finding method is dead on BS2 (SetEvent is
+   wrapped/virtually dispatched, zero static callers of the wrapper) - so start LIVE: port
+   BS1's SetEvent caller sampler (`reentry kick` instrument), sample the game-thread submit
+   caller, walk back to the entry offline. Pump-loop candidates 0x7C3E40 / 0xCF3EE0 banked
+   in ENGINE_NOTES. `dumpframe full 2` decode-check on BS2 is a cheap first probe. Per the
+   policy: check whether BS2 offers a less invasive doubling path before assuming
+   SequentialReentry's exact BS1 shape.
+2. Record the BS2 FOV slider min/max endpoints next time someone is in Graphics Options
+   (ENGINE_NOTES gap, cosmetic).
 3. **Triage the BS2 idle-gameplay crash** (dump kept, RVA 0x4FF0FE) - one-off or a class?
    BS1's session-23 offline-disasm triage recipe applies.
 4. Menu-load view actor class (vtable RVA 0x106EE20) still not RTTI-identified.
@@ -2555,9 +2563,13 @@ strict-gameplay gated, save/restore, stale-restore from the PE detour since BS2 
 scenedraw hook), heartbeat fov= field, fovaudit, overlay controls, CAP_FOV_WRITE. Flat gates
 passed at the menu including the negative one (gfov refuses to write outside gameplay). A
 harness lesson re-learned the hard way: an unfocused BS2 pauses to ~1-2 ProcessEvent calls/s,
-so a command can sit undispatched for minutes - pair EVERY game-cmd with a game-shot. Open:
-gameplay write gates + slider endpoints + the in-headset acceptance (checklist in
-docs/bioshock2/TESTING.md), then PR.
+so a command can sit undispatched for minutes - pair EVERY game-cmd with a game-shot.
+IN-HEADSET VERDICT (user, same day): **ACCEPTED - fisheye gone, world-drag gone**, viewmodel
+unremarkable, Esc-pause restore edges exercised repeatedly in-headset (vrfov wrote 131 =
+headset-derived, effectively BS1's 130; gfov lever re-defaulted to 130 for parity). User also
+confirmed mono parallax depth reads well and asked for stereo - correctly not there yet;
+world-scale perception likewise deferred to stereo (the mono slider only scales lean
+translation, flat-proved working). PR opened and merged same session per the s24 precedent.
 
 ### Session 24 - 2026-07-29 - M10 started: BioShock 2 adapter to M3 parity
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,98 +2,92 @@
 
 > Handoff file. Rewrite "Current state" and "Next steps" every session; append to the session log.
 
-## Current state (2026-07-29, session 24 - M10 STARTED: BioShock 2 Remastered adapter at M3 parity, ProcessEvent CalcView seam, per-game data dirs + adapter registry, per-game docs folders - branch s24-m10-bs2-adapter)
+## Current state (2026-07-29, session 25 - M10: BS2 FOV DONE flat - readback claim == rendered, forced-headset-FOV write default OFF, discovery tooling ported, crash-dump loop fixed - branch s25-m10-bs2-fov)
 
-**BS2 RUNS THE MOD.** First M10 session: `src/game/bioshock2r/` exists, injects via the same
-proxy (no new shim), scans clean, and drives a 6DOF head camera. All flat 6DOF checks passed
-integer-exact; in-headset M3 verdict: see the session log entry.
+**The BS2 FOV-claim mismatch is closed on the flat side.** `UShockUserSettings.HorizontalFOV`
+derived fresh at **+0x4C** (BS1's +0x8C reads 3 on BS2 - the never-copy rule earned its keep),
+readback wired into `vr::set_rendered_hfov` every CalcView, `vrfov`/`gfov` write levers landed
+DEFAULT OFF, capabilities now 0x3. In-headset acceptance (fisheye + world-drag gone) is the
+one open gate - checklist in docs/bioshock2/TESTING.md.
 
-### 1. THE HEADLINE: BS2's event thunk is dead code - the seam is ProcessEvent
+### 1. THE HEADLINE: BS2's foreground follows the world FOV natively - BS1's fg apparatus stays unported
 
-`eventPlayerCalcView` resolves on BS2 exactly like BS1 (FName-chain scan, RVA 0x395CC0,
-correct thunk shape) - and NEVER FIRES: the 16-minutes-earlier build inlined the event
-dispatch at every call site. Offline caller census: BS1's thunk has 29 static callers, BS2's
-has ZERO (the check that cracked it - run it BEFORE hooking, not after). The shipped seam:
-hook `UObject::FindFunctionChecked` (RVA 0xB6BA30) to learn the PlayerCalcView `UFunction*` by
-FName index (zero UObject-layout assumptions), and hook the outer `UObject::ProcessEvent`
-(RVA 0x37A7E0, resolved via the controller vtable slot 3 stub chain, prologue-gated) to mutate
-the 0x1C param block `{viewActor, loc, rot}` after the original returns. Full derivation:
-docs/bioshock2/ENGINE_NOTES.md. Bonus banked: any BS2 script event is now hookable by name.
+The session-24 policy gate ran FIRST and returned the best possible answer: poking the FOV
+option re-lensed the drill viewmodel WITH the world (screenshot pair, ENGINE_NOTES). BS1's
+entire foreground counter-model - fovA/fovB, kFgEyeComp, vrfgfov, the lock/lockpull domain -
+exists to fight a fixed-lens fg rig that BS2 simply does not have. None of it ports. BS2's
+FOV milestone is readback + gated write + nothing else.
 
-### 2. Runtime-verified BS2 facts (session 24)
+### 2. The derivation (session 25, full chain in docs/bioshock2/ENGINE_NOTES.md)
 
-- RTTI candidates VERIFIED live: AShockPlayer 0x11197C0 (gameplay view actor),
-  AShockPlayerController 0x1117BF0 (vtable slot 3 resolves to ProcessEvent; menu-load view
-  actor). The camera module logs the observed view-actor vtable RVA on change, so a wrong
-  candidate names its own correction.
-- `view state: GAMEPLAY (ShockPlayer view)` transition works (same phrase as BS1 - the
-  harness detector transfers).
-- BS2's main menu does NOT run PlayerCalcView (BS1's attract scene does, at ~7000/s) - the
-  b2r command poller therefore ticks from the ProcessEvent detour, so the command seam works
-  at the menu too. Dispatch rates observed: ~200-850 calls/s, spikes ~4500/s during loads.
-- Flat 6DOF acceptance (log-measured, final-camera heartbeat): offset z +50.0 exact; simhead
-  pitch 20 deg -> 3640 units, roll 15 -> 2730, yaw residual -5461 integer-exact; sim position
-  (0.10 0.20 -0.30) m -> headOff (6.1 31.0 20.0) UU = |37.4| at worldscale 100, halves exactly
-  at 50. The b2r `simhead` lane takes a position triple - full-6DOF provable flat, which BS1's
-  rotation-only lane never could.
+- Vtable 0x11523D8 runtime-VERIFIED via the new `vtscan` probe before anything trusted it
+  (3 matches: 2 stack slots + the real heap object).
+- Offset by ini-adjacency (`MouseIconScale=10` immediately precedes `HorizontalFOV=100` in
+  Bioshock2SP.ini's [ShockGame.ShockUserSettings]; the object mirrors it at +0x48=10,
+  +0x4C=100) + poke proof: 100->130 img-diff 8.99 mean-abs / 39.3% changed vs a 1.34 / 5.0%
+  restore floor. Renderer-consumed per frame, no APPLY, no code clamp through 150.
+- Production locate: heap scan for the vtable (BS1 shape) + 3-miss DORMANCY from day one
+  (the b2r scanner bakes in the session-22 lesson BS1's own settings scanner predates);
+  re-armed on view-state changes. Measured ~0.4 s at menu, ~3 s in gameplay (Debug).
 
-### 3. Architecture work M10 forced (all committed)
+### 3. What landed in code (branch s25-m10-bs2-fov, 5 commits so far)
 
-- `game/adapter_registry.cpp`: `init_adapter()`/`adapter()` moved out of bioshock1r, dispatch
-  by host exe name; silent host detection feeds `log::init(subdir)` BEFORE the log exists.
-- Per-game data dirs: BS2 = `%LOCALAPPDATA%\BioshockVR\bs2\`, BS1's released flat layout
-  FROZEN (user decision). Two data-dir bypasses fixed (b1r command.txt, core framedump) -
-  everything now composes from `log::data_dir()`.
-- `ue_math.h` -> `game/shared/` (bvr::ue + per-game aliases). Docs restructure: per-game
-  `docs/bioshock1/` + `docs/bioshock2/` (ENGINE_NOTES + TESTING each); CLAUDE.md updated.
-- Tools: `-Game bs1|bs2` on build/install/uninstall/tail-log/game-cmd/game-shot/game-click
-  (defaults bs1, behavior-identical). boot.ps1 stays BS1-only - BS2's gameswf menu ignores
-  synthetic clicks/Enter (arrow keys move the selection; activation unreliable - drive by
-  hand).
-- Seam-leak inventory recorded in the ARCHITECTURE decision log (M10 acceptance criterion):
-  command seam lives per-adapter, preset serializer persists core state from b1r, gameplay
-  predicate + heartbeat + head-drive math duplicated in b2r, IGameAdapter doc-vs-reality gap.
-  Policy: duplicate-in-b2r now, unify once BS2 stabilizes. b2r writes NO ini - BS1
-  calibration untouchable by construction.
-- BS1 regression smoke PASSED after the refactors (same CalcView RVA, caps 0x3, boot.ps1 to
-  GAMEPLAY, command seam + framedump at unchanged paths, ini timestamps untouched).
+- b2r command seam: full memscan/pokeaddr/hexdump/fsweep/strscan/membases/dumpframe family
+  (verbatim BS1 routes) + the b2r-first `vtscan <hexRva>` candidate-vtable verifier.
+- b2r patterns: `scan_for_vtable_object` (full-4GB LAA walk, SEH-guarded) + `hfov_option_ptr`
+  (cache + vtable revalidate + 2 s rate limit + 3-miss dormancy + `hfov_scan_rearm`).
+- Readback: every CalcView claims the live option (menus included); missing object claims 0 =
+  core's explicit fallback signal (bit-identical to pre-readback behavior). Heartbeat gained
+  `fov=N`; `fovaudit` ported (simple form); overlay shows the option + Force-headset-FOV
+  checkbox + manual game-FOV write controls.
+- Write block: BS1 shape - `vrfov` (headset-suggested hfov) wants strictGameplay AND vrDrove;
+  `gfov` (manual) wants strictGameplay; one-shot save/restore of the user's option; the
+  CalcView-silent stale-restore ticks from the ProcessEvent detour (BS2 has no scenedraw
+  hook). Adapter advertises CAP_FOV_WRITE; `setFov` routes to the manual lever.
+- Core fix (only BS1-shared file touched): crash.cpp repeat-fault suppressor + 3-dumps-per-
+  session cap. Motive below.
 
-### 4. Known BS2 gaps (deliberate, next M10 sessions)
+### 4. Flat gates all PASSED (log-measured)
 
-- NO FOV readback/write: projection claims headset FOV over the game's rendered FOV -
-  confirmed in-headset as fisheye + the world dragging with head turns (user report,
-  session 24). THE first follow-up. BS2 has a native FOV slider (Graphics Options, default
-  100) - likely UShockUserSettings; candidate vtable 0x11523D8 unconsumed, offset must be
-  derived fresh.
-- Mono only (M4 stereo not started): no scene-reentry scan, no 1t substrate on BS2 yet.
-- No aim/hands/bones/body/input-drive/console-exec; BS1's wider command vocabulary
-  (memscan family, vrstereo, vraim, reentry, exec) not ported.
-- Menu-load view actor class (vtable RVA 0x106EE20) not RTTI-identified yet.
+Scan one-shot at menu boot, correct object chosen from 4 matches, heartbeat `fov=100`;
+`fovaudit` option=100 with option-derived tanH=1.191754 == tan(50 deg) exact (src=none only
+because no XR session was up - readback claim is stored); `gfov 120` at the MENU correctly
+refuses to write (strictGameplay gate); `vrfov status` reports force=off suggested=0.0
+writing=0. Gameplay-side write gates (ON/OFF edges, stale-restore) still need a loaded save -
+queued for the user session below.
+
+### 5. Incident: the session-24 build crash-looped and wrote 115 GB of dumps
+
+The user's BS2 run crashed at 18:20 (null read, `Bioshock2HD.exe+0x4FF0FE`, after ~11 min
+idle in gameplay, headset in VISIBLE-idle) - and Steam's CSERHelper filter CONTINUE_EXECUTIONs
+the fault, so our chained filter re-dumped the SAME fault once per second for 40 minutes:
+2,083 dumps, 115 GB. Cleaned to two exemplars (`bs2\crash\bvr_20260729_182015.dmp` +
+`_185932.dmp`); crash.cpp now suppresses repeat reports at the same address and caps minidumps
+at 3/session. The crash itself is UNTRIAGED - dump kept, RVA 0x4FF0FE, registers in the log
+around 18:20:15.
 
 ## Next steps
 
-**STANDING POLICY for all BS2 work (user directive, session 24): BS2 is not bound by BS1's
-methods.** BS1's fg/viewmodel FOV counter-modeling, weapon scaling compensation and aim
-workarounds were forced by BS1 limitations - when BS2 affords a cleaner/native method, use it.
-Test whether the BS1 problem even exists on BS2 before porting any compensation machinery.
-Full entry in the ARCHITECTURE decision log; also in CLAUDE.md hard rules.
+**STANDING POLICY (user directive, session 24): BS2 is not bound by BS1's methods** - check
+native first, test whether the BS1 problem exists, port only what is proven necessary. Full
+entry in the ARCHITECTURE decision log + CLAUDE.md hard rules. Session 25's fg verdict is the
+first applied case.
 
-1. **BS2 FOV** (kills the confirmed fisheye + world-drag): the goal is claim == rendered,
-   then the forced-headset-FOV write (toggle like BS1's, default per the every-lever-off
-   rule). Order of work under the policy above: (a) FIRST test the native path - change
-   BS2's own FOV slider in the options UI and check whether the viewmodel/weapons stay
-   correct across values (if yes, BS1's entire fg apparatus stays unported); (b) derive the
-   UShockUserSettings hfov offset fresh via the UI-slider + value-rescan method (BS1
-   session-4 recipe; candidate vtable 0x11523D8); (c) wire readback into
-   `vr::set_rendered_hfov` so the projection claim is honest; (d) the gated write.
-2. **BS2 M4 stereo**: re-derive the scene-build seam + render-queue substrate for
-   SequentialReentry; expect the same shapes as BS1, different RVAs, plus the jmp-stub
-   indirection everywhere - and per the policy, check first whether BS2's renderer offers a
-   less invasive doubling path before assuming SR's exact BS1 shape.
-3. Port the value_scan/dumpframe command routes to b2r (or move the dispatcher to a shared
-   home per the decision-log leak list) so BS2 discovery work has the full toolkit - needed
-   by step 1b.
-4. BS1 carries: v0.4.1 to the external tester (crash capture), 2K-account lead, seated
+1. **User session for the FOV acceptance** (checklist in docs/bioshock2/TESTING.md): flat
+   gameplay gates (`gfov 120` ON/OFF edges, Esc stale-restore, slider min/max endpoints for
+   ENGINE_NOTES), then in-headset: fisheye + world-drag gone with `vrfov` off, image fills
+   the headset with `vrfov` on, viewmodel correct (the in-headset native confirmation).
+   Then PR s25-m10-bs2-fov -> main, merge when green.
+2. **BS2 M4 stereo**: re-derive the scene-build seam + render-queue substrate; same shapes as
+   BS1 expected (frame submit ret 0xC + SetEvent tail, render pump WFSO loop, scene build ret
+   0x10), different RVAs, E9-stub hop on every census - and per the policy, check first
+   whether BS2's renderer offers a less invasive doubling path before assuming
+   SequentialReentry's exact BS1 shape. `dumpframe full 2` decode-check on BS2 is a cheap
+   first probe.
+3. **Triage the BS2 idle-gameplay crash** (dump kept, RVA 0x4FF0FE) - one-off or a class?
+   BS1's session-23 offline-disasm triage recipe applies.
+4. Menu-load view actor class (vtable RVA 0x106EE20) still not RTTI-identified.
+5. BS1 carries: v0.4.1 to the external tester (crash capture), 2K-account lead, seated
    recenter designs, letterbox investigation.
 
 ## Previous state (session 23, superseded - CLEAN-MACHINE NEW-USER FLOW + CRASH CAPTURE: Steam's CSERHelper was eating our crash handler, load-crossing stereo drop fixed, thumbrest ammo modifier, v0.4.1 packaged - branch s23-crash-diagnostics)
@@ -2537,6 +2531,33 @@ and it resumes.
   (install.ps1 backs theirs up automatically).
 
 ## Session log (newest first)
+
+### Session 25 - 2026-07-29 - BS2 FOV: readback + write landed flat, fg apparatus proven unnecessary
+
+Branched s25-m10-bs2-fov off main. Opened by discovering the session-24 build had crash-looped
+on the user's machine: a null read at Bioshock2HD.exe+0x4FF0FE after ~11 min of idle gameplay,
+and CSERHelper's chained filter retries the faulting instruction, so our filter wrote the SAME
+55 MB dump once per second for 40 minutes - 2,083 dumps, 115 GB. Killed the zombie, kept two
+exemplar dumps, deleted the rest, and fixed crash.cpp (repeat-fault suppressor + 3 dumps per
+session cap) - the only BS1-shared file touched all session. Then the milestone work in plan
+order: ported the value_scan/dumpframe routes into b2r's dispatcher (duplicate-now policy) and
+added the b2r-first `vtscan` probe over a new duplicated heap scanner. Derivation ran mostly
+WITHOUT the user: vtscan verified vtable 0x11523D8 live (real object among stack-slot false
+positives), the ini's property adjacency (MouseIconScale=10 right before HorizontalFOV=100)
+matched the object hexdump at +0x48/+0x4C, and the poke proof landed first try - 100->130
+moved 39.3% of pixels (8.99 mean-abs), restore back to the 5.0% ambient floor, monotonic
+through 150, no clamp. THE finding: the drill viewmodel re-lensed WITH the world in the poke
+pair - BS2's foreground follows the world FOV natively, so fovA/fovB/kFgEyeComp/vrfgfov stay
+unported (first applied case of the s24 policy; the offset ALSO proved the never-copy rule:
+BS1's +0x8C reads 3 here). Wired the readback (claim == rendered, missing object claims 0 =
+core's own fallback), the write block (vrfov headset-forced + gfov manual, both default OFF,
+strict-gameplay gated, save/restore, stale-restore from the PE detour since BS2 has no
+scenedraw hook), heartbeat fov= field, fovaudit, overlay controls, CAP_FOV_WRITE. Flat gates
+passed at the menu including the negative one (gfov refuses to write outside gameplay). A
+harness lesson re-learned the hard way: an unfocused BS2 pauses to ~1-2 ProcessEvent calls/s,
+so a command can sit undispatched for minutes - pair EVERY game-cmd with a game-shot. Open:
+gameplay write gates + slider endpoints + the in-headset acceptance (checklist in
+docs/bioshock2/TESTING.md), then PR.
 
 ### Session 24 - 2026-07-29 - M10 started: BioShock 2 adapter to M3 parity
 

--- a/docs/bioshock2/ENGINE_NOTES.md
+++ b/docs/bioshock2/ENGINE_NOTES.md
@@ -180,6 +180,31 @@ included; null object claims 0 = core's explicit fallback signal); the gated wri
 stale-restore from the ProcessEvent detour because BS2 has no scenedraw hook); the 1 Hz
 heartbeat's `fov=` field; `fovaudit`.
 
+## M4 stereo candidates (session 25 stretch - offline recon ONLY, nothing hooked)
+
+Shape-search of the exe against BS1's three render-architecture functions (frame submit:
+TLS-prologue + ret 0xC + SetEvent near tail; render pump: WaitForSingleObject(INFINITE) loop;
+scene build: aligned-stack prologue + ret 0x10). Findings:
+
+- **BS1's static submit-finding method is DEAD on BS2**: the exe has only two `FF 15`
+  SetEvent call sites, both inside wrapper functions (0xB81020, 0xCDB917). The 0xCDB917
+  wrapper (reached via E9 stub 0xD9BD) has ~1954 static callers - a general-purpose sync
+  utility, census-useless. The 0xB81020 wrapper (stub 0xF01A) has ZERO static E8 callers -
+  virtual/register dispatch. No TLS-prologue ret-0xC SetEvent-calling function exists
+  statically. Conclusion: find the submit LIVE, the way BS1 originally did - a kernel32
+  SetEvent caller sampler on the game thread (BS1's `reentry kick` instrument), then walk
+  the sampled return RVA back to the enclosing entry offline.
+- **Render-pump candidates** (WFSO(INFINITE) with a backward-jump loop shape): entries
+  0x7C3E40 and 0xCF3EE0. Unverified; the pump confirms itself live by
+  GetCurrentThreadId-registration + once-per-Present drain cadence.
+- **Scene build**: the aligned-stack + ret 0x10 shape has 300+ static matches - not rankable
+  offline. Derive it from the live submit's gameplay caller ret RVA (BS1 session-6 recipe:
+  hook the submit, log callers, capstone-walk backward past decoy SEH entries; remember the
+  frameless-prologue and 11-byte-CC-run lessons).
+- Per the standing policy: before building SequentialReentry's exact BS1 shape, first check
+  whether BS2's renderer offers a less invasive doubling path (the ProcessEvent-by-name seam
+  may expose per-view script events BS1 never had; unexplored).
+
 ## Derivation recipes (shared with BS1 - short form)
 
 - **FName-chain event scan** (core `pattern_scan::find_event_function`, game-agnostic): wide

--- a/docs/bioshock2/ENGINE_NOTES.md
+++ b/docs/bioshock2/ENGINE_NOTES.md
@@ -105,7 +105,7 @@ was validated by reproducing all of BS1's known-good vtable RVAs exactly.
 |---|---|---|
 | `AShockPlayer` | 0x11197C0 | **VERIFIED** - view actor vtable in gameplay matches; drives `view state: GAMEPLAY` |
 | `AShockPlayerController` | 0x1117BF0 | **VERIFIED** (indirectly) - its vtable slot 3 stub resolves to ProcessEvent, and the pre-save menu/load view actor logs it |
-| `UShockUserSettings` | 0x11523D8 | candidate - unconsumed (FOV readback is the next step) |
+| `UShockUserSettings` | 0x11523D8 | **VERIFIED** (session 25) - vtscan found a live heap object with dword0 == base + RVA; consumed by the FOV readback/write (see the FOV section) |
 | `APlayerWeapon` | 0x112CC78 | candidate - unconsumed |
 | `AHands` | 0x1125478 | candidate - unconsumed |
 | `SkeletonInstance` | 0x10D0FC0 | candidate - unconsumed |
@@ -124,12 +124,61 @@ change, so a wrong candidate names its own correction from any session log. Obse
   the CalcView tail works at the BS2 menu - which is why the b2r command poller ticks from the
   ProcessEvent detour instead.
 - The graphics-options first-boot screen has a native **Field Of View slider (default 100)** -
-  BS2 has an exposed FOV concept BS1 lacked; likely the same `UShockUserSettings` int the BS1
-  FOV write targets. Verify offset fresh before writing.
+  BS2 has an exposed FOV concept BS1 lacked. Session 25 confirmed it is the
+  `UShockUserSettings.HorizontalFOV` int (offset below) - and, decisively: **BS2's foreground
+  viewmodel follows the world FOV natively** (poking the option re-lensed the drill WITH the
+  world, screenshot-verified). BS1's entire fg counter-model (fovA/fovB, kFgEyeComp, vrfgfov)
+  exists because BS1's fg rig has a FIXED lens; BS2 does not have that defect, so none of that
+  machinery ports. First applied case of the "BS2 is not bound by BS1's methods" directive.
 - Flat 6DOF checks (session 24, log-measured via the final-camera heartbeat): `offset 0 0 50` ->
   z +50.0 exact; `simhead 0 20 0` -> pitch 3640; roll 15 -> 2730; yaw residual integer-exact
   (16450 -> 10989 = -5461 = -30.0 deg); sim position (0.10, 0.20, -0.30) m at worldscale 100 ->
   headOff (6.1, 31.0, 20.0) UU, |37.4|, halving exactly at worldscale 50.
+
+## UShockUserSettings and the FOV option (session 25)
+
+**`HorizontalFOV` = `UShockUserSettings + 0x4C`, int32, DEGREES.** BS1's +0x8C does NOT
+transfer (it reads 3 here) - derived fresh, as the hard rule demands.
+
+Derivation chain (2026-07-29, live save "Adonis Luxury Resort", option at 100):
+
+1. **Vtable verify first**: `vtscan 11523D8` (the one-shot heap-scan probe, ~3 s Debug walk of
+   the full 4 GB) -> 3 matches: 0x008FF29C / 0x008FF304 (stack slots 0x68 apart holding the
+   pointer - the BS1-documented stack false-positive shape) and **0x0D368F80, a real heap
+   object** whose dword0 == base + 0x11523D8. Candidate promoted to VERIFIED before anything
+   trusted it.
+2. **Object layout vs ini**: `hexdump` of the object against `[ShockGame.ShockUserSettings]` in
+   `%APPDATA%\BioshockHD\Bioshock2\Bioshock2SP.ini`. Config properties visibly mirror the ini:
+   the four volume 100s at +0x64..+0x70, Sensitivity=50 at +0x78, Brightness/Contrast/Gamma
+   0.5/0.5/1.2f at +0x80..+0x88, MouseSensitivity=4.0f at +0xA8. The clincher:
+   `MouseIconScale=10` immediately precedes `HorizontalFOV=100` in the ini, and the object has
+   **+0x48=10 followed by +0x4C=100**. (The object spans ~0xE0 bytes; another UObject starts at
+   +0xE0. +0x44 read 105 - some other field, do not confuse.)
+3. **Consumed-copy proof (poke + img-diff)**: `pokeaddri <obj+0x4C> 130` -> screenshot
+   mean-abs-diff **8.99, 39.3% pixels changed** vs baseline (BS1's session-4 consumed-copy
+   evidence was 11.09/44.2%); `memrestore` -> **1.34 / 5.0%** = the ambient-animation floor.
+   Renderer-consumed **per frame**, no options APPLY. The ini value is only read at boot -
+   matching BS1's "editing the ini does not propagate" finding.
+4. **No code clamp in range**: poke 150 -> monotonic widening (9.97/43.9% vs base, 6.91/34.0%
+   vs the 130 shot). The UI slider's own range is still unrecorded (menu work needs the user);
+   irrelevant for the write path since `suggested_hfov_deg` caps at 160 and Quest-class
+   headsets ask ~104-115.
+5. **Native fg verdict** (the policy gate): in the 100-vs-130 screenshot pair the drill
+   viewmodel SHRANK with the wider lens exactly like the world - BS2's foreground renders
+   through the world FOV. BS1's fixed-lens fg defect does not exist here.
+
+Production locate (patterns.cpp `hfov_option_ptr`): no static pointer assumed (BS1 precedent -
+its .data "roots" were coincidental); heap-scan for the vtable, cache the instance, revalidate
+`dword0 == base + RVA` every call, 2000 ms rescan rate limit, **DORMANT after 3 straight
+misses** (the b2r scanner bakes in the BS1 session-22 dormancy lesson from day one), re-armed
+on view-state changes. Scan cost measured ~3 s (Debug, gameplay heap) - one-shot per session
+in practice.
+
+Consumers: `calcview_tail` readback -> `vr::set_rendered_hfov` (claim == rendered, menus
+included; null object claims 0 = core's explicit fallback signal); the gated write block
+(`vrfov` forced-headset / `gfov` manual, both DEFAULT OFF, strict-gameplay + save/restore,
+stale-restore from the ProcessEvent detour because BS2 has no scenedraw hook); the 1 Hz
+heartbeat's `fov=` field; `fovaudit`.
 
 ## Derivation recipes (shared with BS1 - short form)
 

--- a/docs/bioshock2/TESTING.md
+++ b/docs/bioshock2/TESTING.md
@@ -36,8 +36,9 @@ Differences from BS1:
 - The command poller runs off the **ProcessEvent detour**, not the CalcView tail - so commands
   work at the main menu too (BS2's menu never runs PlayerCalcView).
 - The 1 Hz heartbeat logs the **FINAL camera** (post drive + offsets):
-  `[b2r] camera: loc=(...) rot=(...) headOff=(...) drive=0|1 (N calls/s)` - flat checks measure
-  these numbers directly.
+  `[b2r] camera: loc=(...) rot=(...) fov=N headOff=(...) drive=0|1 (N calls/s)` - flat checks
+  measure these numbers directly (`fov=` is the live HorizontalFOV option, 0 until the settings
+  object is located).
 - `simhead` takes an optional **position triple** (meters, XR space):
   `simhead <yaw> <pitch> <roll> [px py pz] [holdMs]` - proves the full 6DOF mapping flat, which
   BS1's rotation-only lane could not.
@@ -54,9 +55,26 @@ Differences from BS1:
 | `worldscale 50` | headOff halves exactly |
 | `worldscale 100` + `simhead off` + `offset 0 0 0` | camera returns to game values, drive=0 |
 
-M3 command vocabulary: `recenter`, `offset x y z`, `worldscale v`, `headoff up fwd`,
-`simhead ...`, `vrcam on|off`, `camlog on|off`, `vroverlay on|off`, `vrcine ...`. BS1's wider
-vocabulary (memscan family, vrstereo, vraim, reentry, exec) is NOT ported yet.
+Command vocabulary: `recenter`, `offset x y z`, `worldscale v`, `headoff up fwd`,
+`simhead ...`, `vrcam on|off`, `camlog on|off`, `vroverlay on|off`, `vrcine ...`; since
+session 25 also the FOV levers (`vrfov on|off|status`, `gfov <deg>|off`, `fovaudit`) and the
+full discovery family (`memscan(i)/memrescan(i)/memlist/memread/mempoke(i)/memrestore/memptr/
+pokeaddr(i)/hexdump/fsweep/strscan/membases/dumpframe`, plus the b2r-first
+`vtscan <hexRva> [needBytesHex]` candidate-vtable verifier - one-shot, walks the full 4 GB,
+~3 s Debug in gameplay, EXPECTED to freeze the game for that long). BS1's vrstereo/vraim/
+reentry/exec are NOT ported yet.
+
+## FOV flat acceptance (session 25 - log + img-diff measured)
+
+| step | expected |
+|---|---|
+| boot to menu | `UShockUserSettings scan: N vtable match(es), chosen=<heap addr>` one-shot; heartbeat gains `fov=100` (the option value) |
+| `fovaudit` | `option=<slider value>`, option-derived tanH == tan(option/2); with an XR session up, `src=readback` and submitted == option-derived; without one, `src=none swap=0x0` |
+| user changes the slider in Graphics Options | heartbeat `fov=` and `fovaudit` follow, no rescan (cache revalidates) |
+| `gfov 120` in gameplay | `game fov write ON (saved option N)`; heartbeat `fov=120`; visibly wider render |
+| `gfov off` | `game fov write OFF (restored option N)`; options UI still shows the user's value afterwards |
+| Esc to pause menu with a write armed | restore within ~0.5 s: the OFF edge (menu still CalcViews) or the stale-restore line (`calcview silent`) |
+| `vrfov on` flat (no XR session) | no write (`suggested_hfov` is 0 without a session) - the status form says so |
 
 ## In-headset M3 checklist
 
@@ -69,9 +87,28 @@ vocabulary (memscan family, vrstereo, vraim, reentry, exec) is NOT ported yet.
 5. Recenter from the overlay: horizon level, forward = game forward.
 6. Tune world scale (BS1 shipped 100 UU/m) and head offset up/fwd.
 7. Esc pause menu: drops to the flat big screen, returns to VR camera on resume.
-8. Report distortion/fisheye: EXPECTED at M3 - there is no BS2 FOV readback yet, so the
-   projection layer claims the headset FOV while the game renders its own (the documented next
-   M10 step; note BS2 has a native FOV slider in Graphics Options).
+8. Distortion/fisheye: since session 25 there is a live FOV readback, so this should be GONE
+   with `vrfov` off (see the FOV checklist below). If fisheye is back, check `fovaudit` first.
 
 Verify from the log, not from a flat mirror screenshot: `view state: GAMEPLAY (ShockPlayer
 view)`, heartbeat `drive=1`, and moving `headOff` values are the acceptance signals.
+
+## In-headset FOV checklist (session 25 acceptance: fisheye + world-drag gone)
+
+1. Quest 3 + Virtual Desktop (VDXR), launch BS2, load a save, `vrcam on` (overlay or command).
+2. `fovaudit` -> `src=readback`, submitted tanH == option-derived tanH (the honest claim).
+3. With `vrfov` OFF (the default): look around and at straight edges - **fisheye GONE, no
+   world-drag on head turns** (the world holds still). The image will not fill the headset's
+   full FOV - that is CORRECT at the game's option FOV (Quest 3 wants ~104+, the option
+   default is 100).
+4. `vrfov on` (command or the "Force headset FOV" checkbox): log shows
+   `game fov write ON (saved option N)`; the image now fills the headset FOV, still
+   undistorted, still no world-drag.
+5. Viewmodel check while `vrfov` is on: drill/weapon/hands look correctly proportioned (BS2's
+   fg follows the world FOV natively - flat-verified session 25; this step is the in-headset
+   confirmation. Only if the viewmodel breaks HERE does any BS1 fg machinery get considered).
+6. Esc to pause: `game fov write OFF (restored option N)` in the log; resume re-arms the write.
+7. Quit to the main menu, open Graphics Options: the FOV slider shows YOUR original value
+   (save/restore leak check). While there, note the slider's min/max endpoints - they are
+   still unrecorded in ENGINE_NOTES.
+8. Report: fisheye gone? world-drag gone? viewmodel correct with vrfov on? slider endpoints?

--- a/src/core/util/crash.cpp
+++ b/src/core/util/crash.cpp
@@ -125,6 +125,43 @@ LONG CALLBACK VectoredFilter(EXCEPTION_POINTERS* info) {
 void report(EXCEPTION_POINTERS* info, const char* reason) {
     // A fault inside MiniDumpWriteDump used to recurse straight back into here.
     if (InterlockedCompareExchange(&g_inFilter, 1, 0) != 0) return;
+
+    // Repeat-fault suppressor (session 25): a chained filter (BS2's
+    // CSERHelper) can CONTINUE_EXECUTION a persistent fault, re-executing the
+    // faulting instruction forever - observed as one 55 MB dump per second
+    // for 40 minutes (2083 dumps, 115 GB) on one BS2 crash. The first report
+    // of an address has full detail + dump; repeats at the SAME address log a
+    // heartbeat line only. Statics are safe: the g_inFilter latch makes this
+    // section single-flight.
+    static void* s_lastEip = nullptr;
+    static unsigned s_repeats = 0;
+    void* eip = info && info->ExceptionRecord ? info->ExceptionRecord->ExceptionAddress
+                                              : nullptr;
+    if (eip && eip == s_lastEip) {
+        ++s_repeats;
+        if (s_repeats == 1)
+            BVR_LOG("crash: same fault at %p again - suppressing repeat dumps and detail "
+                    "(a chained filter is retrying the faulting instruction)",
+                    eip);
+        else if (s_repeats % 500 == 0)
+            BVR_LOG("crash: fault at %p repeated %u times", eip, s_repeats);
+        InterlockedExchange(&g_inFilter, 0);
+        return;
+    }
+    s_lastEip = eip;
+    s_repeats = 0;
+
+    // Distinct-fault dump cap: a cascade of different crash addresses (heap
+    // corruption walking) must not fill the disk either. Crash LINES keep
+    // logging; only the minidump writes stop.
+    static unsigned s_dumpsWritten = 0;
+    const bool wantDump = s_dumpsWritten < 3;
+    if (s_dumpsWritten == 3) {
+        ++s_dumpsWritten; // log the cap notice once
+        BVR_LOG("crash: dump cap (3 per session) reached - further faults are logged "
+                "without minidumps");
+    }
+
     BVR_LOG("crash: caught via %s", reason);
 
     wchar_t dir[MAX_PATH];
@@ -142,17 +179,21 @@ void report(EXCEPTION_POINTERS* info, const char* reason) {
         type = static_cast<MINIDUMP_TYPE>(MiniDumpWithFullMemory | MiniDumpWithHandleData |
                                           MiniDumpWithThreadInfo | MiniDumpWithUnloadedModules);
 
-    HANDLE file = CreateFileW(path, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS,
-                              FILE_ATTRIBUTE_NORMAL, nullptr);
     BOOL wrote = FALSE;
-    if (file != INVALID_HANDLE_VALUE) {
-        MINIDUMP_EXCEPTION_INFORMATION mei{};
-        mei.ThreadId = GetCurrentThreadId();
-        mei.ExceptionPointers = info;
-        mei.ClientPointers = FALSE;
-        wrote = MiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(), file, type, &mei,
-                                  nullptr, nullptr);
-        CloseHandle(file);
+    if (wantDump) {
+        ++s_dumpsWritten; // count attempts, not successes - a failing write
+                          // storm must hit the cap too
+        HANDLE file = CreateFileW(path, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS,
+                                  FILE_ATTRIBUTE_NORMAL, nullptr);
+        if (file != INVALID_HANDLE_VALUE) {
+            MINIDUMP_EXCEPTION_INFORMATION mei{};
+            mei.ThreadId = GetCurrentThreadId();
+            mei.ExceptionPointers = info;
+            mei.ClientPointers = FALSE;
+            wrote = MiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(), file, type,
+                                      &mei, nullptr, nullptr);
+            CloseHandle(file);
+        }
     }
 
     const EXCEPTION_RECORD* rec = info ? info->ExceptionRecord : nullptr;
@@ -176,7 +217,8 @@ void report(EXCEPTION_POINTERS* info, const char* reason) {
     }
 
     BVR_LOG("crash: %s (code 0x%08X at %p [%s], fault addr 0x%08X%s) tid=%u build %s (%s)",
-            wrote ? "minidump written" : "MINIDUMP WRITE FAILED",
+            wrote ? "minidump written"
+                  : (wantDump ? "MINIDUMP WRITE FAILED" : "minidump skipped (session cap)"),
             rec ? rec->ExceptionCode : 0, addr, where, static_cast<unsigned>(faultAddr), access,
             GetCurrentThreadId(), BVR_VERSION, BVR_BUILD_ID);
     if (wrote) {

--- a/src/game/bioshock2r/bioshock2r_adapter.cpp
+++ b/src/game/bioshock2r/bioshock2r_adapter.cpp
@@ -7,9 +7,10 @@
 namespace bvr::b2r {
 
 uint32_t Bioshock2RAdapter::capabilities() const {
-    // No CAP_FOV_WRITE: BS2 has no runtime-verified FOV source yet (the
-    // UShockUserSettings candidate is unconsumed at M3).
-    return camera::hook_live() ? game::CAP_CAMERA_OVERRIDE : 0u;
+    // CAP_FOV_WRITE since session 25: the UShockUserSettings HorizontalFOV
+    // offset is runtime-verified and the write is save/restore-gated
+    // (camera.cpp write block; patterns.h has the derivation).
+    return camera::hook_live() ? (game::CAP_CAMERA_OVERRIDE | game::CAP_FOV_WRITE) : 0u;
 }
 
 bool Bioshock2RAdapter::init(const bvr::pattern_scan::ProcessImage& image) {
@@ -21,8 +22,8 @@ bool Bioshock2RAdapter::init(const bvr::pattern_scan::ProcessImage& image) {
     return true;
 }
 
-void Bioshock2RAdapter::setFov(float) {
-    // No FOV lever on this game yet - see capabilities().
+void Bioshock2RAdapter::setFov(float hfovDeg) {
+    camera::set_fov_override(hfovDeg); // <= 0 turns the manual write off
 }
 
 void Bioshock2RAdapter::drawDebugUi() {

--- a/src/game/bioshock2r/camera.cpp
+++ b/src/game/bioshock2r/camera.cpp
@@ -53,6 +53,15 @@ std::atomic<float> g_offsetX{0.0f}, g_offsetY{0.0f}, g_offsetZ{0.0f};
 // in every session log. Toggle off with `camlog off` / the overlay.
 std::atomic<bool> g_logCamera{true};
 
+// FOV (session 25). The readback claims whatever the game renders (honest
+// projection = no fisheye/world-drag); both WRITE levers ship DEFAULT OFF
+// per the every-lever-off rule. `vrfov` asks for the headset-suggested hfov
+// in strict gameplay while the HMD drives; `gfov` is the manual test lever.
+std::atomic<int32_t> g_lastOptionFov{0}; // telemetry: 0 = object not located
+std::atomic<bool> g_forceHeadsetFov{false};
+std::atomic<bool> g_gameFovWrite{false};
+std::atomic<float> g_gameFovDeg{100.0f};
+
 // M3 VR camera drive. worldScale default follows BS1's in-headset calibration
 // (100 UU/m, session 16) as the starting point - BS2 gets its own verdict
 // from the user before anything is persisted.
@@ -95,6 +104,12 @@ uintptr_t g_imageBase = 0;
 size_t g_imageSize = 0;
 uint64_t g_lastHeartbeatMs = 0;
 uint32_t g_heartbeatBaseCount = 0;
+// FOV write latch (game thread only): one-shot save of the user's option on
+// the ON edge, restored on the OFF edge - the option ini value is the user's
+// property and must survive every path out of gameplay.
+bool g_wasWritingGameFov = false;
+int32_t g_savedGameFov = 0;
+uint64_t g_lastCalcViewMs = 0;
 bool g_haveRecenter = false;
 bvr::vr::HeadPose g_recenterPose{};
 // The seated frame's yaw zero, in ROTATOR UNITS (65536/turn), integer for the
@@ -157,6 +172,11 @@ bool is_gameplay_view_rva(uint32_t vtblRva) {
 //   camlog on|off                1 Hz heartbeat
 //   vroverlay on|off             core overlay visibility (bring-up A/B)
 //   vrcine <args>                core cinematic-fallback A/B (vrcine status..)
+// FOV (session 25; both write levers DEFAULT OFF):
+//   vrfov on|off|status          forced headset FOV write (strict gameplay +
+//                                HMD driving only; save/restore of the option)
+//   gfov <deg>|off               manual game FOV write (flat test lever)
+//   fovaudit                     option vs submitted claim vs rendered fov
 // Discovery commands (route to core/debug/value_scan; game thread only),
 // ported from BS1's dispatcher for the session-25 FOV derivation - the
 // duplicate-now seam policy applies (see the ARCHITECTURE decision log):
@@ -242,6 +262,80 @@ void apply_command(const char* cmd, const char* args) {
         BVR_LOG("[b2r] command: vroverlay %s", strncmp(args, "off", 3) != 0 ? "on" : "off");
     } else if (strcmp(cmd, "vrcine") == 0) {
         bvr::vr::handle_cine_command(args); // core detector A/B on a new game
+    } else if (strcmp(cmd, "vrfov") == 0) {
+        // Forced headset FOV, DEFAULT OFF: in strict gameplay while the HMD
+        // drives, write the headset-suggested hfov into the game option so
+        // the image fills the headset. Off restores on the next CalcView.
+        if (strncmp(args, "status", 6) == 0) {
+            BVR_LOG("[b2r] vrfov status: force=%s suggested=%.1f option=%d "
+                    "writing=%d savedOption=%d",
+                    g_forceHeadsetFov.load(std::memory_order_relaxed) ? "on" : "off",
+                    bvr::vr::suggested_hfov_deg(),
+                    g_lastOptionFov.load(std::memory_order_relaxed),
+                    g_wasWritingGameFov ? 1 : 0, g_savedGameFov);
+        } else {
+            bool on = strncmp(args, "off", 3) != 0;
+            g_forceHeadsetFov.store(on, std::memory_order_relaxed);
+            BVR_LOG("[b2r] command: vrfov %s (suggested headset hfov %.1f deg; engages "
+                    "in strict gameplay while the HMD drives)",
+                    on ? "on" : "off", bvr::vr::suggested_hfov_deg());
+        }
+    } else if (strcmp(cmd, "gfov") == 0) {
+        // Manual game-option FOV write (flat test lever + clamp probe).
+        if (strncmp(args, "off", 3) == 0) {
+            g_gameFovWrite.store(false, std::memory_order_relaxed);
+            BVR_LOG("[b2r] command: gfov off");
+        } else if (sscanf_s(args, "%f", &v) == 1 && v > 0.0f) {
+            g_gameFovDeg.store(v, std::memory_order_relaxed);
+            g_gameFovWrite.store(true, std::memory_order_relaxed);
+            BVR_LOG("[b2r] command: gfov %.1f (writes in strict gameplay)", v);
+        } else {
+            BVR_LOG("[b2r] usage: gfov <deg> | gfov off");
+        }
+    } else if (strcmp(cmd, "fovaudit") == 0) {
+        // The three fov truths side by side (BS1 session-21 instrument, minus
+        // the pose/eyes stereo sub-forms BS2 does not have yet): the engine
+        // option, what the runtime last tagged the projection layer with, and
+        // the option-derived expectation at the swap aspect. The RENDERED
+        // side comes from the core fov watch when it decodes, else from
+        // `dumpframe full 2` + tools/decode-framedump.ps1.
+        int32_t* opt = patterns::hfov_option_ptr();
+        float tanH = 0.0f, tanV = 0.0f;
+        int src = -1;
+        unsigned sw = 0, sh = 0;
+        bvr::vr::fov_audit(&tanH, &tanV, &src, &sw, &sh);
+        // Option-derived expectation. Flat there is no session (swap dims
+        // 0x0) - assume the 16:9 render aspect.
+        float optTanH = 0.0f, optTanV = 0.0f;
+        if (opt) {
+            optTanH = tanf(static_cast<float>(*opt) * 0.5f / kRadToDeg);
+            optTanV = optTanH * ((sw && sh) ? (static_cast<float>(sh) / static_cast<float>(sw))
+                                            : (9.0f / 16.0f));
+        }
+        BVR_LOG("[b2r] fovaudit: option=%d gfovWrite=%s(%.1f) vrfov=%s | submitted "
+                "tanH=%.6f tanV=%.6f src=%s swap=%ux%u | option-derived tanH=%.6f "
+                "tanV=%.6f",
+                opt ? *opt : -1,
+                g_gameFovWrite.load(std::memory_order_relaxed) ? "on" : "off",
+                g_gameFovDeg.load(std::memory_order_relaxed),
+                g_forceHeadsetFov.load(std::memory_order_relaxed) ? "on" : "off", tanH,
+                tanV,
+                src == 0   ? "readback"
+                : src == 1 ? "fallback"
+                : src == 2 ? "manual"
+                : src == 3 ? "live"
+                           : "none",
+                sw, sh, optTanH, optTanV);
+        float liveTanH = 0.0f, liveTanV = 0.0f;
+        unsigned long long liveAge = 0;
+        if (bvr::hud::fov_watch(&liveTanH, &liveTanV, &liveAge))
+            BVR_LOG("[b2r] fovaudit live: rendered tanH=%.4f tanV=%.4f (%.1f deg) "
+                    "age=%llums | mismatch=%d cineActive=%d",
+                    liveTanH, liveTanV, 2.0f * atanf(liveTanH) * kRadToDeg, liveAge,
+                    bvr::hud::fov_mismatch() ? 1 : 0,
+                    bvr::vr::cinematic_active() ? 1 : 0);
+        else
+            BVR_LOG("[b2r] fovaudit live: no decoded scene tangents yet");
     } else if (strcmp(cmd, "fsweep") == 0) {
         float flo = 0.0f, fhi = 0.0f;
         if (sscanf_s(args, "%x %u %f %f", &addr, &len, &flo, &fhi) == 4)
@@ -381,6 +475,17 @@ void calcview_tail(void* self, CalcViewParams* p) {
     }
 
     uint64_t now = GetTickCount64();
+    g_lastCalcViewMs = now;
+
+    // FOV readback (session 25): claim what the game actually renders, every
+    // call, menus included - BS1 shape. Null option object -> claim 0, which
+    // core treats exactly like "no readback yet" (falls back to the headset
+    // target, src=fallback), so nothing regresses before the first scan
+    // lands. While the write block below holds the option, the readback
+    // echoes the written value - correct, the renderer really renders it.
+    int32_t* optionFov = patterns::hfov_option_ptr();
+    g_lastOptionFov.store(optionFov ? *optionFov : 0, std::memory_order_relaxed);
+    bvr::vr::set_rendered_hfov(optionFov ? static_cast<float>(*optionFov) : 0.0f);
 
     // Gameplay verdict + candidate-RVA self-diagnosis. Published every call:
     // core's cinematic fallback keys on this verdict AND its staleness, so a
@@ -416,6 +521,9 @@ void calcview_tail(void* self, CalcViewParams* p) {
             s_lastViewState = viewState;
             BVR_LOG("[b2r] view state: %s",
                     strictGameplay ? "GAMEPLAY (ShockPlayer view)" : "menu/cutscene");
+            // A view-state change is the cheap signal that the object world
+            // changed under us - the moment to retry a dormant settings scan.
+            patterns::hfov_scan_rearm("view state change");
         }
     }
 
@@ -510,6 +618,37 @@ void calcview_tail(void* self, CalcViewParams* p) {
     // Stick-pitch-kill gate for the core input bridge, same funnel BS1 feeds.
     bvr::input::publish_vr_gameplay(vrDrove && strictGameplay);
 
+    // FOV write (session 25, BS1 write-block shape): strict gameplay only,
+    // VR wants it only while the HMD actually drives, manual lever for flat
+    // tests. One-shot save/restore of the user's option value around the
+    // whole written span; leaving gameplay restores immediately, and the
+    // stale-restore in the ProcessEvent detour covers CalcView-silent
+    // scripted scenes. No clamp needed: derivation showed the renderer
+    // consumes at least up to 150 unclamped, and suggested_hfov_deg caps at
+    // 160 on its own.
+    if (optionFov) {
+        float vrFov = g_forceHeadsetFov.load(std::memory_order_relaxed)
+                          ? bvr::vr::suggested_hfov_deg()
+                          : 0.0f;
+        bool wantVr = strictGameplay && vrDrove && vrFov > 0.0f;
+        bool wantManual =
+            strictGameplay && g_gameFovWrite.load(std::memory_order_relaxed);
+        if (wantVr || wantManual) {
+            if (!g_wasWritingGameFov) {
+                g_savedGameFov = *optionFov;
+                g_wasWritingGameFov = true;
+                BVR_LOG("[b2r] game fov write ON (saved option %d)", g_savedGameFov);
+            }
+            float want = wantVr ? vrFov : g_gameFovDeg.load(std::memory_order_relaxed);
+            int32_t wantInt = static_cast<int32_t>(want + 0.5f);
+            if (*optionFov != wantInt) *optionFov = wantInt;
+        } else if (g_wasWritingGameFov) {
+            *optionFov = g_savedGameFov;
+            g_wasWritingGameFov = false;
+            BVR_LOG("[b2r] game fov write OFF (restored option %d)", g_savedGameFov);
+        }
+    }
+
     // Debug camera offset - the cheapest "the block is writable on this game
     // too" proof, log-measurable via the heartbeat.
     loc->x += g_offsetX.load(std::memory_order_relaxed);
@@ -525,11 +664,10 @@ void calcview_tail(void* self, CalcViewParams* p) {
             g_lastHeartbeatMs = now;
             g_heartbeatBaseCount = count;
         } else if (now - g_lastHeartbeatMs >= 1000) {
-            // No fov field: BS2 has no verified FOV source yet (the
-            // UShockUserSettings candidate is unconsumed at M3).
-            BVR_LOG("[b2r] camera: loc=(%.1f %.1f %.1f) rot=(%d %d %d) "
+            BVR_LOG("[b2r] camera: loc=(%.1f %.1f %.1f) rot=(%d %d %d) fov=%d "
                     "headOff=(%.1f %.1f %.1f) drive=%d (%u calls/s)",
                     loc->x, loc->y, loc->z, rot->pitch, rot->yaw, rot->roll,
+                    g_lastOptionFov.load(std::memory_order_relaxed),
                     g_headOffX.load(std::memory_order_relaxed),
                     g_headOffY.load(std::memory_order_relaxed),
                     g_headOffZ.load(std::memory_order_relaxed), vrDrove ? 1 : 0,
@@ -540,6 +678,25 @@ void calcview_tail(void* self, CalcViewParams* p) {
     } else {
         g_lastHeartbeatMs = 0;
     }
+}
+
+// The CalcView-silent hole (BS1 session-22 lesson, bathysphere descent):
+// scripted cameras can stop PlayerCalcView entirely, so the write block's
+// OFF edge never runs and the user's option would stay overwritten. BS1
+// restores from its scene-build detour; BS2 has no scenedraw hook, but
+// ProcessEvent keeps firing for every script event, so the restore ticks
+// from the detour below. Game thread only.
+void restore_game_fov_if_stale(uint64_t staleMs) {
+    if (!g_wasWritingGameFov) return; // steady-state cost: one bool read
+    uint64_t now = GetTickCount64();
+    if (g_lastCalcViewMs == 0 || now - g_lastCalcViewMs < staleMs) return;
+    int32_t* optionFov = patterns::hfov_option_ptr();
+    if (!optionFov) return;
+    *optionFov = g_savedGameFov;
+    g_wasWritingGameFov = false;
+    BVR_LOG("[b2r] game fov write OFF (restored option %d - calcview silent %llu ms)",
+            g_savedGameFov,
+            static_cast<unsigned long long>(now - g_lastCalcViewMs));
 }
 
 // --- the detours -------------------------------------------------------------
@@ -570,6 +727,7 @@ void __fastcall ProcessEventDetour(void* self, void* edx, void* fn, void* parms,
 
     static uint32_t s_pollGate = 0; // game thread only
     if ((++s_pollGate & 0xFF) == 0) poll_command_file(GetTickCount64());
+    if ((s_pollGate & 0x3F) == 0) restore_game_fov_if_stale(400);
 
     if (fn && parms && fn == g_calcViewFn.load(std::memory_order_relaxed))
         calcview_tail(self, static_cast<CalcViewParams*>(parms));
@@ -629,6 +787,15 @@ bool install(const patterns::Symbols& symbols) {
 
 bool hook_live() {
     return g_hookLive.load(std::memory_order_relaxed);
+}
+
+void set_fov_override(float hfovDeg) {
+    if (hfovDeg > 0.0f) {
+        g_gameFovDeg.store(hfovDeg, std::memory_order_relaxed);
+        g_gameFovWrite.store(true, std::memory_order_relaxed);
+    } else {
+        g_gameFovWrite.store(false, std::memory_order_relaxed);
+    }
 }
 
 void draw_debug_ui() {
@@ -695,6 +862,9 @@ void draw_debug_ui() {
         atomic_slider("World scale (UU per m)", g_worldScale, 10.0f, 200.0f);
         atomic_slider("Head offset up (UU)", g_headOffUpUu, -150.0f, 150.0f);
         atomic_slider("Head offset fwd (UU)", g_headOffFwdUu, -80.0f, 80.0f);
+        bool forceFov = g_forceHeadsetFov.load(std::memory_order_relaxed);
+        if (ImGui::Checkbox("Force headset FOV (off = game FOV, narrower)", &forceFov))
+            g_forceHeadsetFov.store(forceFov, std::memory_order_relaxed);
     }
 
     if (ImGui::CollapsingHeader("Camera debug")) {
@@ -704,6 +874,16 @@ void draw_debug_ui() {
         bool logCam = g_logCamera.load(std::memory_order_relaxed);
         if (ImGui::Checkbox("Log camera (1 Hz to file)", &logCam))
             g_logCamera.store(logCam, std::memory_order_relaxed);
+        int32_t optFov = g_lastOptionFov.load(std::memory_order_relaxed);
+        if (optFov > 0)
+            ImGui::Text("fov option: %d (readback claims it)", optFov);
+        else
+            ImGui::TextColored(ImVec4(1.0f, 0.7f, 0.4f, 1.0f),
+                               "fov option: settings object not located yet");
+        bool gfovOn = g_gameFovWrite.load(std::memory_order_relaxed);
+        if (ImGui::Checkbox("Game FOV write (manual)", &gfovOn))
+            g_gameFovWrite.store(gfovOn, std::memory_order_relaxed);
+        atomic_slider("Game FOV (deg)", g_gameFovDeg, 60.0f, 150.0f);
     }
 }
 

--- a/src/game/bioshock2r/camera.cpp
+++ b/src/game/bioshock2r/camera.cpp
@@ -60,7 +60,10 @@ std::atomic<bool> g_logCamera{true};
 std::atomic<int32_t> g_lastOptionFov{0}; // telemetry: 0 = object not located
 std::atomic<bool> g_forceHeadsetFov{false};
 std::atomic<bool> g_gameFovWrite{false};
-std::atomic<float> g_gameFovDeg{100.0f};
+// Manual-lever default 130 = BS1 parity (user request, session 25 in-headset
+// pass: the headset-derived vrfov wrote 131 on the Quest 3 / VD rig and was
+// judged good, so the manual lever defaults to match that neighborhood).
+std::atomic<float> g_gameFovDeg{130.0f};
 
 // M3 VR camera drive. worldScale default follows BS1's in-headset calibration
 // (100 UU/m, session 16) as the starting point - BS2 gets its own verdict

--- a/src/game/bioshock2r/camera.cpp
+++ b/src/game/bioshock2r/camera.cpp
@@ -8,6 +8,8 @@
 
 #include "game/bioshock2r/camera.h"
 
+#include "core/debug/value_scan.h"
+#include "core/gfx/frame_inspector.h"
 #include "core/gfx/hud_capture.h"
 #include "core/input/xinput_bridge.h"
 #include "core/ui/overlay.h"
@@ -155,9 +157,23 @@ bool is_gameplay_view_rva(uint32_t vtblRva) {
 //   camlog on|off                1 Hz heartbeat
 //   vroverlay on|off             core overlay visibility (bring-up A/B)
 //   vrcine <args>                core cinematic-fallback A/B (vrcine status..)
+// Discovery commands (route to core/debug/value_scan; game thread only),
+// ported from BS1's dispatcher for the session-25 FOV derivation - the
+// duplicate-now seam policy applies (see the ARCHITECTURE decision log):
+//   memscan <f>  memrescan <f>  memlist [n]  memread <idx>
+//   memscani <u>  memrescani <u>   (integer-typed variants)
+//   mempoke <idx> <f>  mempoke <lo>-<hi> <f>  mempokei ...same with <u>
+//   memrestore  memptr <idx> [maxDeltaHex]
+//   pokeaddr <hex> <f>  pokeaddri <hex> <u>  hexdump <hex> <len>
+//   fsweep <hexaddr> <len> <lo> <hi>  strscan <text>  membases
+//   dumpframe [full] [n]
+//   vtscan <hexRva> [needBytesHex]  (b2r-first: one-shot heap scan for live
+//   objects whose dword0 == base + RVA - the candidate-vtable verifier)
 
 void apply_command(const char* cmd, const char* args) {
-    float x = 0.0f, y = 0.0f, z = 0.0f;
+    float v = 0.0f, x = 0.0f, y = 0.0f, z = 0.0f;
+    unsigned lo = 0, hi = 0, n = 0;
+    unsigned addr = 0, len = 0;
 
     if (strcmp(cmd, "recenter") == 0) {
         g_recenterRequested.store(true, std::memory_order_relaxed);
@@ -226,9 +242,88 @@ void apply_command(const char* cmd, const char* args) {
         BVR_LOG("[b2r] command: vroverlay %s", strncmp(args, "off", 3) != 0 ? "on" : "off");
     } else if (strcmp(cmd, "vrcine") == 0) {
         bvr::vr::handle_cine_command(args); // core detector A/B on a new game
+    } else if (strcmp(cmd, "fsweep") == 0) {
+        float flo = 0.0f, fhi = 0.0f;
+        if (sscanf_s(args, "%x %u %f %f", &addr, &len, &flo, &fhi) == 4)
+            bvr::value_scan::float_sweep(addr, len, flo, fhi);
+        else
+            BVR_LOG("[b2r] usage: fsweep <hexaddr> <len> <lo> <hi>");
+    } else if (strcmp(cmd, "memscan") == 0) {
+        if (sscanf_s(args, "%f", &v) == 1) bvr::value_scan::scan_f32(v);
+    } else if (strcmp(cmd, "memrescan") == 0) {
+        if (sscanf_s(args, "%f", &v) == 1) bvr::value_scan::rescan_f32(v);
+    } else if (strcmp(cmd, "memscani") == 0) {
+        if (sscanf_s(args, "%u", &n) == 1) bvr::value_scan::scan_u32(n);
+    } else if (strcmp(cmd, "memrescani") == 0) {
+        if (sscanf_s(args, "%u", &n) == 1) bvr::value_scan::rescan_u32(n);
+    } else if (strcmp(cmd, "memlist") == 0) {
+        bvr::value_scan::list(sscanf_s(args, "%u", &n) == 1 ? n : 32);
+    } else if (strcmp(cmd, "memread") == 0) {
+        if (sscanf_s(args, "%u", &n) == 1) bvr::value_scan::read_at(n);
+    } else if (strcmp(cmd, "mempoke") == 0) {
+        if (sscanf_s(args, "%u-%u %f", &lo, &hi, &v) == 3)
+            bvr::value_scan::poke_range(lo, hi, v);
+        else if (sscanf_s(args, "%u %f", &n, &v) == 2)
+            bvr::value_scan::poke(n, v);
+    } else if (strcmp(cmd, "mempokei") == 0) {
+        unsigned iv = 0;
+        if (sscanf_s(args, "%u-%u %u", &lo, &hi, &iv) == 3)
+            bvr::value_scan::poke_range_u32(lo, hi, iv);
+        else if (sscanf_s(args, "%u %u", &n, &iv) == 2)
+            bvr::value_scan::poke_u32(n, iv);
+    } else if (strcmp(cmd, "memrestore") == 0) {
+        bvr::value_scan::restore_all();
+    } else if (strcmp(cmd, "memptr") == 0) {
+        unsigned maxDelta = 0x400;
+        if (sscanf_s(args, "%u %x", &n, &maxDelta) >= 1)
+            bvr::value_scan::ptr_scan(n, maxDelta);
+    } else if (strcmp(cmd, "pokeaddr") == 0) {
+        if (sscanf_s(args, "%x %f", &addr, &v) == 2)
+            bvr::value_scan::poke_addr(addr, v);
+    } else if (strcmp(cmd, "pokeaddri") == 0) {
+        unsigned iv = 0;
+        if (sscanf_s(args, "%x %u", &addr, &iv) == 2)
+            bvr::value_scan::poke_addr_u32(addr, iv);
+    } else if (strcmp(cmd, "hexdump") == 0) {
+        if (sscanf_s(args, "%x %u", &addr, &len) >= 1)
+            bvr::value_scan::hexdump(addr, len ? len : 64);
+    } else if (strcmp(cmd, "strscan") == 0) {
+        char text[96];
+        if (sscanf_s(args, "%95s", text, static_cast<unsigned>(sizeof text)) == 1)
+            bvr::value_scan::log_string_scan(text);
+    } else if (strcmp(cmd, "membases") == 0) {
+        bvr::value_scan::log_module_bases();
+    } else if (strcmp(cmd, "dumpframe") == 0) {
+        // dumpframe [full] [n] - n > 1 records consecutive present windows
+        // (files suffixed _qN). Same core frame inspector as BS1; the dump
+        // lands in this game's data dir via log::data_dir().
+        bool full = strncmp(args, "full", 4) == 0;
+        int count = 1;
+        sscanf_s(full ? args + 4 : args, " %d", &count);
+        bvr::frame_inspector::arm(full ? 2 : 1, count);
+    } else if (strcmp(cmd, "vtscan") == 0) {
+        // vtscan <hexRva> [needBytesHex] - one-shot candidate-vtable verifier:
+        // logs every live object whose dword0 == base + RVA. The accept
+        // callback never chooses, so the census covers ALL matches; the
+        // summary's chosen=00000000 is expected. EXPENSIVE (full 4 GB walk) -
+        // probe use only, never wire onto a cadence.
+        unsigned needBytes = 0x100;
+        if (sscanf_s(args, "%x %x", &addr, &needBytes) >= 1) {
+            uint32_t rva = addr;
+            patterns::scan_for_vtable_object(
+                rva, needBytes,
+                [](void* obj, void* user) -> bool {
+                    BVR_LOG("[b2r] vtscan 0x%X match @ %p",
+                            *static_cast<const uint32_t*>(user), obj);
+                    return false;
+                },
+                &rva, "vtscan", nullptr);
+        } else {
+            BVR_LOG("[b2r] usage: vtscan <hexRva> [needBytesHex]");
+        }
     } else {
-        BVR_LOG("[b2r] unknown command: %s (M3 seam - BS1's wider vocabulary has not "
-                "been ported; see camera.cpp)",
+        BVR_LOG("[b2r] unknown command: %s (see the vocabulary comment in camera.cpp; "
+                "BS1-only levers like vrstereo/vraim/reentry/exec are not ported yet)",
                 cmd);
     }
 }

--- a/src/game/bioshock2r/camera.h
+++ b/src/game/bioshock2r/camera.h
@@ -1,8 +1,9 @@
 #pragma once
-// PlayerCalcView seam for BioShock 2 Remastered - the M3 subset: per-frame
-// camera telemetry, the command-file seam, and the 6DOF HMD head drive
-// (recenter, additive yaw, world scale, head-anchor offsets). No FOV writes,
-// no stereo, no aim/hands - those land with their own milestones.
+// PlayerCalcView seam for BioShock 2 Remastered: per-frame camera telemetry,
+// the command-file seam, the 6DOF HMD head drive (recenter, additive yaw,
+// world scale, head-anchor offsets), and since session 25 the FOV readback
+// (projection claim == rendered) plus the gated FOV write levers (default
+// OFF). No stereo, no aim/hands - those land with their own milestones.
 //
 // Unlike BS1 (event-thunk hook), the seam here is a ProcessEvent hook
 // filtered to the PlayerCalcView UFunction, learned via a FindFunctionChecked
@@ -25,6 +26,10 @@ void init_image(const bvr::pattern_scan::ProcessImage& image);
 bool install(const patterns::Symbols& symbols);
 
 bool hook_live();
+
+// IGameAdapter::setFov funnel: > 0 arms the manual game-FOV write at that
+// value (strict gameplay only, save/restore-gated), <= 0 disarms it.
+void set_fov_override(float hfovDeg);
 
 // Full ImGui section: hook status, telemetry, and the M3 camera controls.
 // Called from the overlay through IGameAdapter::drawDebugUi().

--- a/src/game/bioshock2r/patterns.cpp
+++ b/src/game/bioshock2r/patterns.cpp
@@ -13,6 +13,16 @@ namespace {
 // this session's ASLR base.
 const uint8_t* g_imageBase = nullptr;
 
+// Cached UShockUserSettings instance (revalidated by vtable every call).
+// Like BS1 there is no known static pointer to it; unlike BS1's scanner this
+// one goes DORMANT after 3 straight misses (scan-hygiene rule from the BS1
+// session-22 weapon-resolver lesson: backoff alone still reads as "the game
+// freezes every couple of seconds" on saves where the object never appears).
+void* g_userSettings = nullptr;
+uint64_t g_lastScanMs = 0;
+int g_scanMisses = 0;
+bool g_scanDormant = false;
+
 bool region_scannable(const MEMORY_BASIC_INFORMATION& mbi) {
     if (mbi.State != MEM_COMMIT) return false;
     if (mbi.Protect & (PAGE_GUARD | PAGE_NOACCESS)) return false;
@@ -93,6 +103,71 @@ void* scan_for_vtable_object(uint32_t vtableRva, uint32_t needBytes, ObjectAccep
     BVR_LOG("[b2r] %s scan: %d vtable match(es), chosen=%p", what, matches, chosen);
     if (outMatches) *outMatches = matches;
     return chosen;
+}
+
+namespace {
+
+// Accept the first UShockUserSettings whose HorizontalFOV reads as a
+// plausible degree value, logging every candidate so a wrong pick (stack
+// slot, class default object) is diagnosable from the session log.
+bool accept_user_settings(void* obj, void*) {
+    int32_t fov = *reinterpret_cast<const int32_t*>(static_cast<uint8_t*>(obj) +
+                                                    kUserSettingsHfovOffset);
+    BVR_LOG("[b2r] UShockUserSettings vtable match @ %p HorizontalFOV=%d", obj, fov);
+    return fov >= 40 && fov <= 170;
+}
+
+} // namespace
+
+int32_t* hfov_option_ptr() {
+    using namespace bvr::pattern_scan;
+    if (!g_imageBase) return nullptr;
+
+    const void* wantVtable = g_imageBase + kUserSettingsVtableRva;
+
+    // Revalidate the cache: object freed/moved -> vtable no longer matches.
+    if (g_userSettings) {
+        if (is_memory_valid(g_userSettings, kUserSettingsHfovOffset + sizeof(int32_t)) &&
+            *reinterpret_cast<const void* const*>(g_userSettings) == wantVtable) {
+            return reinterpret_cast<int32_t*>(static_cast<uint8_t*>(g_userSettings) +
+                                              kUserSettingsHfovOffset);
+        }
+        g_userSettings = nullptr; // stale, fall through to a rescan
+        hfov_scan_rearm("cached object went stale");
+    }
+
+    if (g_scanDormant) return nullptr;
+
+    // Rate-limit rescans so a not-yet-created object doesn't scan every frame.
+    uint64_t now = GetTickCount64();
+    if (now - g_lastScanMs < 2000) return nullptr;
+    g_lastScanMs = now;
+
+    int matches = 0;
+    g_userSettings = scan_for_vtable_object(kUserSettingsVtableRva,
+                                            kUserSettingsHfovOffset + sizeof(int32_t),
+                                            &accept_user_settings, nullptr,
+                                            "UShockUserSettings", &matches);
+    if (!g_userSettings) {
+        if (++g_scanMisses >= 3) {
+            g_scanDormant = true;
+            BVR_LOG("[b2r] UShockUserSettings scan DORMANT after %d misses (a view-state "
+                    "change re-arms it)",
+                    g_scanMisses);
+        }
+        return nullptr;
+    }
+    g_scanMisses = 0;
+    return reinterpret_cast<int32_t*>(static_cast<uint8_t*>(g_userSettings) +
+                                      kUserSettingsHfovOffset);
+}
+
+void hfov_scan_rearm(const char* why) {
+    g_scanMisses = 0;
+    if (g_scanDormant) {
+        g_scanDormant = false;
+        BVR_LOG("[b2r] UShockUserSettings scan re-armed (%s)", why);
+    }
 }
 
 bool resolve(const bvr::pattern_scan::ProcessImage& image, Symbols& out) {

--- a/src/game/bioshock2r/patterns.cpp
+++ b/src/game/bioshock2r/patterns.cpp
@@ -2,10 +2,45 @@
 
 #include "core/util/log.h"
 
+#include <windows.h>
+
 #include <cstring>
 
 namespace bvr::b2r::patterns {
 namespace {
+
+// Captured by resolve() so the heap scanner can form vtable addresses for
+// this session's ASLR base.
+const uint8_t* g_imageBase = nullptr;
+
+bool region_scannable(const MEMORY_BASIC_INFORMATION& mbi) {
+    if (mbi.State != MEM_COMMIT) return false;
+    if (mbi.Protect & (PAGE_GUARD | PAGE_NOACCESS)) return false;
+    if (mbi.Type != MEM_PRIVATE) return false; // the object lives on the heap
+    switch (mbi.Protect & 0xFF) {
+        case PAGE_READWRITE:
+        case PAGE_EXECUTE_READWRITE:
+            return true;
+        default:
+            return false;
+    }
+}
+
+// SEH-guarded scan of one region for the vtable dword. A region can decommit
+// between VirtualQuery and the read (the game heap churns on other threads),
+// so the raw walk must not fault the game. No C++ objects in this frame.
+void scan_region(uintptr_t base, uintptr_t end, uintptr_t wantVtable, uint32_t needBytes,
+                 ObjectAccept accept, void* user, void** outChosen, int* outMatches) {
+    __try {
+        for (uintptr_t a = base; a + needBytes <= end; a += 4) {
+            if (*reinterpret_cast<const uintptr_t*>(a) != wantVtable) continue;
+            ++*outMatches;
+            void* obj = reinterpret_cast<void*>(a);
+            if (!*outChosen && accept(obj, user)) *outChosen = obj;
+        }
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+    }
+}
 
 // Follow one incremental-link jmp stub (E9 rel32). Returns the input when it
 // is not a stub. BS2's vtables and inlined call sites route through a stub
@@ -33,9 +68,37 @@ bool prologue_matches(const uint8_t* fn, const uint8_t* expect, size_t n, const 
 
 } // namespace
 
+void* scan_for_vtable_object(uint32_t vtableRva, uint32_t needBytes, ObjectAccept accept,
+                             void* user, const char* what, int* outMatches) {
+    if (!g_imageBase || !accept) return nullptr;
+    const uintptr_t wantVtable = reinterpret_cast<uintptr_t>(g_imageBase) + vtableRva;
+    void* chosen = nullptr;
+    int matches = 0;
+
+    uintptr_t p = 0x10000;
+    MEMORY_BASIC_INFORMATION mbi{};
+    // Walk the FULL 4 GB range: the game is Large-Address-Aware and allocates
+    // actors above 2 GB after a while (BS1 session-18 lesson, baked into this
+    // game's notes up front). VirtualQuery fails past the top on non-LAA
+    // processes, so the loop still terminates there.
+    while (p < 0xFFFE0000u &&
+           VirtualQuery(reinterpret_cast<void*>(p), &mbi, sizeof(mbi)) == sizeof(mbi)) {
+        uintptr_t base = reinterpret_cast<uintptr_t>(mbi.BaseAddress);
+        uintptr_t end = base + mbi.RegionSize;
+        if (end <= base) break;
+        if (region_scannable(mbi))
+            scan_region(base, end, wantVtable, needBytes, accept, user, &chosen, &matches);
+        p = end;
+    }
+    BVR_LOG("[b2r] %s scan: %d vtable match(es), chosen=%p", what, matches, chosen);
+    if (outMatches) *outMatches = matches;
+    return chosen;
+}
+
 bool resolve(const bvr::pattern_scan::ProcessImage& image, Symbols& out) {
     using namespace bvr::pattern_scan;
 
+    g_imageBase = image.base;
     BVR_LOG("[b2r] scanning main module: base %p size 0x%zX", image.base, image.size);
 
     // FName-chain scan (game-agnostic, core/hooks/pattern_scan.h). On BS2 its

--- a/src/game/bioshock2r/patterns.h
+++ b/src/game/bioshock2r/patterns.h
@@ -63,12 +63,36 @@ constexpr uint8_t kFindFuncCheckedPrologue[] = {0x55, 0x8B, 0xEC, 0x64, 0xA1,
 constexpr uint32_t kProcessEventVtblByteOffset = 0xC;
 
 // Further candidates from the same RTTI walk, recorded for the milestone's
-// next steps (FOV readback, hands, skeleton, console exec). Nothing consumes
-// them at M3, so they stay comment-only until the consuming code lands:
-//   UShockUserSettings 0x11523D8   APlayerWeapon    0x112CC78
-//   AHands             0x1125478   SkeletonInstance 0x10D0FC0
+// next steps (hands, skeleton, console exec). Nothing consumes them yet, so
+// they stay comment-only until the consuming code lands:
+//   APlayerWeapon      0x112CC78   AHands           0x1125478
+//   SkeletonInstance   0x10D0FC0
 //   UGameEngine        0x10BD7DC / 0x10BD9E8 (BS1's console_exec used the
 //   second of the pair - expect the same here, but verify before calling).
+
+// --- UShockUserSettings: the FOV option (session 25) ------------------------
+// Vtable RVA runtime-VERIFIED 2026-07-29: vtscan found a live heap object
+// whose dword0 == base + RVA (the two other matches were stack slots holding
+// the same pointer). HorizontalFOV offset derived FRESH - BS1's +0x8C does
+// NOT transfer (it reads 3 here): located by ini-adjacency (MouseIconScale=10
+// immediately precedes HorizontalFOV=100 in [ShockGame.ShockUserSettings] of
+// Bioshock2SP.ini, mirrored in the object as +0x48=10, +0x4C=100) and proven
+// by poke evidence (100->130 screenshot img-diff mean-abs 8.99 / 39.3%
+// changed vs a 1.34 / 5.0% ambient floor after restore; the drill viewmodel
+// re-lensed WITH the world = BS2's foreground follows the option natively;
+// monotonic widening through 150 = no code clamp in the writable range).
+// int32 DEGREES, renderer-consumed per frame, no options APPLY. Full recipe
+// in docs/bioshock2/ENGINE_NOTES.md.
+constexpr uint32_t kUserSettingsVtableRva = 0x11523D8;
+constexpr uint32_t kUserSettingsHfovOffset = 0x4C;
+
+// Live pointer to the HorizontalFOV int, or null while the settings object
+// is not located. Cache + revalidate by vtable dword every call; a miss
+// falls through to the heap scan (rate-limited, DORMANT after 3 straight
+// misses - hfov_scan_rearm() clears that, called on view-state changes).
+// Game thread only.
+int32_t* hfov_option_ptr();
+void hfov_scan_rearm(const char* why);
 
 // --- heap scan for vtable-identified objects (session 25) -------------------
 // BS2 shape of BS1's scanner (bioshock1r/patterns.cpp - duplicated per the

--- a/src/game/bioshock2r/patterns.h
+++ b/src/game/bioshock2r/patterns.h
@@ -70,6 +70,18 @@ constexpr uint32_t kProcessEventVtblByteOffset = 0xC;
 //   UGameEngine        0x10BD7DC / 0x10BD9E8 (BS1's console_exec used the
 //   second of the pair - expect the same here, but verify before calling).
 
+// --- heap scan for vtable-identified objects (session 25) -------------------
+// BS2 shape of BS1's scanner (bioshock1r/patterns.cpp - duplicated per the
+// duplicate-now seam policy): walk the FULL 4 GB committed private RW space
+// (the game is LAA; actors allocate above 2 GB) for objects whose dword0 is
+// imageBase + vtableRva. `accept` is called per match until it takes one;
+// every call site must treat this as EXPENSIVE (multi-second) - one-shot use
+// only, never on a cadence (BS1 session-22 lesson: a scan cadence reads as
+// "the game freezes every couple of seconds").
+using ObjectAccept = bool (*)(void* obj, void* user);
+void* scan_for_vtable_object(uint32_t vtableRva, uint32_t needBytes, ObjectAccept accept,
+                             void* user, const char* what, int* outMatches);
+
 struct Symbols {
     // The dead-on-BS2 event thunk (RVA 0x395CC0 live) - resolved and logged
     // for the knowledge base, NEVER hooked: its signature differs from BS1's


### PR DESCRIPTION
Session 25 (M10): closes the one confirmed BS2 defect from session 24 - the FOV-claim mismatch (projection layer claimed the headset FOV over the game's rendered FOV, producing fisheye + world-drag on head turns).

## What landed

- **FOV source derived fresh**: UShockUserSettings vtable 0x11523D8 runtime-verified via the new vtscan probe; HorizontalFOV at **+0x4C** (int32 degrees, renderer-consumed per frame; BS1's +0x8C does not transfer - it reads 3 on BS2). Full derivation chain in docs/bioshock2/ENGINE_NOTES.md (ini-adjacency + poke/img-diff proof, no clamp through 150).
- **Readback**: every CalcView claims the live option via vr::set_rendered_hfov (claim == rendered); missing object claims 0 = core's explicit fallback. Heartbeat gains fov=N; fovaudit ported.
- **Write levers, DEFAULT OFF**: vrfov (headset-suggested hfov, strict-gameplay + HMD-driving gated) and gfov (manual, defaults 130 for BS1 parity); one-shot save/restore of the user's option; CalcView-silent stale-restore ticks from the ProcessEvent detour. CAP_FOV_WRITE advertised.
- **Discovery tooling on BS2**: memscan family + dumpframe routes (duplicate-now policy) + the b2r-first vtscan candidate-vtable verifier over a new heap scanner with 3-miss dormancy.
- **Policy win**: the native-path check ran FIRST - BS2's foreground viewmodel follows the world FOV natively (poke pair, drill re-lensed with the world), so BS1's entire fg apparatus (fovA/fovB, kFgEyeComp, vrfgfov) stays unported.
- **Core fix**: crash.cpp repeat-fault suppressor + 3-dumps/session cap (the s24 build crash-looped through Steam's CSERHelper filter and wrote 2,083 identical dumps / 115 GB in 40 min).
- **M4 recon banked**: BS1's static submit census is dead on BS2 (SetEvent wrapped/virtual, zero static callers) - next session starts with the live SetEvent caller sampler; pump-loop candidates recorded.

## Verification

- Flat: scan one-shot at boot, fov=100 heartbeat, fovaudit tangents exact (tan(50) to print precision), gfov correctly refuses to write at the menu, restore round-trips img-diff-clean.
- **In-headset (user, Quest 3 / VDXR): ACCEPTED - fisheye gone, world-drag gone**, viewmodel correct, Esc-pause restore edges exercised repeatedly, options slider retains the user's value.