### PR TITLE
BS2 M4-level stereo: SequentialReentry on the threaded substrate (no 1t)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -594,3 +594,36 @@ runtime.
   option re-lensed the drill viewmodel WITH the world (screenshots, ENGINE_NOTES) - so
   fovA/fovB/kFgEyeComp/vrfgfov stay unported, and BS2's FOV milestone is readback +
   write + nothing else.
+
+- **2026-07-29 (session 26, M10): BS2 SequentialReentry runs on the THREADED
+  substrate - none of BS1's single-threading machinery ports.** The policy gate
+  ("check whether BS2 needs the BS1 workaround before porting it") ran against the
+  derived substrate and returned no: BS1 forces the renderer inline because its game
+  thread enters a racy kick-and-wait event handshake per frame (the 0x61D38E deadlock
+  class); BS2's `UGameEngine::Draw` fills a cursor-based command ring with no
+  handshake, and the per-tick render sync runs once AFTER the doubled call - so a
+  second Draw just enqueues a second scene + present. Flat-proven: pulse + continuous
+  + stereo all clean, `presents/s == 2 x draws/s` exact, zero faults. Consequences:
+  no flush-point hook, no drain guard, no hw-thread quotient poke, no watchdog (the
+  deadlock class it detects cannot form without the handshake; one gets added only if
+  a hang is ever observed), and `vrstereo` sequences just camera mode -> stereo. The
+  render-thread sync pair (FEventWin globals 0x1A69294/98) is banked in ENGINE_NOTES
+  UNCONSUMED as the 1t-fallback derivation entry point if long soaks ever disprove
+  this. Load safety replaces BS1's structural-1t discipline with a deny-by-default
+  caller gate: pass 2 doubles only Draws whose return RVA is the single census-verified
+  gameplay dispatcher (0xCD5D7B) plus the calcview-silent and present-stall skips.
+
+- **2026-07-29 (session 26, M10): BS2 pass-2 camera enters via the ProcessEvent seam
+  replay, and commands can never execute mid-Draw.** The doubled Draw re-dispatches
+  PlayerCalcView exactly once (live: 2nd-pass hits == second calls, 655/655), so the
+  BS1 replay design transfers onto the ProcessEvent filter: the fn-match branch checks
+  `second_pass_for_current_thread` and runs `second_pass_replay` (cached pass-1 base +
+  +IPD/2, absolute writes = idempotent, no telemetry/drive/FOV/heartbeat side effects,
+  and no `g_lastCalcViewMs` update so staleness keeps meaning "the NORMAL pass went
+  silent") instead of `calcview_tail`. Hardening the BS1 shape improved on it: the
+  command poller and FOV stale-restore now defer while `inside_hooked_call()` holds
+  (BS1 polls from inside the hooked build; on BS2 a `vtscan` landing mid-Draw would
+  freeze the pair and a hook toggle mid-Draw would be UB - the deferred tick lands
+  milliseconds later given ProcessEvent traffic), and the overlay's vrstereo checkbox
+  posts a request that the same outside-hooked-calls lane applies (also the only lane
+  that works at BS2's menu, which never runs PlayerCalcView).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -596,7 +596,18 @@ kill. Both prerequisites below are now MET.):**
       at UShockUserSettings+0x4C, claim == rendered, vrfov/gfov default OFF, the native-path
       check killed the entire BS1 fg-porting question (viewmodel follows the world FOV
       natively), and the in-headset acceptance PASSED same day: fisheye gone, world-drag
-      gone, restore edges exercised. Still open: M4-level stereo - the milestone's last leg.)
+      gone, restore edges exercised.
+      M4-level stereo: session 26, FLAT-COMPLETE - substrate derived in one session
+      (UGameEngine::Draw 0x4EE8D0 via the live kick/kick2 samplers + offline capstone
+      walks), and the policy gate paid out its biggest win yet: SequentialReentry runs
+      on the THREADED substrate - no 1t, no flush-point, no drain guard, none of BS1's
+      single-threading machinery ports. Pulse/continuous/stereo all flat-green:
+      presents/s == 2 x draws/s exact, per-eye camera delta IPD-exact (6.30 UU), 2nd-pass
+      CalcView replay 655/655, zero faults; `vrstereo on` one-toggle READY; every lever
+      default OFF; pass 2 deny-by-default on the single gameplay caller. Still open for
+      the milestone tick: the IN-HEADSET depth verdict (checklist in
+      docs/bioshock2/TESTING.md - depth reads, eye swap, comfort, world-scale
+      calibration now unblocked) and a user-driven load-crossing pass.)
 
 ## Post-v1 backlog (not scheduled)
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,7 +2,93 @@
 
 > Handoff file. Rewrite "Current state" and "Next steps" every session; append to the session log.
 
-## Current state (2026-07-29, session 25 - M10: BS2 FOV DONE flat - readback claim == rendered, forced-headset-FOV write default OFF, discovery tooling ported, crash-dump loop fixed - branch s25-m10-bs2-fov)
+## Current state (2026-07-29, session 26 - M10: BS2 STEREO FLAT-COMPLETE on the THREADED substrate - no 1t needed, presents == 2x draws exact, per-eye delta IPD-exact, vrstereo one-toggle READY - branch s26-m10-bs2-stereo)
+
+**BS2 SequentialReentry is flat-green, and the headline is what it does NOT need: none of
+BS1's single-threading machinery.** The substrate was derived in one session (live
+kick/kick2 samplers -> offline capstone walks -> `UGameEngine::Draw` = RVA 0x4EE8D0,
+engine vtable 0x10BD7DC slot +0x118 - the session-24 RTTI candidate, now consumed), and
+the policy gate returned its biggest win yet: BS2's Draw path has no kick-and-wait
+handshake (BS1's deadlock class cannot form), so the double Draw runs on the THREADED
+renderer as-is. Flat gates all passed: pulse (call2 ~5 ms real work, presents == draws +
+pulses), continuous (2nd/s == draws/s, presents/s == 2x exact, off recovers instantly),
+stereo (per-eye camera delta 6.30 UU == ipd/1000 x worldScale EXACT, 2nd-pass CalcView
+replay 655/655, zero skips/faults), `vrstereo on` -> READY, ~5 min stereo soak clean.
+Every lever DEFAULT OFF; pass 2 is deny-by-default on the single gameplay caller ret
+0xCD5D7B. In-headset depth verdict + world-scale calibration = the user checklist in
+docs/bioshock2/TESTING.md (world scale was blocked on stereo since session 24 - now
+unblocked).
+
+### 1. THE HEADLINE: threaded-substrate SequentialReentry (the policy's second big payout)
+
+BS1 forces the renderer inline (structural 1t via the flush-point hook) because its
+game thread parks in a racy per-frame event handshake. Session 26 checked whether BS2
+even has that defect before porting the cure: it does not. `UGameEngine::Draw` fills a
+cursor-based command ring; the render-thread sync runs once per tick AFTER Draw
+returns; a doubled Draw enqueues a second scene + present command and the dedicated
+render thread (presentTid != drawTid, live-attributed) just drains both. No flush-point
+derivation, no drain guard, no hw-thread poke, no watchdog. The 1t-fallback entry
+points (render sync FEventWin pair 0x1A69294/98) are banked UNCONSUMED in ENGINE_NOTES
+in case long soaks ever disprove this.
+
+### 2. The derivation (session 26; full chains in docs/bioshock2/ENGINE_NOTES.md "Scene-draw architecture")
+
+- Live instruments first: `reentry kick` (BS1's SetEvent sampler + a BS2 deep-caller
+  extension - the FF15 wrapper methods mask direct callers here) and `reentry kick2`
+  (sampler ON `FEventWin::Trigger` 0xB81050 itself - its ret addr IS the virtual call
+  site). kick2 split the game thread's five once-per-present kicks and cracked the
+  protocol: they are Flash/FMOD lock-step and endframe signals, NOT render submits.
+- Session-25 recon CORRECTED: the "SetEvent wrappers" were thread Suspend/Resume +
+  CRT once-init; the "pump candidates" were a semaphore ctor + an unrelated wait
+  helper; 0x5C7C80 wears BS1's submit shape but is the CONTENT-STREAMING view hand-off
+  (RTTI: FContentStreamingManager). The never-copy rule extends to shapes: a
+  shape-match on the wrong game is a mislabel waiting to happen.
+- PlayerCalcView dispatches EXACTLY once inside every Draw (live: calcIn == draws every
+  beat) - so BS1's pass-2 replay design transferred unchanged onto the ProcessEvent
+  seam. camSrc probe + streaming camera globals live-verified via hexdump.
+
+### 3. What landed in code (branch s26-m10-bs2-stereo, 3 commits)
+
+- b2r `scenedraw.{h,cpp}` (new): kick/kick2/calcstack instruments, prologue-gated
+  HookSlot infra with the vtable-chain build-identity gate (`verify_draw_chain`),
+  pass-through Draw/stream hooks + beat telemetry, `maybe_second_draw` (poison latch,
+  gameplay-caller gate, calcview-silent + present-stall skips, SEH-guarded second call),
+  `vrstereo` one-toggle + overlay checkbox request lane.
+- b2r camera.cpp: `apply_eye_offset` (full-rotation right axis), AER wiring + inter-eye
+  delta log, SR pass-1 base cache + pass-2 `second_pass_replay` on the ProcessEvent
+  fn-match branch, poll-gate hardening (commands NEVER execute mid-Draw - a BS2
+  improvement over BS1), `vrstereo` command, `calcview_silent` export.
+- core (one-liner): `d3d11_hook::last_present_tid()` - the single- vs multi-threaded
+  render attribution that decided the whole design.
+- Adapter advertises CAP_SCENE_REENTRY while reentry hooks are live.
+
+### 4. Carries closed
+
+- Menu controller vtable 0x106EE20 RTTI-identified: plain `APlayerController` (the
+  menu scene runs the base class) - session-24 gap closed.
+- Idle-gameplay crash 0x4FF0FE TRIAGED (offline disasm): a focus-poll path reads
+  `[[0x1A638F0]+0x4C]+0x44` (viewport window object) and it was transiently NULL after
+  ~11 min idle - then the code compares a virtual result against `GetFocus()`. A rare
+  idle/focus race, one-off class, dump cap already ships; no fix attempted.
+- FOV slider endpoints: still unrecorded (needs the user in Graphics Options - on
+  their checklist).
+
+## Next steps
+
+1. **User in-headset run** (checklist: docs/bioshock2/TESTING.md "In-headset stereo
+   checklist"): depth verdict (L/R fused, not swapped), head-motion comfort (pair
+   pacing ships ON), THE WORLD-SCALE CALIBRATION (unblocked at last), IPD slider
+   verify, pause/load edges. Plus the load-crossing pass (quit-to-menu, CONTINUE) -
+   the menu needs a human driver on BS2.
+2. If the user reports instability under stereo: the 1t fallback derivation entry
+   points are banked in ENGINE_NOTES (render sync pair 0x1A69294/98, endframe fn
+   0x501EA0, reader 0xB929F2).
+3. BS2 combat-scene stereo perf profile (needs a combat save).
+4. Record the BS2 FOV slider min/max endpoints when someone is in Graphics Options.
+5. BS1 carries: v0.4.1 to the external tester, 2K-account lead, seated recenter
+   designs, letterbox investigation.
+
+## Previous state (2026-07-29, session 25 - M10: BS2 FOV DONE flat - readback claim == rendered, forced-headset-FOV write default OFF, discovery tooling ported, crash-dump loop fixed - branch s25-m10-bs2-fov)
 
 **The BS2 FOV-claim mismatch is CLOSED - in-headset ACCEPTED (user, Quest 3 / VDXR).**
 `UShockUserSettings.HorizontalFOV` derived fresh at **+0x4C** (BS1's +0x8C reads 3 on BS2 -
@@ -74,7 +160,7 @@ the fault, so our chained filter re-dumped the SAME fault once per second for 40
 at 3/session. The crash itself is UNTRIAGED - dump kept, RVA 0x4FF0FE, registers in the log
 around 18:20:15.
 
-## Next steps
+### Next steps as of session 25 (superseded - the stereo item became session 26; live items carried into the list above)
 
 **STANDING POLICY (user directive, session 24): BS2 is not bound by BS1's methods** - check
 native first, test whether the BS1 problem exists, port only what is proven necessary. Full
@@ -2539,6 +2625,44 @@ and it resumes.
   (install.ps1 backs theirs up automatically).
 
 ## Session log (newest first)
+
+### Session 26 - 2026-07-29 - BS2 stereo: substrate derived and SR flat-green on the THREADED renderer, no 1t
+
+Branched s26-m10-bs2-stereo off main. Commit 1 shipped the discovery instruments (BS1's
+kick sampler + a BS2 deep-caller extension, and kick2 - the sampler hooked on
+FEventWin::Trigger itself since the FF15 wrappers mask direct callers) plus the
+AlternateEye offset wiring. The pre-derivation offline pass immediately CORRECTED the
+session-25 recon: the "SetEvent wrappers" were thread Suspend/Resume + CRT once-init
+machinery, the "pump candidates" were a semaphore ctor + an unrelated wait helper.
+Live sampling then cracked the frame protocol in two windows: kick2 split the game
+thread's five once-per-present Trigger sites and the deep chains + capstone walks
+resolved them into Flash/FMOD lock-step kicks and the endframe signal - and the walk
+from the Draw-tail chain landed on an aligned-stack ret-0x10 function at 0x4EE8D0 whose
+identity fell out beautifully: it sits at slot +0x118 of the session-24 UGameEngine
+vtable candidate 0x10BD7DC = UGameEngine::Draw, with BS1's exact ring-cursor offsets
+(this+0x118/0x11C) and a tail gate into what session 25 had mislabeled the submit -
+actually the FContentStreamingManager view hand-off (its BS1-submit shape match was the
+mislabel; RTTI told the truth). Live hexdumps through the command seam verified the
+streaming camera globals mirror the CalcView camera and the frame-id pair uses BS1's
+high-bit-done convention. Commit 2's pass-through hooks then answered the two live
+questions in one beat line: draws/s == presents/s == calcIn/s exactly (PlayerCalcView
+runs ONCE inside every Draw - the static "it's tick-side" read was wrong, live wins),
+single gameplay caller 0xCD5D7B, and presentTid != drawTid (threaded renderer). The
+decisive design call followed the standing policy: BS2's Draw path has NO kick-and-wait
+handshake, so commit 3 built SequentialReentry directly on the THREADED substrate -
+maybe_second_draw (poison latch, deny-by-default caller gate, calcview-silent +
+present-stall skips, SEH-guarded second call), pass-2 replay on the ProcessEvent
+fn-match branch, pass-1 base cache + eye offsets, poll-gate hardening (commands never
+execute mid-Draw), vrstereo one-toggle = camera mode -> stereo, NO 1t rung. Flat gates
+all green first try: pulse call2 ~5 ms real work with presents == draws + pulses;
+continuous 107/107 doubled at presents 214/s == 2x with instant off-recovery; stereo
+per-eye delta 6.30 UU == expected EXACT with 2nd-pass replay 655/655 and zero
+skips/faults; VRSTEREO READY; ~5 min stereo soak clean (monitor caught nothing, crash
+dir unchanged). Carries closed: 0x106EE20 = plain APlayerController (RTTI); the
+0x4FF0FE idle crash triaged to a transient-null viewport-window read in a focus-poll
+path (rare idle race, dump cap already ships). Handoff: the in-headset depth +
+world-scale checklist is in docs/bioshock2/TESTING.md - world-scale tuning is
+unblocked for the first time.
 
 ### Session 25 - 2026-07-29 - BS2 FOV: readback + write landed flat, fg apparatus proven unnecessary
 

--- a/docs/bioshock2/ENGINE_NOTES.md
+++ b/docs/bioshock2/ENGINE_NOTES.md
@@ -180,30 +180,99 @@ included; null object claims 0 = core's explicit fallback signal); the gated wri
 stale-restore from the ProcessEvent detour because BS2 has no scenedraw hook); the 1 Hz
 heartbeat's `fov=` field; `fovaudit`.
 
-## M4 stereo candidates (session 25 stretch - offline recon ONLY, nothing hooked)
+## Scene-draw architecture (session 26) - SequentialReentry WITHOUT single-threading
 
-Shape-search of the exe against BS1's three render-architecture functions (frame submit:
-TLS-prologue + ret 0xC + SetEvent near tail; render pump: WaitForSingleObject(INFINITE) loop;
-scene build: aligned-stack prologue + ret 0x10). Findings:
+**The headline: BS2's SequentialReentry runs on the THREADED substrate.** BS1 needed
+structural single-threading (the flush-point hook) because its game thread parks in a
+racy kick-and-wait handshake per frame; BS2's Draw path has NO such handshake - the
+game thread fills a cursor-based command ring and the per-tick sync runs once AFTER the
+doubled call - so a second Draw simply enqueues a second scene + present command.
+Flat-proven: pulse and continuous doubling, `presents/s == 2 x draws/s` exact, per-eye
+camera delta IPD-exact, zero faults. None of BS1's 1t/flush-point/drain-guard machinery
+ports. (Second applied case of the "BS2 is not bound by BS1's methods" directive, after
+the session-25 fg verdict.)
 
-- **BS1's static submit-finding method is DEAD on BS2**: the exe has only two `FF 15`
-  SetEvent call sites, both inside wrapper functions (0xB81020, 0xCDB917). The 0xCDB917
-  wrapper (reached via E9 stub 0xD9BD) has ~1954 static callers - a general-purpose sync
-  utility, census-useless. The 0xB81020 wrapper (stub 0xF01A) has ZERO static E8 callers -
-  virtual/register dispatch. No TLS-prologue ret-0xC SetEvent-calling function exists
-  statically. Conclusion: find the submit LIVE, the way BS1 originally did - a kernel32
-  SetEvent caller sampler on the game thread (BS1's `reentry kick` instrument), then walk
-  the sampled return RVA back to the enclosing entry offline.
-- **Render-pump candidates** (WFSO(INFINITE) with a backward-jump loop shape): entries
-  0x7C3E40 and 0xCF3EE0. Unverified; the pump confirms itself live by
-  GetCurrentThreadId-registration + once-per-Present drain cadence.
-- **Scene build**: the aligned-stack + ret 0x10 shape has 300+ static matches - not rankable
-  offline. Derive it from the live submit's gameplay caller ret RVA (BS1 session-6 recipe:
-  hook the submit, log callers, capstone-walk backward past decoy SEH entries; remember the
-  frameless-prologue and 11-byte-CC-run lessons).
-- Per the standing policy: before building SequentialReentry's exact BS1 shape, first check
-  whether BS2's renderer offers a less invasive doubling path (the ProcessEvent-by-name seam
-  may expose per-view script events BS1 never had; unexplored).
+### The derived render substrate (all RVAs live-verified 2026-07-29, session 26)
+
+| symbol | RVA | role + derivation |
+|---|---|---|
+| `UGameEngine::Draw` | **0x4EE8D0** | THE SequentialReentry seam ("build"). Aligned-stack + SEH prologue `53 8B DC 83 EC 08 83 E4 F0` (BS1's build family), `ret 0x10`, ECX = engine this (stored [ebp-0x84]), arg1 = viewport -> edi (+0x48 read at tail). Render-command ring cursors at `this+0x118/+0x11C` (BS1's exact offsets). Derivation: live kick2 deep-chains -> offline capstone walk -> the fn sits at **engine vtable 0x10BD7DC slot +0x118** (stub 0x139D -> body; the session-24 RTTI candidate, now consumed) - the install path re-verifies that whole chain from the image every time. ZERO static E8 callers (virtual dispatch). Live: draws/s == presents/s == calcIn/s exactly; ~0.6-0.8 ms pass-through. |
+| gameplay Draw caller | ret **0xCD5D7B** | the ONLY caller observed over every gameplay beat (count == presents): the 13-instr virtual-dispatch fn at 0xCD5D60 (`call [vtbl+0x118]`, ret 4), called from the viewport iterator 0xCD2C40 (IsWindow-gated, viewport type == 1). Pass 2's deny-by-default gate: double ONLY Draws from this ret. |
+| `FContentStreamingManager` view hand-off | 0x5C7C80 | **NOT a frame submit** - it wears BS1's submit shape exactly (TLS frame-id spin-wait head, camera globals, `ret 0xC`, tail event kick) and that shape-match was session 25's mislabel. `this` = the streaming mgr global; called from the Draw tail (ret 0x4EF541, gated on mgr non-null + ring cursors unequal) and from the no-world frame fn (ret 0x4F9AB9 in fn 0x4F6E70 - the load/menu path). Prologue `55 8B EC 64 A1 2C 00 00 00`. Hooked as telemetry only (fires 1:1 with draws in gameplay). |
+| `FEventWin::Trigger` | 0xB81050 | the event class's signal: `push [ecx+4]; call [IAT SetEvent]; ret` - handle at +4, vtable 0x11E4FAC slot 2 (slot 4 = Pulse, +0x14 = timed wait, +0x18 = wait INFINITE). The engine's ONLY static kernel32!SetEvent path; virtually dispatched everywhere. `reentry kick2` hooks it to sample engine-side call sites. |
+| Flash/FMOD lock-step runnables | Run = 0x67DAD0 | `FThreadLockStepRunnable::Run` (vtable 0x10D53D4 slot 1; abstract work virtual at +0x14): `while (![this+0xC]) { [this+4]->wait(); vtbl[+0x14](); [this+4]->signal(); }`. Shared by `FFlashUpdateRunnable` (vtbl 0x10D53F8) and `FFMODUpdateThread` (vtbl 0x11FB574) - THESE are the two once-per-present SetEvent threads the kick sampler sees, NOT render threads. Flash kick fn 0x67DB30 (gate obj [0x17F7794], work at +0x10, dt at +0x14, wake via 0xBB1950); gate methods: 0xBB1400 wait, 0xBB1610 signal-done, 0xBB1420 execute-INLINE-if-no-thread. |
+| hw-thread quotient | num **0x149760C** / div **0x1497798** | BS1's quotient family, ONE out-of-line copy at 0x67DAB0 (`return [num]/[div] > 1`), gating the Flash kick in the engine-tick fn (~0x500452 region, ret site 0x500546). Not consumed by the mod - kept for the record. |
+| streaming camera globals | loc 0x17F5D7C, rot 0x17F5D90 | live-verified via hexdump: mirror the CalcView camera exactly (the streamer's view info). Frame-id pair 0x17F5D8C/0x17F5DA0 with BS1's high-bit-done convention (`0x800000BA` parked in steady state - backpressure slots, not per-frame counters); streaming mgr global 0x17F5D54; its FEventWin kick obj global 0x17F5D60. |
+| render-thread sync pair | FEventWin globals 0x1A69294 / 0x1A69298 | the endframe fn 0x501EA0 Triggers [0x1A69294] once per present (kick2 site 0x5029BA); static reader 0xB929F2 = render-thread loop candidate. Presents run on a dedicated thread (presentTid != drawTid, live). BANKED, UNCONSUMED - only needed if threaded doubling ever proves unstable and a 1t fallback must be derived. |
+| Draw camera-source probe | viewport+0x48 -> camActor +0x1EC loc / +0x1F8 rot | the Draw head copies these cached fields into its locals (telemetry probe in the detour). NOT the final view camera (loc differs from CalcView's output) - the live camera enters via the CalcView dispatch below. |
+
+### Frame protocol (live-measured)
+
+Game thread per tick: engine tick fn (~0x500452, SEH state machine) -> viewport iterator
+0xCD2C40 -> dispatcher 0xCD5D60 -> **virtual `UGameEngine::Draw`** (fills the command
+ring; **PlayerCalcView dispatches EXACTLY ONCE inside every Draw** - live: calcIn ==
+draws every beat; the script-VM chain 0x4D3400 -> 0x4D06F0 -> 0x4D1080 carries the
+inlined dispatch, 0x4D1080 references the FName index global 0x17D9A08) -> Draw tail:
+streaming view hand-off + Flash kick-if-idle -> back in the tick fn: threaded Flash
+kick + endframe 0x501EA0 (render event Trigger + FMOD kicks + QPC stats). A dedicated
+render thread drains the ring and Presents (~200/s == draws/s); Flash + FMOD lock-step
+threads each SetEvent once per present. PlayerCalcView also dispatches ~3x per frame
+OUTSIDE Draw (other consumers).
+
+### SequentialReentry results (flat gates, 2026-07-29)
+
+- **Pulse** (3x): second Draw does real work (call2 4.5-5.0 ms vs 0.6-0.8 ms
+  pass-through), presents == draws + seconds exactly in the same beat, zero faults,
+  instant 1:1 recovery.
+- **Continuous** (yaw 30): every gameplay Draw doubled - 107/107, presents 214/s == 2x,
+  game tick halves (204 -> 107 draws/s), `reentry off` recovers instantly. 2nd-pass
+  CalcView hits == seconds exactly (655/655): the doubled Draw re-dispatches CalcView
+  once and the ProcessEvent-seam replay applies the pass-2 camera. (PrintWindow
+  phase-determinism catches the FIRST present of each pair on this game - the yawed
+  frame never appears in flat screenshots; the numeric gates carry the proof.)
+- **Stereo**: `2nd/s == draws/s`, `presents/s == 2x draws/s` (99->198 ... 105->210),
+  per-eye camera delta `|d| = 6.30 UU == ipd/1000 x worldScale` EXACT, L/R symmetric
+  around the base along the full-rotation right axis, zero skips/faults/tag-ring
+  resyncs. `vrstereo on` one-toggle (camera mode -> stereo, NO 1t rung) logs READY.
+- Load safety: pass 2 is deny-by-default on the single gameplay caller ret 0xCD5D7B +
+  `calcview_silent(400)` skip + present-stall skip; loaders/menus can never double.
+
+### Frame inspector on BS2 (dumpframe decode-check, session 26)
+
+`dumpframe full 2` under live stereo captured both halves of an SR pair - two
+consecutive present windows, each a FULL depth-tested scene (~808/812 draws, ~630 cb0
+blocks) - dump-level corroboration of the double render. KNOWN GAP: BS1's
+`tools/decode-framedump.ps1` tangent recovery (cb0 floats 12..18 layout) decodes ZERO
+screen-ray blocks on BS2's cb0 layout, so `hud::fov_watch` / `fovaudit`'s "rendered"
+side stays `no decoded scene tangents` on this game. The BS2 cb0 view-proj layout needs
+its own derivation pass when something consumes it (the fov readback claim is already
+verified by other means; the script's $fgBakeRvas are also BS1-only - fgBakeStacks
+reads 0 here, cosmetic).
+
+### Session-25 recon corrections (banked so nobody re-trusts them)
+
+- 0xB81020 (E9 stub 0xF01A) = thread-object Suspend/Resume (tail-jmps
+  SuspendThread/ResumeThread by flag), not a SetEvent wrapper.
+- 0xCDB917 (stub 0xD9BD) = crit-section once-init helper; the second FF15 SetEvent
+  site 0xCDB9BB is CRT encoded-pointer once-init machinery.
+- "Pump candidates": 0xCF3EE0 = CreateSemaphoreW object ctor; 0x7C3E40 = a
+  WFSO(INFINITE) helper over the handle pair at 0x1803A14 with callers
+  0x7A3FD6/0x7A4563 - neither is the render pump.
+- The FF25 import jmp-thunks (SetEvent's at 0xF3E494) have zero callers (dead linker
+  thunks) - an E8-to-thunk census finds nothing.
+
+### Live-sampling instruments that produced all of this (b2r scenedraw.cpp)
+
+`reentry kick` = process-wide kernel32!SetEvent sampler, BS1's shape + a BS2 extension:
+on FIRST insertion of a (tid, ret-RVA) key the slot deep-captures up to 3 further
+call-preceded exe return RVAs from the sampling thread's stack (the FF15 wrapper
+methods mask the direct caller on this game); reports include the window's presents
+delta so cadence reads as a ratio. `reentry kick2` = the same sampler hooked on
+`FEventWin::Trigger` itself - its return address IS the engine-side virtual call site
+(this one split the game thread's five per-frame kicks and cracked the architecture).
+`reentry calcstack` = one-shot call-preceded stack scan at the next CalcView dispatch.
+Menu-controller note: the 0x106EE20 view-actor vtable is plain **APlayerController**
+(RTTI, session 26) - the menu scene runs the base class, closing the session-24 gap.
 
 ## Derivation recipes (shared with BS1 - short form)
 

--- a/docs/bioshock2/TESTING.md
+++ b/docs/bioshock2/TESTING.md
@@ -61,8 +61,44 @@ session 25 also the FOV levers (`vrfov on|off|status`, `gfov <deg>|off`, `fovaud
 full discovery family (`memscan(i)/memrescan(i)/memlist/memread/mempoke(i)/memrestore/memptr/
 pokeaddr(i)/hexdump/fsweep/strscan/membases/dumpframe`, plus the b2r-first
 `vtscan <hexRva> [needBytesHex]` candidate-vtable verifier - one-shot, walks the full 4 GB,
-~3 s Debug in gameplay, EXPECTED to freeze the game for that long). BS1's vrstereo/vraim/
-reentry/exec are NOT ported yet.
+~3 s Debug in gameplay, EXPECTED to freeze the game for that long). Since session 26 also
+the stereo family: `vrstereo on|off` (one toggle: camera mode + stereo - NO 1t rung on
+this game) and `reentry vrstereo|stereo|pulse|on|off|yaw|reset|hook [draw|stream]|unhook|
+dump <n>|kick on|off|kick2 on|off|calcstack|status`. Still unported from BS1: vraim/
+vrhands/vrbones/exec.
+
+## Stereo flat acceptance (session 26 - all PASSED, log-measured; stereo-only policy)
+
+| step | expected |
+|---|---|
+| `reentry hook` in gameplay | `UGameEngine::Draw chain VERIFIED` + `draw hook ENABLED`; beat line shows `draws/s == presents/s`, `calc in == draws`, single caller `CD5D7B` |
+| `reentry pulse 3` | 3x `second draw ok` (call2 ~5 ms vs ~0.7 ms pass-through); that beat shows `presents == draws + 3` |
+| `reentry on` (yaw 30) | `2nd/s == draws/s`, `presents/s == 2x draws/s`, tick halves; `reentry off` recovers 1:1 instantly. Do NOT expect a yawed flat screenshot - PrintWindow catches the FIRST present of each pair on this game |
+| `reentry stereo on` | beat `2nd/s == draws/s`, `presents == 2x`; 1 Hz `[b2r] sr eyes: ... |d|=6.30 UU (expect 6.30)` - the per-eye delta must equal ipd/1000 x worldScale |
+| `reentry status` | `2ndHits == seconds`, `skips=0 foreign=0 poisoned=0` in steady gameplay |
+| `vrstereo on` | `VRSTEREO READY` (camera mode + stereo sequence) |
+| load crossing (user drives the menu) | with vrstereo armed: quit-to-menu / reload - zero faults, `foreign` may tick (loader draws skipped by the caller gate), stereo re-engages in gameplay without re-arm |
+
+## In-headset stereo checklist (session 26 - the M10 depth acceptance)
+
+1. Quest 3 + Virtual Desktop (VDXR), launch BS2, load a save.
+2. `vrstereo on` (overlay "VR stereo" checkbox in the BS2 reentry section, or
+   `.\tools\game-cmd.ps1 -Game bs2 "vrstereo on"`). Log must say `VRSTEREO READY`.
+3. Depth check: nearby geometry (railings, the drill) must read at DIFFERENT depths
+   than the far wall - real parallax, not a flat screen. If everything fuses but feels
+   inside-out/eye-swapped, note it (core has a swap-eyes diagnostic).
+4. Head motion comfort: look around + lean - the SR pair pacing (one xrWaitFrame per
+   L/R pair) ships ON; report any "eyes feel weird" shear on head turns (BS1 session-7
+   symptom; the fix is already active, this verifies it transfers).
+5. World scale: NOW judge it (mono could not show scale) - tune the overlay
+   "World scale" slider until the drill/hands/architecture read life-sized, note the
+   number (BS1 calibrated 100).
+6. IPD slider (overlay): verify it visibly changes eye separation.
+7. Esc pause + resume: quad screen on pause, stereo re-engages on resume.
+8. Quit to menu, CONTINUE back in: stereo must re-engage without re-arm, no crash.
+9. Report: depth correct? eye swap? comfort on head motion? world-scale number?
+   pause/load edges clean? fps feel (expect the tick to halve - ~100 pairs/s in the
+   Adonis spawn flat).
 
 ## FOV flat acceptance (session 25 - log + img-diff measured)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,6 +71,8 @@ add_library(bioshockvr SHARED
     game/bioshock2r/camera.h
     game/bioshock2r/patterns.cpp
     game/bioshock2r/patterns.h
+    game/bioshock2r/scenedraw.cpp
+    game/bioshock2r/scenedraw.h
     game/shared/ue_math.h
 )
 set_target_properties(bioshockvr PROPERTIES PREFIX "")

--- a/src/core/hooks/d3d11_hook.cpp
+++ b/src/core/hooks/d3d11_hook.cpp
@@ -24,6 +24,7 @@ PresentFn g_origPresent = nullptr;
 ResizeBuffersFn g_origResizeBuffers = nullptr;
 std::atomic<bool> g_loggedFirstPresent{false};
 std::atomic<uint64_t> g_presentCount{0};
+std::atomic<uint32_t> g_lastPresentTid{0};
 
 void LogSwapchainInfo(IDXGISwapChain* swapchain) {
     DXGI_SWAP_CHAIN_DESC desc{};
@@ -55,6 +56,7 @@ void LogSwapchainInfo(IDXGISwapChain* swapchain) {
 
 HRESULT WINAPI PresentDetour(IDXGISwapChain* swapchain, UINT syncInterval, UINT flags) {
     const uint64_t presents = g_presentCount.fetch_add(1, std::memory_order_relaxed);
+    g_lastPresentTid.store(GetCurrentThreadId(), std::memory_order_relaxed);
     // Cheap re-arm of our unhandled-exception filter (~every 10 s at 60 fps).
     // The game, the Steam overlay and the 2K SDK all install theirs after our
     // DLL attach, and last writer wins - session 23: a tester's crash produced
@@ -209,6 +211,10 @@ bool install() {
     BVR_LOG("D3D11 swapchain hooks installed (Present @ %p, ResizeBuffers @ %p)",
             present, resizeBuffers);
     return true;
+}
+
+uint32_t last_present_tid() {
+    return g_lastPresentTid.load(std::memory_order_relaxed);
 }
 
 uint64_t present_count() {

--- a/src/core/hooks/d3d11_hook.h
+++ b/src/core/hooks/d3d11_hook.h
@@ -15,4 +15,8 @@ bool install();
 // Lifetime Present count (telemetry: presents-per-frame-root ratios etc.).
 uint64_t present_count();
 
+// Thread id observed on the most recent Present (telemetry: single- vs
+// multi-threaded render attribution - session 26, BS2 substrate work).
+uint32_t last_present_tid();
+
 } // namespace bvr::d3d11_hook

--- a/src/game/bioshock2r/bioshock2r_adapter.cpp
+++ b/src/game/bioshock2r/bioshock2r_adapter.cpp
@@ -3,6 +3,7 @@
 #include "core/util/log.h"
 #include "game/bioshock2r/camera.h"
 #include "game/bioshock2r/patterns.h"
+#include "game/bioshock2r/scenedraw.h"
 
 namespace bvr::b2r {
 
@@ -17,6 +18,7 @@ bool Bioshock2RAdapter::init(const bvr::pattern_scan::ProcessImage& image) {
     patterns::Symbols symbols{};
     if (!patterns::resolve(image, symbols)) return false; // resolve() logged why
     camera::init_image(image); // vtable-RVA identity checks need the bounds
+    scenedraw::init(image);    // RVA math for the discovery instruments
     if (!camera::install(symbols)) return false;
     BVR_LOG("[b2r] adapter ready, capabilities 0x%X", capabilities());
     return true;
@@ -28,6 +30,7 @@ void Bioshock2RAdapter::setFov(float hfovDeg) {
 
 void Bioshock2RAdapter::drawDebugUi() {
     camera::draw_debug_ui();
+    scenedraw::draw_debug_ui();
 }
 
 bvr::game::IGameAdapter* create_adapter() {

--- a/src/game/bioshock2r/bioshock2r_adapter.cpp
+++ b/src/game/bioshock2r/bioshock2r_adapter.cpp
@@ -11,7 +11,12 @@ uint32_t Bioshock2RAdapter::capabilities() const {
     // CAP_FOV_WRITE since session 25: the UShockUserSettings HorizontalFOV
     // offset is runtime-verified and the write is save/restore-gated
     // (camera.cpp write block; patterns.h has the derivation).
-    return camera::hook_live() ? (game::CAP_CAMERA_OVERRIDE | game::CAP_FOV_WRITE) : 0u;
+    // CAP_SCENE_REENTRY since session 26: advertised while a reentry hook is
+    // live (the double-Draw SR machinery in scenedraw.cpp).
+    uint32_t caps =
+        camera::hook_live() ? (game::CAP_CAMERA_OVERRIDE | game::CAP_FOV_WRITE) : 0u;
+    if (scenedraw::hook_live()) caps |= game::CAP_SCENE_REENTRY;
+    return caps;
 }
 
 bool Bioshock2RAdapter::init(const bvr::pattern_scan::ProcessImage& image) {

--- a/src/game/bioshock2r/camera.cpp
+++ b/src/game/bioshock2r/camera.cpp
@@ -66,15 +66,31 @@ std::atomic<bool> g_gameFovWrite{false};
 // judged good, so the manual lever defaults to match that neighborhood).
 std::atomic<float> g_gameFovDeg{130.0f};
 
-// M4 rung 1 (AlternateEye) + the future SR passes share this half-IPD shift.
-// The eye sign comes from core (vr::current_eye_sign(), 0 while the AER
-// checkbox is off), suppressed once SequentialReentry stereo is active.
+// M4 rung 1 (AlternateEye) + the SR passes share this half-IPD shift. The
+// AER eye sign comes from core (vr::current_eye_sign(), 0 while the AER
+// checkbox is off), suppressed while SequentialReentry stereo is active.
 std::atomic<float> g_ipdMm{63.0f};
 // AER flat measure (game thread only): last eyed camera loc per sign, so the
 // heartbeat can print the live inter-eye delta - the G0 stereo quantity
 // (ipd/1000 x worldScale UU between consecutive frames' cameras).
 FVector g_aerLoc[2] = {};
 uint64_t g_aerStampMs[2] = {};
+
+// M4 rung 2 (SequentialReentry): the pass-1 dispatch caches the fully-driven
+// camera here (post head drive + debug offsets, PRE eye offset) so pass 2
+// replays the exact same base with the opposite eye. Game thread only; pass
+// 2 always immediately follows its pass 1 inside the same doubled Draw.
+// The stamp kills the stale-base hazard (scripted scenes silence CalcView);
+// the eyed latch carries pass-1's strict-gameplay decision so a non-gameplay
+// pair renders both eyes IDENTICAL (quad-screen content must not jitter).
+bool g_srBaseValid = false;
+FVector g_srBaseLoc{};
+FRotator g_srBaseRot{};
+uint64_t g_srBaseStampMs = 0;
+bool g_srBaseEyed = false;
+// SR flat measure: final per-eye cameras (post eye offset) for the 1 Hz log.
+FVector g_srEyeLoc[2] = {};
+uint64_t g_srEyeStampMs[2] = {};
 
 // M3 VR camera drive. worldScale default follows BS1's in-headset calibration
 // (100 UU/m, session 16) as the starting point - BS2 gets its own verdict
@@ -220,8 +236,11 @@ void apply_eye_offset(FVector* loc, const FRotator& rot, int sign) {
 //   dumpframe [full] [n]
 //   vtscan <hexRva> [needBytesHex]  (b2r-first: one-shot heap scan for live
 //   objects whose dword0 == base + RVA - the candidate-vtable verifier)
-// Render-substrate discovery (session 26; scenedraw.h has the grammar):
-//   reentry kick on|off | kick2 on|off | calcstack | status
+// Stereo / render substrate (session 26; scenedraw.h has the grammar):
+//   vrstereo on|off              ONE toggle: camera mode + stereo (threaded
+//                                substrate - BS2's primary bet, no 1t rung)
+//   reentry vrstereo|stereo|pulse|on|off|yaw|reset|hook [draw|stream]|
+//           unhook|dump <n>|kick on|off|kick2 on|off|calcstack|status
 
 void apply_command(const char* cmd, const char* args) {
     float v = 0.0f, x = 0.0f, y = 0.0f, z = 0.0f;
@@ -450,6 +469,11 @@ void apply_command(const char* cmd, const char* args) {
         }
     } else if (strcmp(cmd, "reentry") == 0) {
         scenedraw::handle_command(args);
+    } else if (strcmp(cmd, "vrstereo") == 0) {
+        // Top-level alias for the one-toggle (BS1 parity). The poller only
+        // ticks outside hooked calls, so applying directly here is safe.
+        scenedraw::handle_command(strncmp(args, "on", 2) == 0 ? "vrstereo on"
+                                                              : "vrstereo off");
     } else {
         BVR_LOG("[b2r] unknown command: %s (see the vocabulary comment in camera.cpp; "
                 "BS1-only levers like vrstereo/vraim/exec are not ported yet)",
@@ -704,6 +728,26 @@ void calcview_tail(void* self, CalcViewParams* p) {
     loc->y += g_offsetY.load(std::memory_order_relaxed);
     loc->z += g_offsetZ.load(std::memory_order_relaxed);
 
+    // SR pass 1 (LEFT eye): cache the fully-driven base camera LAST - after
+    // everything above that mutates it - then shift this pass's render half
+    // an IPD left. Pass 2 replays the base with the opposite eye. The eyed
+    // latch carries the strict-gameplay decision (non-gameplay pairs render
+    // both eyes identical for the quad screen).
+    if (scenedraw::stereo_active()) {
+        g_srBaseLoc = *loc;
+        g_srBaseRot = *rot;
+        g_srBaseStampMs = now;
+        g_srBaseValid = true;
+        g_srBaseEyed = strictGameplay && !bvr::vr::cinematic_active();
+        if (g_srBaseEyed) {
+            apply_eye_offset(loc, *rot, -1);
+            g_srEyeLoc[0] = *loc;
+            g_srEyeStampMs[0] = now;
+        }
+    } else {
+        g_srBaseValid = false;
+    }
+
     // Heartbeat LAST so it reports the FINAL camera handed back to the game -
     // drive, offsets and all. This is what the flat 6DOF checks measure
     // (offset -> exact UU delta; simhead -> exact rotator units; sim position
@@ -721,6 +765,22 @@ void calcview_tail(void* self, CalcViewParams* p) {
                     g_headOffY.load(std::memory_order_relaxed),
                     g_headOffZ.load(std::memory_order_relaxed), vrDrove ? 1 : 0,
                     count - g_heartbeatBaseCount);
+            // SR flat measure (G6): live inter-eye camera delta from the two
+            // passes of the current pair. Expect |d| == ipdMm/1000 x
+            // worldScale UU (6.3 at defaults).
+            if (g_srEyeStampMs[0] && g_srEyeStampMs[1] && now - g_srEyeStampMs[0] < 500 &&
+                now - g_srEyeStampMs[1] < 500) {
+                float dx = g_srEyeLoc[1].x - g_srEyeLoc[0].x;
+                float dy = g_srEyeLoc[1].y - g_srEyeLoc[0].y;
+                float dz = g_srEyeLoc[1].z - g_srEyeLoc[0].z;
+                BVR_LOG("[b2r] sr eyes: L=(%.2f %.2f %.2f) R=(%.2f %.2f %.2f) "
+                        "|d|=%.2f UU (expect %.2f)",
+                        g_srEyeLoc[0].x, g_srEyeLoc[0].y, g_srEyeLoc[0].z,
+                        g_srEyeLoc[1].x, g_srEyeLoc[1].y, g_srEyeLoc[1].z,
+                        sqrtf(dx * dx + dy * dy + dz * dz),
+                        g_ipdMm.load(std::memory_order_relaxed) / 1000.0f *
+                            g_worldScale.load(std::memory_order_relaxed));
+            }
             // AER flat measure (G0): live inter-eye camera delta. Expect
             // |d| == ipdMm/1000 x worldScale UU (6.3 at defaults) with the
             // head held still (simhead).
@@ -762,6 +822,35 @@ void restore_game_fov_if_stale(uint64_t staleMs) {
             static_cast<unsigned long long>(now - g_lastCalcViewMs));
 }
 
+// The SECOND-pass dispatch of a doubled Draw (SequentialReentry pass 2).
+// Runs INSTEAD of calcview_tail: replay the cached pass-1 base with the
+// RIGHT eye, or (non-stereo probe mode) add the flat yaw delta. Everything
+// else is deliberately skipped - no drive, no telemetry, no FOV write, no
+// heartbeat, and NO g_lastCalcViewMs update (staleness must keep meaning
+// "the NORMAL pass went silent"). Writes are absolute, so multiple
+// dispatches inside one pass-2 window are idempotent.
+// NOTE for the future body/bones port: BS1's pass 2 also re-applies the
+// bone drive here (bioshock1r/camera.cpp:821-824 - the engine re-evaluates
+// the skeleton during pass 2). BS2 has no bones module yet; revisit this
+// exact spot when it grows one.
+void second_pass_replay(CalcViewParams* p, float yawDeg) {
+    uint64_t now = GetTickCount64();
+    if (scenedraw::stereo_active()) {
+        if (!g_srBaseValid || now - g_srBaseStampMs > 100) return; // stale base: leave as-is
+        p->loc = g_srBaseLoc;
+        p->rot = g_srBaseRot;
+        if (g_srBaseEyed) {
+            apply_eye_offset(&p->loc, p->rot, +1);
+            g_srEyeLoc[1] = p->loc;
+            g_srEyeStampMs[1] = now;
+        }
+    } else {
+        // Flat double-render probe: a visibly yawed second frame is the
+        // proof the engine renders a second full scene per tick.
+        p->rot.yaw += static_cast<int32_t>(yawDeg * kRotUnitsPerDegree);
+    }
+}
+
 // --- the detours -------------------------------------------------------------
 
 // FindFunctionChecked: learn the PlayerCalcView UFunction pointer with zero
@@ -798,12 +887,25 @@ void __fastcall ProcessEventDetour(void* self, void* edx, void* fn, void* parms,
     if ((s_pollGate & 0xFF) == 0 || (s_pollGate & 0x3F) == 0) {
         if (!scenedraw::inside_hooked_call()) {
             if ((s_pollGate & 0xFF) == 0) poll_command_file(GetTickCount64());
-            if ((s_pollGate & 0x3F) == 0) restore_game_fov_if_stale(400);
+            if ((s_pollGate & 0x3F) == 0) {
+                restore_game_fov_if_stale(400);
+                // Overlay-posted vrstereo request: hook installs must never
+                // run mid-Draw or from the render thread; this lane is the
+                // game thread outside hooked calls. Also the MENU-arming
+                // path - BS2's menu never runs PlayerCalcView.
+                scenedraw::apply_pending_vrstereo();
+            }
         }
     }
 
-    if (fn && parms && fn == g_calcViewFn.load(std::memory_order_relaxed))
-        calcview_tail(self, static_cast<CalcViewParams*>(parms));
+    if (fn && parms && fn == g_calcViewFn.load(std::memory_order_relaxed)) {
+        auto* p = static_cast<CalcViewParams*>(parms);
+        float yawDeg = 0.0f;
+        if (scenedraw::second_pass_for_current_thread(&yawDeg))
+            second_pass_replay(p, yawDeg);
+        else
+            calcview_tail(self, p);
+    }
 }
 
 void atomic_slider(const char* label, std::atomic<float>& value, float lo, float hi) {
@@ -869,6 +971,12 @@ void set_fov_override(float hfovDeg) {
     } else {
         g_gameFovWrite.store(false, std::memory_order_relaxed);
     }
+}
+
+bool calcview_silent(uint64_t maxAgeMs) {
+    if (g_lastCalcViewMs == 0) return true;
+    uint64_t now = GetTickCount64();
+    return now - g_lastCalcViewMs > maxAgeMs;
 }
 
 void draw_debug_ui() {

--- a/src/game/bioshock2r/camera.cpp
+++ b/src/game/bioshock2r/camera.cpp
@@ -15,6 +15,7 @@
 #include "core/ui/overlay.h"
 #include "core/util/log.h"
 #include "core/vr/openxr_runtime.h"
+#include "game/bioshock2r/scenedraw.h"
 #include "game/shared/ue_math.h"
 
 #include <windows.h>
@@ -64,6 +65,16 @@ std::atomic<bool> g_gameFovWrite{false};
 // pass: the headset-derived vrfov wrote 131 on the Quest 3 / VD rig and was
 // judged good, so the manual lever defaults to match that neighborhood).
 std::atomic<float> g_gameFovDeg{130.0f};
+
+// M4 rung 1 (AlternateEye) + the future SR passes share this half-IPD shift.
+// The eye sign comes from core (vr::current_eye_sign(), 0 while the AER
+// checkbox is off), suppressed once SequentialReentry stereo is active.
+std::atomic<float> g_ipdMm{63.0f};
+// AER flat measure (game thread only): last eyed camera loc per sign, so the
+// heartbeat can print the live inter-eye delta - the G0 stereo quantity
+// (ipd/1000 x worldScale UU between consecutive frames' cameras).
+FVector g_aerLoc[2] = {};
+uint64_t g_aerStampMs[2] = {};
 
 // M3 VR camera drive. worldScale default follows BS1's in-headset calibration
 // (100 UU/m, session 16) as the starting point - BS2 gets its own verdict
@@ -161,6 +172,23 @@ bool is_gameplay_view_rva(uint32_t vtblRva) {
     return vtblRva == patterns::kShockPlayerVtableRva;
 }
 
+// Half-IPD shift along view-right of `rot`, sign -1 = left eye. Shared by the
+// AER path now and both SequentialReentry passes later - ONE implementation,
+// exactly like BS1 (its session-22 lesson: a yaw-only right axis keeps the
+// virtual eyes horizontal while real eyes stack vertically under head roll;
+// ue_rot_basis's full-rotation right row fixes that, and at roll 0 it reduces
+// bit-identically to the yaw-only formula).
+void apply_eye_offset(FVector* loc, const FRotator& rot, int sign) {
+    float fwd[3], right[3], up[3];
+    ue_rot_basis(rot, fwd, right, up);
+    float halfIpdUu = static_cast<float>(sign) *
+                      (g_ipdMm.load(std::memory_order_relaxed) / 2000.0f) *
+                      g_worldScale.load(std::memory_order_relaxed);
+    loc->x += right[0] * halfIpdUu;
+    loc->y += right[1] * halfIpdUu;
+    loc->z += right[2] * halfIpdUu;
+}
+
 // --- command seam ------------------------------------------------------------
 // <data_dir>\command.txt (= %LOCALAPPDATA%\BioshockVR\bs2\command.txt) polled
 // at 1 Hz on the game thread, same contract as BS1's seam - but driven from
@@ -192,6 +220,8 @@ bool is_gameplay_view_rva(uint32_t vtblRva) {
 //   dumpframe [full] [n]
 //   vtscan <hexRva> [needBytesHex]  (b2r-first: one-shot heap scan for live
 //   objects whose dword0 == base + RVA - the candidate-vtable verifier)
+// Render-substrate discovery (session 26; scenedraw.h has the grammar):
+//   reentry kick on|off | kick2 on|off | calcstack | status
 
 void apply_command(const char* cmd, const char* args) {
     float v = 0.0f, x = 0.0f, y = 0.0f, z = 0.0f;
@@ -418,9 +448,11 @@ void apply_command(const char* cmd, const char* args) {
         } else {
             BVR_LOG("[b2r] usage: vtscan <hexRva> [needBytesHex]");
         }
+    } else if (strcmp(cmd, "reentry") == 0) {
+        scenedraw::handle_command(args);
     } else {
         BVR_LOG("[b2r] unknown command: %s (see the vocabulary comment in camera.cpp; "
-                "BS1-only levers like vrstereo/vraim/reentry/exec are not ported yet)",
+                "BS1-only levers like vrstereo/vraim/exec are not ported yet)",
                 cmd);
     }
 }
@@ -479,6 +511,7 @@ void calcview_tail(void* self, CalcViewParams* p) {
 
     uint64_t now = GetTickCount64();
     g_lastCalcViewMs = now;
+    scenedraw::note_calcview(); // in/out attribution + one-shot instruments
 
     // FOV readback (session 25): claim what the game actually renders, every
     // call, menus included - BS1 shape. Null option object -> claim 0, which
@@ -610,6 +643,19 @@ void calcview_tail(void* self, CalcViewParams* p) {
             loc->y += sinf(vyaw) * hoFwd;
             loc->z += hoUp;
         }
+
+        // AlternateEye (M4 rung 1): shift half an IPD along view-right; core
+        // flips the sign after each submitted frame so successive game frames
+        // render alternating eyes. Suppressed under SequentialReentry stereo
+        // (rung 2), which applies both eye offsets itself. Same wiring as
+        // BS1's shipped AER path.
+        int eyeSign = scenedraw::stereo_active() ? 0 : bvr::vr::current_eye_sign();
+        if (eyeSign != 0) {
+            apply_eye_offset(loc, *rot, eyeSign);
+            int e = eyeSign < 0 ? 0 : 1;
+            g_aerLoc[e] = *loc;
+            g_aerStampMs[e] = now;
+        }
         vrDrove = true;
     }
     g_vrDriving.store(vrDrove, std::memory_order_relaxed);
@@ -675,6 +721,20 @@ void calcview_tail(void* self, CalcViewParams* p) {
                     g_headOffY.load(std::memory_order_relaxed),
                     g_headOffZ.load(std::memory_order_relaxed), vrDrove ? 1 : 0,
                     count - g_heartbeatBaseCount);
+            // AER flat measure (G0): live inter-eye camera delta. Expect
+            // |d| == ipdMm/1000 x worldScale UU (6.3 at defaults) with the
+            // head held still (simhead).
+            if (g_aerStampMs[0] && g_aerStampMs[1] && now - g_aerStampMs[0] < 500 &&
+                now - g_aerStampMs[1] < 500) {
+                float dx = g_aerLoc[1].x - g_aerLoc[0].x;
+                float dy = g_aerLoc[1].y - g_aerLoc[0].y;
+                float dz = g_aerLoc[1].z - g_aerLoc[0].z;
+                BVR_LOG("[b2r] aer: eye delta=(%.2f %.2f %.2f) |d|=%.2f UU "
+                        "(expect %.2f)",
+                        dx, dy, dz, sqrtf(dx * dx + dy * dy + dz * dz),
+                        g_ipdMm.load(std::memory_order_relaxed) / 1000.0f *
+                            g_worldScale.load(std::memory_order_relaxed));
+            }
             g_lastHeartbeatMs = now;
             g_heartbeatBaseCount = count;
         }
@@ -728,9 +788,19 @@ void __fastcall ProcessEventDetour(void* self, void* edx, void* fn, void* parms,
                                    void* result) {
     g_originalPE(self, edx, fn, parms, result);
 
+    // The poll and the stale-restore defer while this thread is inside a
+    // hooked render call (session 26): a command that installs or disables
+    // hooks must never execute mid-build. Total ProcessEvent traffic is high,
+    // so a deferred tick lands again within milliseconds. (BS2 improvement
+    // over BS1, whose poller runs inside the build via the CalcView detour.)
     static uint32_t s_pollGate = 0; // game thread only
-    if ((++s_pollGate & 0xFF) == 0) poll_command_file(GetTickCount64());
-    if ((s_pollGate & 0x3F) == 0) restore_game_fov_if_stale(400);
+    ++s_pollGate;
+    if ((s_pollGate & 0xFF) == 0 || (s_pollGate & 0x3F) == 0) {
+        if (!scenedraw::inside_hooked_call()) {
+            if ((s_pollGate & 0xFF) == 0) poll_command_file(GetTickCount64());
+            if ((s_pollGate & 0x3F) == 0) restore_game_fov_if_stale(400);
+        }
+    }
 
     if (fn && parms && fn == g_calcViewFn.load(std::memory_order_relaxed))
         calcview_tail(self, static_cast<CalcViewParams*>(parms));
@@ -865,6 +935,7 @@ void draw_debug_ui() {
         atomic_slider("World scale (UU per m)", g_worldScale, 10.0f, 200.0f);
         atomic_slider("Head offset up (UU)", g_headOffUpUu, -150.0f, 150.0f);
         atomic_slider("Head offset fwd (UU)", g_headOffFwdUu, -80.0f, 80.0f);
+        atomic_slider("IPD (mm, AER + stereo)", g_ipdMm, 50.0f, 75.0f);
         bool forceFov = g_forceHeadsetFov.load(std::memory_order_relaxed);
         if (ImGui::Checkbox("Force headset FOV (off = game FOV, narrower)", &forceFov))
             g_forceHeadsetFov.store(forceFov, std::memory_order_relaxed);

--- a/src/game/bioshock2r/camera.h
+++ b/src/game/bioshock2r/camera.h
@@ -31,6 +31,11 @@ bool hook_live();
 // value (strict gameplay only, save/restore-gated), <= 0 disarms it.
 void set_fov_override(float hfovDeg);
 
+// True when no normal-pass PlayerCalcView dispatch landed within maxAgeMs -
+// the scripted-camera signal (scenedraw's second-draw skip + the FOV
+// stale-restore both key on it). Game thread only.
+bool calcview_silent(uint64_t maxAgeMs);
+
 // Full ImGui section: hook status, telemetry, and the M3 camera controls.
 // Called from the overlay through IGameAdapter::drawDebugUi().
 void draw_debug_ui();

--- a/src/game/bioshock2r/patterns.cpp
+++ b/src/game/bioshock2r/patterns.cpp
@@ -170,6 +170,31 @@ void hfov_scan_rearm(const char* why) {
     }
 }
 
+bool verify_draw_chain(const bvr::pattern_scan::ProcessImage& image) {
+    using namespace bvr::pattern_scan;
+    const uint8_t* slot = image.base + kGameEngineVtableRva + kDrawVtblByteOffset;
+    if (!is_memory_valid(slot, sizeof(void*))) {
+        BVR_LOG("[b2r] engine vtable Draw slot unreadable (RVA 0x%X+0x%X)",
+                kGameEngineVtableRva, kDrawVtblByteOffset);
+        return false;
+    }
+    const uint8_t* stub = *reinterpret_cast<const uint8_t* const*>(slot);
+    const uint8_t* draw = follow_jmp_stub(stub);
+    if (draw != image.base + kSceneBuildRva) {
+        BVR_LOG("[b2r] Draw via engine vtbl+0x%X = %p (stub %p) does NOT match expected "
+                "RVA 0x%X - build differs, refusing",
+                kDrawVtblByteOffset, draw, stub, kSceneBuildRva);
+        return false;
+    }
+    if (!prologue_matches(draw, kSceneBuildPrologue, sizeof(kSceneBuildPrologue),
+                          "UGameEngine::Draw"))
+        return false;
+    BVR_LOG("[b2r] UGameEngine::Draw chain VERIFIED: vtbl 0x%X slot +0x%X -> stub %p -> "
+            "body %p (RVA 0x%X)",
+            kGameEngineVtableRva, kDrawVtblByteOffset, stub, draw, kSceneBuildRva);
+    return true;
+}
+
 bool resolve(const bvr::pattern_scan::ProcessImage& image, Symbols& out) {
     using namespace bvr::pattern_scan;
 

--- a/src/game/bioshock2r/patterns.h
+++ b/src/game/bioshock2r/patterns.h
@@ -111,10 +111,26 @@ constexpr uint8_t kSceneBuildPrologue[] = {0x53, 0x8B, 0xDC, 0x83, 0xEC,
 // push ebx; mov ebx,esp; sub esp,8; and esp,-16 (aligned-stack MSVC frame,
 // BS1's build prologue family; SEH frame follows)
 
-// Draw's camera source (the pass-2 poke target).
+// Draw's camera source probe (telemetry; the live camera enters via the
+// CalcView dispatch that runs EXACTLY once inside every Draw - live-verified
+// calcIn == draws every beat, so the BS1 pass-2 replay design transfers).
 constexpr uint32_t kViewportCamActorOffset = 0x48;
 constexpr uint32_t kCamActorLocOffset = 0x1EC; // 3 floats
 constexpr uint32_t kCamActorRotOffset = 0x1F8; // 3 int32 rotator units
+
+// The ONE gameplay Draw caller (live census 2026-07-29: single ret RVA over
+// every beat, count == presents). It is the little virtual-dispatch fn at
+// 0xCD5D60 (`call [vtbl+0x118]`, ret 4), itself called from the viewport
+// iterator at 0xCD2C40. Pass 2 doubles ONLY Draws arriving from here -
+// deny-by-default: any other caller (load paths included) is skipped and
+// counted, so doubling can never run inside a loader.
+constexpr uint32_t kSceneBuildGameplayRetRva = 0xCD5D7B;
+
+// Render-thread sync pair (banked for the 1t fallback, unconsumed): the
+// endframe fn 0x501EA0 triggers FEventWin global [0x1A69294] once per
+// present (kick2 site 0x5029BA) and reads its sibling [0x1A69298]; static
+// readers of the pair include 0xB929F2 (render-thread loop candidate).
+// Only derived further if threaded-mode doubling proves unstable.
 
 // FContentStreamingManager view hand-off (telemetry hook only).
 constexpr uint32_t kStreamViewRva = 0x5C7C80;

--- a/src/game/bioshock2r/patterns.h
+++ b/src/game/bioshock2r/patterns.h
@@ -70,30 +70,80 @@ constexpr uint32_t kProcessEventVtblByteOffset = 0xC;
 //   UGameEngine        0x10BD7DC / 0x10BD9E8 (BS1's console_exec used the
 //   second of the pair - expect the same here, but verify before calling).
 
-// --- render-substrate discovery (session 26) --------------------------------
-// The engine's ONLY static path to kernel32!SetEvent is the event-object
-// signal ("Trigger") method below: `push [ecx+4]; call [IAT SetEvent]; ret` -
-// a 10-byte __thiscall with the HANDLE at object+4 (the same event-object
-// shape BS1 documented on its submit kick). It has ZERO static E8 callers
-// (virtual dispatch), so the submit is derived LIVE: `reentry kick2` hooks
-// this method and samples _ReturnAddress() = the engine-side call site.
-// Session-25 recon CORRECTIONS (offline capstone census, 2026-07-29 s26):
-// 0xB81020 (E9 stub 0xF01A) is SuspendThread/ResumeThread on a thread object,
-// 0xCDB917 (stub 0xD9BD) is a crit-section once-init helper, the second FF15
-// SetEvent site 0xCDB9BB is CRT encoded-pointer once-init machinery, and the
-// FF25 import jmp-thunks (SetEvent's at 0xF3E494) have zero callers - none of
-// these are render seams. Sync-primitive census + derivations in
-// docs/bioshock2/ENGINE_NOTES.md. Recorded there, comment-only here until a
-// consumer lands: ReleaseSemaphore FF15 cluster 0x5C98CE/0x5C9A1B/0x5C9B84/
-// 0x5C9DB8 (job-system shape); WFSO(INFINITE, handlePair[i<2]) helper
-// 0x7C3E40 over the global handle pair at RVA 0x1803A14 (pump-wait
-// candidate); CreateSemaphoreW ctor 0xCF3EE0 (session-25 "pump candidate"
-// label was wrong - it is a semaphore-object constructor).
+// --- render substrate (session 26) -------------------------------------------
+// Derived by the live kick/kick2 samplers + offline capstone walks; full
+// derivation chains in docs/bioshock2/ENGINE_NOTES.md "Scene-draw
+// architecture (session 26)". Headlines:
+// - The scene build root is UGameEngine::Draw: vtable slot +0x118 of the
+//   session-24 RTTI candidate 0x10BD7DC holds jmp stub 0x139D -> body
+//   0x4EE8D0 (aligned-stack + SEH prologue, ret 0x10, this = the engine,
+//   render-command ring cursors at this+0x118/+0x11C). ZERO static E8
+//   callers - virtually dispatched; the gameplay caller ret RVA comes from
+//   the live caller census (deny-by-default gate data for pass 2).
+// - Draw reads its camera from the viewport's camera actor at the head:
+//   [[arg1+0x48] + 0x1EC..0x1F4] = loc floats, [+0x1F8..0x200] = rot ints -
+//   written earlier by the tick-side PlayerCalcView dispatch (fn 0x4D1080,
+//   references the documented FName index global 0x17D9A08). CalcView does
+//   NOT run inside Draw on BS2 (BS1 difference!) - a doubled Draw needs the
+//   cached fields poked, not a CalcView replay.
+// - 0x5C7C80 is NOT a frame submit despite wearing BS1's submit shape
+//   (TLS frame-id spin-wait, camera globals, ret 0xC, tail event kick): its
+//   `this` is the FContentStreamingManager global and the camera globals it
+//   fills are the streaming view info. Hooked as telemetry only.
+// - The two once-per-present SetEvent threads are the Flash (gameswf) and
+//   FMOD lock-step runnables (FThreadLockStepRunnable::Run = 0x67DAD0,
+//   shared vtable slot 1); the hw-thread quotient helper 0x67DAB0 gates the
+//   Flash kick: threaded iff [0x149760C] / [0x1497798] > 1 (BS1's quotient
+//   family, one out-of-line copy).
+// Session-25 recon CORRECTIONS: 0xB81020 (stub 0xF01A) = thread
+// Suspend/Resume; 0xCDB917 (stub 0xD9BD) = crit-section once-init helper;
+// FF15 SetEvent site 0xCDB9BB = CRT once-init machinery; 0xCF3EE0 =
+// CreateSemaphoreW object ctor (not a pump); 0x7C3E40 = WFSO(INFINITE)
+// helper over the handle pair at 0x1803A14, callers 0x7A3FD6/0x7A4563
+// (not the render queue).
+
+// UGameEngine::Draw - THE SequentialReentry seam candidate.
+constexpr uint32_t kGameEngineVtableRva = 0x10BD7DC; // RTTI walk s24, consumed s26
+constexpr uint32_t kDrawVtblByteOffset = 0x118;      // slot holding stub -> Draw
+constexpr uint32_t kSceneBuildRva = 0x4EE8D0;        // UGameEngine::Draw body
+constexpr uint8_t kSceneBuildPrologue[] = {0x53, 0x8B, 0xDC, 0x83, 0xEC,
+                                           0x08, 0x83, 0xE4, 0xF0};
+// push ebx; mov ebx,esp; sub esp,8; and esp,-16 (aligned-stack MSVC frame,
+// BS1's build prologue family; SEH frame follows)
+
+// Draw's camera source (the pass-2 poke target).
+constexpr uint32_t kViewportCamActorOffset = 0x48;
+constexpr uint32_t kCamActorLocOffset = 0x1EC; // 3 floats
+constexpr uint32_t kCamActorRotOffset = 0x1F8; // 3 int32 rotator units
+
+// FContentStreamingManager view hand-off (telemetry hook only).
+constexpr uint32_t kStreamViewRva = 0x5C7C80;
+constexpr uint8_t kStreamViewPrologue[] = {0x55, 0x8B, 0xEC, 0x64, 0xA1,
+                                           0x2C, 0x00, 0x00, 0x00};
+// push ebp; mov ebp,esp; mov eax,fs:[0x2C]
+
+// FEventWin::Trigger (vtable 0x11E4FAC slot 2): `push [ecx+4]; call
+// [IAT SetEvent]; ret` - handle at object+4. The kick2 sampler hooks it.
+// Opcode bytes only: the FF15 operand embeds the ASLR-rebased IAT VA.
 constexpr uint32_t kEventTriggerRva = 0xB81050;
-// Opcode bytes only: the FF15 operand embeds the ASLR-rebased IAT VA, so the
-// last 4 bytes of the instruction differ from the disk image at runtime.
 constexpr uint8_t kEventTriggerPrologue[] = {0xFF, 0x71, 0x04, 0xFF, 0x15};
-// push dword ptr [ecx+4]; call dword ptr [imm32]
+
+// Globals (RVAs; live-verified via hexdump against the running game):
+constexpr uint32_t kDrawCounterRva = 0x17D7D2C;     // inc at Draw head (~presents/s)
+constexpr uint32_t kStreamMgrGlobalRva = 0x17F5D54; // FContentStreamingManager*
+constexpr uint32_t kStreamCamLocRva = 0x17F5D7C;    // 3 floats, == live camera
+constexpr uint32_t kStreamFrameIdARva = 0x17F5D8C;  // high bit = done (BS1 shape)
+constexpr uint32_t kStreamCamRotRva = 0x17F5D90;    // 3 int32, == live camera
+constexpr uint32_t kStreamFrameIdBRva = 0x17F5DA0;
+constexpr uint32_t kHwThreadsRva = 0x149760C;       // quotient numerator
+constexpr uint32_t kThreadDivisorRva = 0x1497798;   // quotient divisor
+constexpr uint32_t kFlashTaskGlobalRva = 0x17F7794; // Flash lock-step task
+
+// Static build-identity gate for the Draw hook: image[kGameEngineVtableRva +
+// kDrawVtblByteOffset] must hold imageBase + a jmp stub that lands on
+// kSceneBuildRva, whose bytes match kSceneBuildPrologue. Pure image reads -
+// refuses the hook on any mismatch (a wrong candidate names itself).
+bool verify_draw_chain(const bvr::pattern_scan::ProcessImage& image);
 
 // --- UShockUserSettings: the FOV option (session 25) ------------------------
 // Vtable RVA runtime-VERIFIED 2026-07-29: vtscan found a live heap object

--- a/src/game/bioshock2r/patterns.h
+++ b/src/game/bioshock2r/patterns.h
@@ -70,6 +70,31 @@ constexpr uint32_t kProcessEventVtblByteOffset = 0xC;
 //   UGameEngine        0x10BD7DC / 0x10BD9E8 (BS1's console_exec used the
 //   second of the pair - expect the same here, but verify before calling).
 
+// --- render-substrate discovery (session 26) --------------------------------
+// The engine's ONLY static path to kernel32!SetEvent is the event-object
+// signal ("Trigger") method below: `push [ecx+4]; call [IAT SetEvent]; ret` -
+// a 10-byte __thiscall with the HANDLE at object+4 (the same event-object
+// shape BS1 documented on its submit kick). It has ZERO static E8 callers
+// (virtual dispatch), so the submit is derived LIVE: `reentry kick2` hooks
+// this method and samples _ReturnAddress() = the engine-side call site.
+// Session-25 recon CORRECTIONS (offline capstone census, 2026-07-29 s26):
+// 0xB81020 (E9 stub 0xF01A) is SuspendThread/ResumeThread on a thread object,
+// 0xCDB917 (stub 0xD9BD) is a crit-section once-init helper, the second FF15
+// SetEvent site 0xCDB9BB is CRT encoded-pointer once-init machinery, and the
+// FF25 import jmp-thunks (SetEvent's at 0xF3E494) have zero callers - none of
+// these are render seams. Sync-primitive census + derivations in
+// docs/bioshock2/ENGINE_NOTES.md. Recorded there, comment-only here until a
+// consumer lands: ReleaseSemaphore FF15 cluster 0x5C98CE/0x5C9A1B/0x5C9B84/
+// 0x5C9DB8 (job-system shape); WFSO(INFINITE, handlePair[i<2]) helper
+// 0x7C3E40 over the global handle pair at RVA 0x1803A14 (pump-wait
+// candidate); CreateSemaphoreW ctor 0xCF3EE0 (session-25 "pump candidate"
+// label was wrong - it is a semaphore-object constructor).
+constexpr uint32_t kEventTriggerRva = 0xB81050;
+// Opcode bytes only: the FF15 operand embeds the ASLR-rebased IAT VA, so the
+// last 4 bytes of the instruction differ from the disk image at runtime.
+constexpr uint8_t kEventTriggerPrologue[] = {0xFF, 0x71, 0x04, 0xFF, 0x15};
+// push dword ptr [ecx+4]; call dword ptr [imm32]
+
 // --- UShockUserSettings: the FOV option (session 25) ------------------------
 // Vtable RVA runtime-VERIFIED 2026-07-29: vtscan found a live heap object
 // whose dword0 == base + RVA (the two other matches were stack slots holding

--- a/src/game/bioshock2r/scenedraw.cpp
+++ b/src/game/bioshock2r/scenedraw.cpp
@@ -1,0 +1,365 @@
+// BS2 render-substrate discovery instruments (session 26). The static route
+// to the frame submit is dead on this build (docs/bioshock2/ENGINE_NOTES.md:
+// the engine's ONLY static kernel32!SetEvent path is the virtually-dispatched
+// event-object Trigger method; everything else the session-25 recon flagged
+// turned out to be thread-suspend or CRT once-init machinery). So the submit
+// is found LIVE, the way BS1 originally did it: sample SetEvent callers on
+// the game thread during steady gameplay, take the per-frame-cadence one,
+// walk the sampled return RVA back to the enclosing entry offline.
+//
+// Ported shapes from bioshock1r/scenedraw.cpp (values never copied): the
+// lock-free KickSlot table, the MinHook-on-kernel32 sampler lifecycle, the
+// conservative call-preceded stack scan, prologue-gated install/disable.
+
+#include "game/bioshock2r/scenedraw.h"
+
+#include "core/hooks/d3d11_hook.h"
+#include "core/util/log.h"
+#include "game/bioshock2r/patterns.h"
+
+#include <windows.h>
+#include <MinHook.h>
+
+#include <imgui.h>
+
+#include <atomic>
+#include <cstdio>
+#include <cstring>
+#include <intrin.h>
+
+namespace bvr::b2r::scenedraw {
+namespace {
+
+const uint8_t* g_imageBase = nullptr;
+size_t g_imageSize = 0;
+
+// Reserved for the substrate hooks (commit 2+): nonzero exactly while a
+// depth-0 hooked render call is in flight on that thread. The poll-gate
+// deferral (inside_hooked_call) and the calcview in/out attribution key on
+// these from day one so the camera-side plumbing lands once.
+std::atomic<uint32_t> g_activeTid{0};
+std::atomic<int> g_activeDepth{0};
+std::atomic<uint32_t> g_calcInside{0};
+std::atomic<uint32_t> g_calcOutside{0};
+
+// One-shot CalcView stack scan request.
+std::atomic<int> g_calcstackPending{0};
+
+uint32_t to_rva(const void* p) {
+    uintptr_t d = reinterpret_cast<uintptr_t>(p) - reinterpret_cast<uintptr_t>(g_imageBase);
+    return d < g_imageSize ? static_cast<uint32_t>(d) : 0xFFFFFFFFu;
+}
+
+// --- kick samplers -----------------------------------------------------------
+// Table of distinct (tid, caller-rva) pairs with counts, dumped on "off".
+// BS2 extension over BS1's table: because the engine reaches SetEvent through
+// FF15 wrapper methods (the direct return RVA lands in the wrapper, not the
+// interesting caller), each slot deep-captures up to 3 further call-preceded
+// exe return RVAs from the sampling thread's stack - on FIRST insertion only,
+// so the steady-state cost stays two relaxed atomics per call.
+constexpr int kDeepRvas = 3;
+struct KickSlot {
+    std::atomic<uint32_t> key{0};
+    std::atomic<uint32_t> tid{0};
+    std::atomic<uint32_t> rva{0};
+    std::atomic<uint32_t> count{0};
+    std::atomic<uint32_t> deep[kDeepRvas]{};
+};
+
+// Conservative call-preceded stack scan (BS1 log_game_stack heuristic): a
+// stack dword qualifies if it points into the exe AND the bytes before it
+// decode as a plausible CALL. Collect up to `cap` hits, skipping `skipRva`
+// (the direct return RVA - already in the slot).
+int scan_stack_rvas(uint32_t skipRva, uint32_t* out, int cap) {
+    void** sp = reinterpret_cast<void**>(_AddressOfReturnAddress());
+    int found = 0;
+    for (int i = 0; i < 1024 && found < cap; ++i) {
+        if (!bvr::pattern_scan::is_memory_valid(&sp[i], sizeof(void*))) break;
+        const uint8_t* p = static_cast<const uint8_t*>(sp[i]);
+        uint32_t rva = to_rva(p);
+        if (rva == 0xFFFFFFFFu || rva == skipRva) continue;
+        if (!bvr::pattern_scan::is_memory_valid(p - 6, 6)) continue;
+        bool call = p[-5] == 0xE8 ||                                     // call rel32
+                    (p[-6] == 0xFF && p[-5] == 0x15) ||                  // call [m32]
+                    (p[-6] == 0xFF && p[-5] >= 0x90 && p[-5] <= 0x97) || // call [reg+d32]
+                    (p[-2] == 0xFF && p[-1] >= 0xD0 && p[-1] <= 0xD7) || // call reg
+                    (p[-2] == 0xFF && p[-1] >= 0x10 && p[-1] <= 0x17) || // call [reg]
+                    (p[-3] == 0xFF && p[-2] >= 0x50 && p[-2] <= 0x57);   // call [reg+d8]
+        if (!call) continue;
+        bool dup = false;
+        for (int j = 0; j < found; ++j)
+            if (out[j] == rva) dup = true;
+        if (!dup) out[found++] = rva;
+    }
+    return found;
+}
+
+// retAddr MUST be captured with _ReturnAddress() in the detour body itself -
+// taken here it would name the detour, not the hooked function's caller.
+void kick_note(KickSlot* slots, int nslots, std::atomic<bool>& gate, void* retAddr) {
+    if (!gate.load(std::memory_order_relaxed)) return;
+    uint32_t tid = GetCurrentThreadId();
+    uint32_t rva = to_rva(retAddr);
+    uint32_t key = (tid * 2654435761u) ^ rva;
+    if (key == 0) key = 1;
+    for (int i = 0; i < nslots; ++i) {
+        KickSlot& s = slots[i];
+        uint32_t k = s.key.load(std::memory_order_relaxed);
+        if (k == key) {
+            s.count.fetch_add(1, std::memory_order_relaxed);
+            return;
+        }
+        if (k == 0) {
+            if (s.key.compare_exchange_strong(k, key, std::memory_order_relaxed)) {
+                s.tid.store(tid, std::memory_order_relaxed);
+                s.rva.store(rva, std::memory_order_relaxed);
+                s.count.store(1, std::memory_order_relaxed);
+                uint32_t deep[kDeepRvas] = {};
+                int n = scan_stack_rvas(rva, deep, kDeepRvas);
+                for (int j = 0; j < n; ++j)
+                    s.deep[j].store(deep[j], std::memory_order_relaxed);
+                return;
+            }
+        }
+    }
+}
+
+void kick_report(const char* what, KickSlot* slots, int nslots) {
+    BVR_LOG("[reentry] %s sampler OFF; distinct callers:", what);
+    for (int i = 0; i < nslots; ++i) {
+        KickSlot& s = slots[i];
+        if (s.key.load(std::memory_order_relaxed) == 0) continue;
+        uint32_t rva = s.rva.load(std::memory_order_relaxed);
+        char deepBuf[64] = "";
+        size_t len = 0;
+        for (int j = 0; j < kDeepRvas; ++j) {
+            uint32_t d = s.deep[j].load(std::memory_order_relaxed);
+            if (!d || len >= sizeof deepBuf - 12) continue;
+            len += _snprintf_s(deepBuf + len, sizeof deepBuf - len, _TRUNCATE, "%s0x%X",
+                               len ? "," : " deep=", d);
+        }
+        BVR_LOG("[reentry]   tid=%u caller=%s0x%X count=%u%s",
+                s.tid.load(std::memory_order_relaxed),
+                rva == 0xFFFFFFFFu ? "(non-exe) " : "exe+", rva,
+                s.count.load(std::memory_order_relaxed), deepBuf);
+    }
+}
+
+void kick_reset(KickSlot* slots, int nslots) {
+    for (int i = 0; i < nslots; ++i) {
+        slots[i].key.store(0, std::memory_order_relaxed);
+        slots[i].count.store(0, std::memory_order_relaxed);
+        for (auto& d : slots[i].deep) d.store(0, std::memory_order_relaxed);
+    }
+}
+
+// kick: process-wide kernel32!SetEvent hook (BS1-proven safe; short windows).
+using SetEventFn = BOOL(WINAPI*)(HANDLE);
+SetEventFn g_origSetEvent = nullptr;
+void* g_setEventTarget = nullptr;
+bool g_kickCreated = false; // game thread only
+std::atomic<bool> g_kickSampling{false};
+KickSlot g_kickSlots[10];
+uint64_t g_kickOnPresents = 0; // game thread only: presents at sampler ON
+
+BOOL WINAPI SetEventDetour(HANDLE h) {
+    kick_note(g_kickSlots, 10, g_kickSampling, _ReturnAddress());
+    return g_origSetEvent(h);
+}
+
+// kick2: hook on the event-object Trigger method itself. Its _ReturnAddress()
+// is the engine-side (virtual) call site - no wrapper masking, no stack scan
+// ambiguity. __thiscall with zero stack args returning BOOL: __fastcall with
+// a dummy EDX slot is register/stack/cleanup-identical.
+using TriggerFn = uint32_t(__fastcall*)(void* self, void* edx);
+TriggerFn g_origTrigger = nullptr;
+void* g_triggerTarget = nullptr;
+bool g_trigger2Created = false; // game thread only
+std::atomic<bool> g_trigger2Enabled{false};
+std::atomic<bool> g_kick2Sampling{false};
+KickSlot g_kick2Slots[10];
+uint64_t g_kick2OnPresents = 0; // game thread only
+
+uint32_t __fastcall TriggerDetour(void* self, void* edx) {
+    kick_note(g_kick2Slots, 10, g_kick2Sampling, _ReturnAddress());
+    return g_origTrigger(self, edx);
+}
+
+void kick_sampler(bool on) {
+    if (on) {
+        if (!g_kickCreated) {
+            HMODULE k32 = GetModuleHandleW(L"kernel32.dll");
+            g_setEventTarget =
+                k32 ? reinterpret_cast<void*>(GetProcAddress(k32, "SetEvent")) : nullptr;
+            if (!g_setEventTarget) {
+                BVR_LOG("[reentry] kick: SetEvent not resolved");
+                return;
+            }
+            MH_STATUS st = MH_CreateHook(g_setEventTarget,
+                                         reinterpret_cast<void*>(&SetEventDetour),
+                                         reinterpret_cast<void**>(&g_origSetEvent));
+            if (st != MH_OK) {
+                BVR_LOG("[reentry] kick: MH_CreateHook(SetEvent) failed: %s",
+                        MH_StatusToString(st));
+                return;
+            }
+            g_kickCreated = true;
+        }
+        kick_reset(g_kickSlots, 10);
+        MH_STATUS st = MH_EnableHook(g_setEventTarget);
+        if (st != MH_OK) {
+            BVR_LOG("[reentry] kick: MH_EnableHook failed: %s", MH_StatusToString(st));
+            return;
+        }
+        g_kickOnPresents = bvr::d3d11_hook::present_count();
+        g_kickSampling.store(true, std::memory_order_relaxed);
+        BVR_LOG("[reentry] kick sampler ON (process-wide SetEvent hook)");
+    } else {
+        g_kickSampling.store(false, std::memory_order_relaxed);
+        if (g_kickCreated) MH_DisableHook(g_setEventTarget);
+        BVR_LOG("[reentry] kick window presents delta: %llu",
+                static_cast<unsigned long long>(bvr::d3d11_hook::present_count() -
+                                                g_kickOnPresents));
+        kick_report("kick", g_kickSlots, 10);
+    }
+}
+
+void kick2_sampler(bool on) {
+    if (on) {
+        if (!g_imageBase) {
+            BVR_LOG("[reentry] kick2: no image base - init failed?");
+            return;
+        }
+        if (!g_trigger2Created) {
+            g_triggerTarget = const_cast<uint8_t*>(g_imageBase) + patterns::kEventTriggerRva;
+            // Opcode-only prologue gate: the FF15 operand bytes embed the
+            // ASLR-rebased IAT VA, so only the leading opcodes are stable.
+            if (!bvr::pattern_scan::is_memory_valid(g_triggerTarget,
+                                                    sizeof patterns::kEventTriggerPrologue) ||
+                memcmp(g_triggerTarget, patterns::kEventTriggerPrologue,
+                       sizeof patterns::kEventTriggerPrologue) != 0) {
+                BVR_LOG("[reentry] kick2: Trigger prologue mismatch at %p - build "
+                        "changed? REFUSING hook",
+                        g_triggerTarget);
+                return;
+            }
+            MH_STATUS st = MH_CreateHook(g_triggerTarget,
+                                         reinterpret_cast<void*>(&TriggerDetour),
+                                         reinterpret_cast<void**>(&g_origTrigger));
+            if (st != MH_OK) {
+                BVR_LOG("[reentry] kick2: MH_CreateHook(Trigger) failed: %s",
+                        MH_StatusToString(st));
+                return;
+            }
+            g_trigger2Created = true;
+        }
+        kick_reset(g_kick2Slots, 10);
+        MH_STATUS st = MH_EnableHook(g_triggerTarget);
+        if (st != MH_OK) {
+            BVR_LOG("[reentry] kick2: MH_EnableHook failed: %s", MH_StatusToString(st));
+            return;
+        }
+        g_kick2OnPresents = bvr::d3d11_hook::present_count();
+        g_trigger2Enabled.store(true, std::memory_order_relaxed);
+        g_kick2Sampling.store(true, std::memory_order_relaxed);
+        BVR_LOG("[reentry] kick2 sampler ON (event Trigger method 0x%X hooked)",
+                patterns::kEventTriggerRva);
+    } else {
+        g_kick2Sampling.store(false, std::memory_order_relaxed);
+        if (g_trigger2Created) MH_DisableHook(g_triggerTarget);
+        g_trigger2Enabled.store(false, std::memory_order_relaxed);
+        BVR_LOG("[reentry] kick2 window presents delta: %llu",
+                static_cast<unsigned long long>(bvr::d3d11_hook::present_count() -
+                                                g_kick2OnPresents));
+        kick_report("kick2", g_kick2Slots, 10);
+    }
+}
+
+// Conservative one-shot stack scan on the game thread (from the CalcView
+// dispatch): log every stack dword that points into the exe AND is preceded
+// by a plausible CALL encoding. One log line; game thread only.
+void log_game_stack() {
+    uint32_t rvas[24] = {};
+    int found = scan_stack_rvas(0, rvas, 24);
+    char line[512];
+    int pos = 0;
+    for (int i = 0; i < found && pos < 480; ++i)
+        pos += _snprintf_s(line + pos, sizeof(line) - pos, _TRUNCATE, " %X", rvas[i]);
+    line[pos] = '\0';
+    BVR_LOG("[reentry] calcstack (game tid %u):%s", GetCurrentThreadId(), line);
+}
+
+} // namespace
+
+void init(const bvr::pattern_scan::ProcessImage& image) {
+    g_imageBase = image.base;
+    g_imageSize = image.size;
+}
+
+void handle_command(const char* args) {
+    char verb[16] = {};
+    int consumed = 0;
+    if (sscanf_s(args, "%15s%n", verb, static_cast<unsigned>(sizeof verb), &consumed) != 1) {
+        BVR_LOG("[reentry] command needs a verb: kick on|off|kick2 on|off|"
+                "calcstack|status (substrate verbs land once the RVAs are derived)");
+        return;
+    }
+    const char* rest = args + consumed;
+    while (*rest == ' ' || *rest == '\t') ++rest;
+
+    if (strcmp(verb, "kick") == 0) {
+        kick_sampler(strncmp(rest, "on", 2) == 0);
+    } else if (strcmp(verb, "kick2") == 0) {
+        kick2_sampler(strncmp(rest, "on", 2) == 0);
+    } else if (strcmp(verb, "calcstack") == 0) {
+        g_calcstackPending.store(1, std::memory_order_relaxed);
+        BVR_LOG("[reentry] calcstack armed (next CalcView dispatch logs a stack scan)");
+    } else if (strcmp(verb, "status") == 0) {
+        BVR_LOG("[reentry] status: kick=%d kick2=%d calcview in/out %u/%u "
+                "(BS2 substrate hooks not derived yet - session 26 ladder)",
+                g_kickSampling.load(std::memory_order_relaxed) ? 1 : 0,
+                g_kick2Sampling.load(std::memory_order_relaxed) ? 1 : 0,
+                g_calcInside.load(std::memory_order_relaxed),
+                g_calcOutside.load(std::memory_order_relaxed));
+    } else {
+        BVR_LOG("[reentry] unknown verb '%s' (BS2 has kick|kick2|calcstack|status; "
+                "hook/1t/stereo/vrstereo land after the substrate derivation)",
+                verb);
+    }
+}
+
+void note_calcview() {
+    uint32_t tid = GetCurrentThreadId();
+    if (g_activeTid.load(std::memory_order_relaxed) == tid)
+        g_calcInside.fetch_add(1, std::memory_order_relaxed);
+    else
+        g_calcOutside.fetch_add(1, std::memory_order_relaxed);
+    if (g_calcstackPending.load(std::memory_order_relaxed) > 0 &&
+        g_calcstackPending.exchange(0, std::memory_order_relaxed) > 0)
+        log_game_stack();
+}
+
+bool inside_hooked_call() {
+    return g_activeDepth.load(std::memory_order_relaxed) > 0 &&
+           g_activeTid.load(std::memory_order_relaxed) == GetCurrentThreadId();
+}
+
+bool hook_live() {
+    return g_trigger2Enabled.load(std::memory_order_relaxed);
+}
+
+bool stereo_active() {
+    return false; // SR lands with the substrate commits
+}
+
+void draw_debug_ui() {
+    if (!ImGui::CollapsingHeader("Reentry probe (BS2 discovery)")) return;
+    ImGui::Text("samplers: kick %s  kick2 %s  calcview in/out %u/%u",
+                g_kickSampling.load(std::memory_order_relaxed) ? "ON" : "off",
+                g_kick2Sampling.load(std::memory_order_relaxed) ? "ON" : "off",
+                g_calcInside.load(std::memory_order_relaxed),
+                g_calcOutside.load(std::memory_order_relaxed));
+    ImGui::TextDisabled("control via seam: reentry kick|kick2|calcstack|status");
+}
+
+} // namespace bvr::b2r::scenedraw

--- a/src/game/bioshock2r/scenedraw.cpp
+++ b/src/game/bioshock2r/scenedraw.cpp
@@ -15,6 +15,8 @@
 
 #include "core/hooks/d3d11_hook.h"
 #include "core/util/log.h"
+#include "core/vr/openxr_runtime.h"
+#include "game/bioshock2r/camera.h"
 #include "game/bioshock2r/patterns.h"
 
 #include <windows.h>
@@ -69,6 +71,31 @@ std::atomic<uint32_t> g_lastDrawTid{0};
 std::atomic<uint32_t> g_drawUs{0};
 std::atomic<uint32_t> g_callerRvas[4]{};
 std::atomic<int> g_dumpRemaining{0}; // stream-args dump lines left
+
+// SequentialReentry controls + telemetry (session 26). The BS2 primary bet
+// runs the double Draw on the THREADED substrate: the Draw path has no
+// submit handshake (that spin-wait belongs to the streaming manager), the
+// ring is cursor-based, and the endframe render sync runs once per tick
+// AFTER the doubled call - so a second Draw just enqueues a second scene +
+// present. 1t machinery is derived only if this proves unstable (the
+// standing "BS2 is not bound by BS1's methods" policy gate, applied).
+std::atomic<bool> g_doubleCall{false};
+std::atomic<int> g_pulseCount{0};
+std::atomic<float> g_secondYawDeg{30.0f}; // probe mode: yaw on pass 2
+std::atomic<bool> g_stereo{false};
+std::atomic<uint32_t> g_stereoSkips{0}; // pass 2 skipped (gate/stall)
+std::atomic<uint32_t> g_secondCalls{0};
+std::atomic<uint32_t> g_secondPassTid{0};
+std::atomic<uint32_t> g_secondPassHits{0};
+std::atomic<uint32_t> g_call2Us{0};
+std::atomic<uint32_t> g_foreignCallerSkips{0}; // non-gameplay-caller Draws seen armed
+std::atomic<bool> g_poisoned{false};
+std::atomic<uint32_t> g_lastExcCode{0};
+std::atomic<uint32_t> g_lastExcRva{0};
+std::atomic<int> g_vrstereoPending{-1}; // -1 none, 0 off, 1 on
+// Draw (game) thread only: present count at the previous depth-0 entry -
+// doubling is skipped while presents are stalled (unfocused window).
+uint32_t g_lastDrawPresentLow = 0;
 // Draw-head camera probe: what Draw sees in the viewport camera actor's
 // cached fields (the tick-side CalcView product = the pass-2 poke target).
 std::atomic<float> g_camSrcLoc[3]{};
@@ -77,7 +104,8 @@ std::atomic<uint32_t> g_camActorProbes{0};
 
 // Heartbeat bookkeeping - beat thread (the Draw thread) only.
 uint64_t g_lastBeatMs = 0;
-uint32_t g_beatDraws = 0, g_beatStreams = 0, g_beatCalcIn = 0, g_beatCalcOut = 0;
+uint32_t g_beatDraws = 0, g_beatStreams = 0, g_beatCalcIn = 0, g_beatCalcOut = 0,
+         g_beatSecond = 0;
 uint64_t g_beatPresents = 0;
 
 // One-shot CalcView stack scan request.
@@ -407,6 +435,98 @@ void probe_cam_actor(void* a1) {
     g_camActorProbes.fetch_add(1, std::memory_order_relaxed);
 }
 
+// SEH filter for the SECOND Draw call only (the first stays unguarded -
+// swallowing a vanilla-path crash would destroy real crash dumps). C++
+// throws and stack overflow pass through to the game's own handling.
+int reentry_filter(unsigned code, EXCEPTION_POINTERS* ep) {
+    if (code == 0xE06D7363u) return EXCEPTION_CONTINUE_SEARCH;
+    if (code == EXCEPTION_STACK_OVERFLOW) return EXCEPTION_CONTINUE_SEARCH;
+    g_lastExcCode.store(code, std::memory_order_relaxed);
+    g_lastExcRva.store(ep ? to_rva(ep->ExceptionRecord->ExceptionAddress) : 0,
+                       std::memory_order_relaxed);
+    return EXCEPTION_EXECUTE_HANDLER;
+}
+
+// No C++ objects in this frame (SEH + unwinding = C2712).
+bool call_draw_guarded(DrawFn fn, void* ecx, void* edx, void* a1, void* a2, void* a3,
+                       void* a4) {
+    __try {
+        fn(ecx, edx, a1, a2, a3, a4);
+        return true;
+    } __except (reentry_filter(GetExceptionCode(), GetExceptionInformation())) {
+        return false;
+    }
+}
+
+// The second Draw of a pair (game thread, depth 0, after the first call
+// returned). ORIGINAL args pass through unchanged - the camera enters via
+// the CalcView dispatch that re-fires inside the Draw (live-verified
+// exactly-once-per-Draw), which the ProcessEvent seam replays as the RIGHT
+// eye (second_pass_replay in camera.cpp).
+void maybe_second_draw(void* ecx, void* edx, void* a1, void* a2, void* a3, void* a4,
+                       uint32_t callerRva, uint32_t presentDelta) {
+    if (g_poisoned.load(std::memory_order_relaxed)) return;
+    bool pulse = false;
+    if (g_pulseCount.load(std::memory_order_relaxed) > 0) {
+        pulse = g_pulseCount.fetch_sub(1, std::memory_order_relaxed) > 0;
+        if (!pulse) g_pulseCount.store(0, std::memory_order_relaxed);
+    }
+    bool continuous = g_doubleCall.load(std::memory_order_relaxed) ||
+                      g_stereo.load(std::memory_order_relaxed);
+    if (!pulse && !continuous) return;
+
+    // Deny-by-default caller gate (the 1t-load-hazard lesson in BS2 form):
+    // ONLY the census-verified gameplay dispatcher may be doubled. Loaders,
+    // teardown paths, anything unknown = skip + count.
+    if (callerRva != patterns::kSceneBuildGameplayRetRva) {
+        g_foreignCallerSkips.fetch_add(1, std::memory_order_relaxed);
+        return;
+    }
+    // Scripted-camera hole: CalcView silent means the scene bypasses the
+    // camera dispatch - a doubled frame would replay a stale base.
+    if (camera::calcview_silent(400)) {
+        g_stereoSkips.fetch_add(1, std::memory_order_relaxed);
+        return;
+    }
+    // Present-stall guard: no present landed between the previous Draw and
+    // this one (unfocused window / hitching render thread) - doubling has no
+    // value and a stall is the prime wedge suspect. Pulses bypass it so the
+    // instrument stays usable for A/B while paused.
+    if (presentDelta == 0 && !pulse) {
+        g_stereoSkips.fetch_add(1, std::memory_order_relaxed);
+        return;
+    }
+
+    if (g_stereo.load(std::memory_order_relaxed)) bvr::vr::sr_push_eye(+1);
+    g_secondPassTid.store(GetCurrentThreadId(), std::memory_order_relaxed);
+    LARGE_INTEGER t0, t1, freq;
+    QueryPerformanceCounter(&t0);
+    bool ok = call_draw_guarded(reinterpret_cast<DrawFn>(g_draw.original), ecx, edx, a1,
+                                a2, a3, a4);
+    QueryPerformanceCounter(&t1);
+    QueryPerformanceFrequency(&freq);
+    g_secondPassTid.store(0, std::memory_order_relaxed);
+    g_call2Us.store(
+        static_cast<uint32_t>((t1.QuadPart - t0.QuadPart) * 1000000 / freq.QuadPart),
+        std::memory_order_relaxed);
+    if (!ok) {
+        g_poisoned.store(true, std::memory_order_relaxed);
+        g_doubleCall.store(false, std::memory_order_relaxed);
+        g_stereo.store(false, std::memory_order_relaxed);
+        BVR_LOG("[reentry] second draw FAULTED code=0x%08X rva=0x%X - POISONED "
+                "(doubling disarmed; 'reentry reset' to clear)",
+                g_lastExcCode.load(std::memory_order_relaxed),
+                g_lastExcRva.load(std::memory_order_relaxed));
+        return;
+    }
+    g_secondCalls.fetch_add(1, std::memory_order_relaxed);
+    if (pulse)
+        BVR_LOG("[reentry] pulse: second draw ok, call2=%u us, presentDelta=%u, "
+                "presents now %llu",
+                g_call2Us.load(std::memory_order_relaxed), presentDelta,
+                static_cast<unsigned long long>(bvr::d3d11_hook::present_count()));
+}
+
 void heartbeat(uint64_t now) {
     if (g_lastBeatMs == 0) {
         g_lastBeatMs = now;
@@ -414,6 +534,7 @@ void heartbeat(uint64_t now) {
         g_beatStreams = g_streamEntries.load(std::memory_order_relaxed);
         g_beatCalcIn = g_calcInside.load(std::memory_order_relaxed);
         g_beatCalcOut = g_calcOutside.load(std::memory_order_relaxed);
+        g_beatSecond = g_secondCalls.load(std::memory_order_relaxed);
         g_beatPresents = bvr::d3d11_hook::present_count();
         return;
     }
@@ -422,11 +543,13 @@ void heartbeat(uint64_t now) {
     uint32_t streams = g_streamEntries.load(std::memory_order_relaxed);
     uint32_t calcIn = g_calcInside.load(std::memory_order_relaxed);
     uint32_t calcOut = g_calcOutside.load(std::memory_order_relaxed);
+    uint32_t seconds = g_secondCalls.load(std::memory_order_relaxed);
     uint64_t presents = bvr::d3d11_hook::present_count();
-    BVR_LOG("[reentry] beat: draws/s=%u presents/s=%llu stream/s=%u calc in/out=%u/%u "
-            "drawTid=%u presentTid=%u calcTid=%u drawUs=%u camSrc=(%.1f %.1f %.1f | "
-            "%d %d %d) callers=%X,%X,%X,%X",
-            draws - g_beatDraws, static_cast<unsigned long long>(presents - g_beatPresents),
+    BVR_LOG("[reentry] beat: draws/s=%u 2nd/s=%u presents/s=%llu stream/s=%u calc "
+            "in/out=%u/%u drawTid=%u presentTid=%u calcTid=%u drawUs=%u camSrc=(%.1f "
+            "%.1f %.1f | %d %d %d) callers=%X,%X,%X,%X",
+            draws - g_beatDraws, seconds - g_beatSecond,
+            static_cast<unsigned long long>(presents - g_beatPresents),
             streams - g_beatStreams, calcIn - g_beatCalcIn, calcOut - g_beatCalcOut,
             g_lastDrawTid.load(std::memory_order_relaxed),
             bvr::d3d11_hook::last_present_tid(),
@@ -447,18 +570,29 @@ void heartbeat(uint64_t now) {
     g_beatStreams = streams;
     g_beatCalcIn = calcIn;
     g_beatCalcOut = calcOut;
+    g_beatSecond = seconds;
     g_beatPresents = presents;
 }
 
 void __fastcall DrawDetour(void* ecx, void* edx, void* a1, void* a2, void* a3, void* a4) {
     uint32_t tid = GetCurrentThreadId();
+    uint32_t callerRva = to_rva(_ReturnAddress());
     g_lastDrawTid.store(tid, std::memory_order_relaxed);
-    note_caller(to_rva(_ReturnAddress()));
+    note_caller(callerRva);
     g_drawEntries.fetch_add(1, std::memory_order_relaxed);
     int depth = g_activeDepth.fetch_add(1, std::memory_order_relaxed);
+    uint32_t presentLowAtEntry = static_cast<uint32_t>(bvr::d3d11_hook::present_count());
     if (depth == 0) {
         g_activeTid.store(tid, std::memory_order_relaxed);
         probe_cam_actor(a1);
+        // Pass-1 eye tag: this Draw's present captures as the LEFT eye. The
+        // camera side caches the driven base and applies -IPD/2 on the
+        // CalcView dispatch inside this call. A later pass-2 skip leaves a
+        // lone tag; core's tag ring self-heals at depth > 2.
+        if (g_stereo.load(std::memory_order_relaxed) &&
+            !g_poisoned.load(std::memory_order_relaxed) &&
+            callerRva == patterns::kSceneBuildGameplayRetRva)
+            bvr::vr::sr_push_eye(-1);
     }
 
     LARGE_INTEGER t0, t1, freq;
@@ -471,6 +605,12 @@ void __fastcall DrawDetour(void* ecx, void* edx, void* a1, void* a2, void* a3, v
                    std::memory_order_relaxed);
 
     if (depth == 0) {
+        // Second pass while the depth/tid latch is still held: the pass-2
+        // CalcView dispatch must attribute as inside, and the command poller
+        // must stay deferred for the whole pair.
+        maybe_second_draw(ecx, edx, a1, a2, a3, a4, callerRva,
+                          presentLowAtEntry - g_lastDrawPresentLow);
+        g_lastDrawPresentLow = presentLowAtEntry;
         g_activeTid.store(0, std::memory_order_relaxed);
         heartbeat(GetTickCount64());
     }
@@ -493,6 +633,27 @@ void __fastcall StreamViewDetour(void* ecx, void* edx, void* loc, void* rot, voi
     reinterpret_cast<StreamFn>(g_stream.original)(ecx, edx, loc, rot, a3);
 }
 
+// The one-toggle compound (game thread only, outside hooked calls). BS2
+// sequence: camera mode -> stereo. NO 1t rung - threaded-mode doubling is
+// the primary bet on this game (see the module-head note); compare BS1's
+// apply_vrstereo, which fronts a structural single-threading step.
+void apply_vrstereo(bool on) {
+    if (on) {
+        BVR_LOG("[reentry] VRSTEREO ON: sequencing camera mode -> stereo (threaded "
+                "substrate - the BS2 primary bet, no 1t)");
+        bvr::vr::set_camera_mode(true);
+        if (!g_stereo.load(std::memory_order_relaxed)) handle_command("stereo on");
+        bool ok = g_stereo.load(std::memory_order_relaxed);
+        BVR_LOG("[reentry] VRSTEREO %s (stereo=%d; sticky across loads via the "
+                "gameplay-caller gate; 'vrstereo off' reverses)",
+                ok ? "READY" : "INCOMPLETE - see refusals above", ok ? 1 : 0);
+    } else {
+        BVR_LOG("[reentry] VRSTEREO OFF: stereo -> camera mode");
+        if (g_stereo.load(std::memory_order_relaxed)) handle_command("stereo off");
+        bvr::vr::set_camera_mode(false);
+    }
+}
+
 } // namespace
 
 void init(const bvr::pattern_scan::ProcessImage& image) {
@@ -512,7 +673,65 @@ void handle_command(const char* args) {
     const char* rest = args + consumed;
     while (*rest == ' ' || *rest == '\t') ++rest;
 
-    if (strcmp(verb, "hook") == 0) {
+    if (strcmp(verb, "vrstereo") == 0) {
+        apply_vrstereo(strncmp(rest, "on", 2) == 0);
+    } else if (strcmp(verb, "stereo") == 0) {
+        if (strncmp(rest, "on", 2) == 0) {
+            if (g_poisoned.load(std::memory_order_relaxed)) {
+                BVR_LOG("[reentry] stereo refused: poisoned ('reentry reset' first)");
+                return;
+            }
+            if (!g_draw.enabled.load(std::memory_order_relaxed)) {
+                if (!patterns::verify_draw_chain(g_image)) return;
+                if (!install_slot(g_draw, patterns::kSceneBuildRva,
+                                  reinterpret_cast<void*>(&DrawDetour),
+                                  patterns::kSceneBuildPrologue,
+                                  sizeof patterns::kSceneBuildPrologue))
+                    return;
+            }
+            g_stereo.store(true, std::memory_order_relaxed);
+            BVR_LOG("[reentry] STEREO ON (threaded substrate; every gameplay draw "
+                    "doubles L/R, eye-tagged for per-present capture)");
+        } else {
+            g_stereo.store(false, std::memory_order_relaxed);
+            BVR_LOG("[reentry] stereo off");
+        }
+    } else if (strcmp(verb, "pulse") == 0) {
+        int n = 0;
+        if (sscanf_s(rest, "%d", &n) != 1 || n <= 0) n = 1;
+        if (n > 8) n = 8;
+        if (!g_draw.enabled.load(std::memory_order_relaxed)) {
+            BVR_LOG("[reentry] pulse needs the draw hook ('reentry hook' first)");
+            return;
+        }
+        g_pulseCount.store(n, std::memory_order_relaxed);
+        BVR_LOG("[reentry] pulse armed: next %d gameplay draw(s) double (yaw %.1f on "
+                "pass 2 unless stereo)",
+                n, g_secondYawDeg.load(std::memory_order_relaxed));
+    } else if (strcmp(verb, "on") == 0) {
+        if (!g_draw.enabled.load(std::memory_order_relaxed)) {
+            BVR_LOG("[reentry] 'on' needs the draw hook ('reentry hook' first)");
+            return;
+        }
+        g_doubleCall.store(true, std::memory_order_relaxed);
+        BVR_LOG("[reentry] continuous double-draw ON (yaw %.1f on pass 2)",
+                g_secondYawDeg.load(std::memory_order_relaxed));
+    } else if (strcmp(verb, "off") == 0) {
+        g_doubleCall.store(false, std::memory_order_relaxed);
+        g_pulseCount.store(0, std::memory_order_relaxed);
+        BVR_LOG("[reentry] double-draw off");
+    } else if (strcmp(verb, "yaw") == 0) {
+        float v = 0.0f;
+        if (sscanf_s(rest, "%f", &v) == 1) {
+            g_secondYawDeg.store(v, std::memory_order_relaxed);
+            BVR_LOG("[reentry] second-pass yaw = %.1f deg", v);
+        }
+    } else if (strcmp(verb, "reset") == 0) {
+        g_poisoned.store(false, std::memory_order_relaxed);
+        BVR_LOG("[reentry] poison cleared (last fault code=0x%08X rva=0x%X)",
+                g_lastExcCode.load(std::memory_order_relaxed),
+                g_lastExcRva.load(std::memory_order_relaxed));
+    } else if (strcmp(verb, "hook") == 0) {
         if (strncmp(rest, "stream", 6) == 0) {
             install_slot(g_stream, patterns::kStreamViewRva,
                          reinterpret_cast<void*>(&StreamViewDetour),
@@ -528,6 +747,9 @@ void handle_command(const char* args) {
                          sizeof patterns::kSceneBuildPrologue);
         }
     } else if (strcmp(verb, "unhook") == 0) {
+        g_doubleCall.store(false, std::memory_order_relaxed);
+        g_pulseCount.store(0, std::memory_order_relaxed);
+        g_stereo.store(false, std::memory_order_relaxed);
         disable_slot(g_draw);
         disable_slot(g_stream);
     } else if (strcmp(verb, "dump") == 0) {
@@ -547,20 +769,29 @@ void handle_command(const char* args) {
         g_calcstackPending.store(1, std::memory_order_relaxed);
         BVR_LOG("[reentry] calcstack armed (next CalcView dispatch logs a stack scan)");
     } else if (strcmp(verb, "status") == 0) {
-        BVR_LOG("[reentry] status: draw=%s stream=%s kick=%d kick2=%d calcview in/out "
-                "%u/%u draws=%u streams=%u camProbes=%u",
+        BVR_LOG("[reentry] status: draw=%s stream=%s stereo=%d double=%d pulse=%d "
+                "yaw=%.1f seconds=%u skips=%u foreign=%u 2ndHits=%u call2Us=%u "
+                "poisoned=%d kick=%d kick2=%d calcview in/out %u/%u draws=%u",
                 g_draw.enabled.load(std::memory_order_relaxed) ? "on" : "off",
                 g_stream.enabled.load(std::memory_order_relaxed) ? "on" : "off",
+                g_stereo.load(std::memory_order_relaxed) ? 1 : 0,
+                g_doubleCall.load(std::memory_order_relaxed) ? 1 : 0,
+                g_pulseCount.load(std::memory_order_relaxed),
+                g_secondYawDeg.load(std::memory_order_relaxed),
+                g_secondCalls.load(std::memory_order_relaxed),
+                g_stereoSkips.load(std::memory_order_relaxed),
+                g_foreignCallerSkips.load(std::memory_order_relaxed),
+                g_secondPassHits.load(std::memory_order_relaxed),
+                g_call2Us.load(std::memory_order_relaxed),
+                g_poisoned.load(std::memory_order_relaxed) ? 1 : 0,
                 g_kickSampling.load(std::memory_order_relaxed) ? 1 : 0,
                 g_kick2Sampling.load(std::memory_order_relaxed) ? 1 : 0,
                 g_calcInside.load(std::memory_order_relaxed),
                 g_calcOutside.load(std::memory_order_relaxed),
-                g_drawEntries.load(std::memory_order_relaxed),
-                g_streamEntries.load(std::memory_order_relaxed),
-                g_camActorProbes.load(std::memory_order_relaxed));
+                g_drawEntries.load(std::memory_order_relaxed));
     } else {
-        BVR_LOG("[reentry] unknown verb '%s' (BS2 has hook|unhook|dump|kick|kick2|"
-                "calcstack|status; 1t/stereo/vrstereo land after live verification)",
+        BVR_LOG("[reentry] unknown verb '%s' (BS2 has vrstereo|stereo|pulse|on|off|yaw|"
+                "reset|hook|unhook|dump|kick|kick2|calcstack|status)",
                 verb);
     }
 }
@@ -589,25 +820,59 @@ bool hook_live() {
 }
 
 bool stereo_active() {
-    return false; // SR lands with the substrate commits
+    return g_stereo.load(std::memory_order_relaxed) &&
+           g_draw.enabled.load(std::memory_order_relaxed) &&
+           !g_poisoned.load(std::memory_order_relaxed);
+}
+
+bool second_pass_for_current_thread(float* yawDegOut) {
+    uint32_t t = g_secondPassTid.load(std::memory_order_relaxed);
+    if (t == 0 || t != GetCurrentThreadId()) return false;
+    g_secondPassHits.fetch_add(1, std::memory_order_relaxed);
+    *yawDegOut = g_secondYawDeg.load(std::memory_order_relaxed);
+    return true;
+}
+
+void request_vrstereo(bool on) {
+    g_vrstereoPending.store(on ? 1 : 0, std::memory_order_relaxed);
+}
+
+void apply_pending_vrstereo() {
+    // Act on the EXCHANGED value, not a pre-read - a request posted between
+    // load and exchange must not be swallowed.
+    if (g_vrstereoPending.load(std::memory_order_relaxed) >= 0) {
+        int pending = g_vrstereoPending.exchange(-1, std::memory_order_relaxed);
+        if (pending >= 0) apply_vrstereo(pending == 1);
+    }
 }
 
 void draw_debug_ui() {
-    if (!ImGui::CollapsingHeader("Reentry probe (BS2 discovery)")) return;
-    ImGui::Text("hooks: draw %s  stream %s  samplers: kick %s  kick2 %s",
+    if (!ImGui::CollapsingHeader("Reentry / stereo (BS2)")) return;
+    // The one-toggle: applied on the game thread via the pending request -
+    // the overlay may be drawing on the render thread.
+    bool srOn = stereo_active();
+    bool srToggle = srOn;
+    if (ImGui::Checkbox("VR stereo (camera mode + stereo)", &srToggle) && srToggle != srOn)
+        request_vrstereo(srToggle);
+    ImGui::Text("hooks: draw %s  stream %s%s%s  samplers: kick %s  kick2 %s",
                 g_draw.enabled.load(std::memory_order_relaxed) ? "ON" : "off",
                 g_stream.enabled.load(std::memory_order_relaxed) ? "ON" : "off",
+                g_stereo.load(std::memory_order_relaxed) ? "  STEREO" : "",
+                g_poisoned.load(std::memory_order_relaxed) ? "  POISONED" : "",
                 g_kickSampling.load(std::memory_order_relaxed) ? "ON" : "off",
                 g_kick2Sampling.load(std::memory_order_relaxed) ? "ON" : "off");
-    ImGui::Text("draws %u  streams %u  calcview in/out %u/%u  drawTid %u presentTid %u",
+    ImGui::Text("draws %u  2nd %u  skips %u/%u  calc in/out %u/%u  drawTid %u "
+                "presentTid %u",
                 g_drawEntries.load(std::memory_order_relaxed),
-                g_streamEntries.load(std::memory_order_relaxed),
+                g_secondCalls.load(std::memory_order_relaxed),
+                g_stereoSkips.load(std::memory_order_relaxed),
+                g_foreignCallerSkips.load(std::memory_order_relaxed),
                 g_calcInside.load(std::memory_order_relaxed),
                 g_calcOutside.load(std::memory_order_relaxed),
                 g_lastDrawTid.load(std::memory_order_relaxed),
                 bvr::d3d11_hook::last_present_tid());
-    ImGui::TextDisabled(
-        "control via seam: reentry hook|unhook|dump|kick|kick2|calcstack|status");
+    ImGui::TextDisabled("control via seam: reentry vrstereo|stereo|pulse|on|off|yaw|"
+                        "reset|hook|unhook|dump|kick|kick2|calcstack|status");
 }
 
 } // namespace bvr::b2r::scenedraw

--- a/src/game/bioshock2r/scenedraw.cpp
+++ b/src/game/bioshock2r/scenedraw.cpp
@@ -32,15 +32,53 @@ namespace {
 
 const uint8_t* g_imageBase = nullptr;
 size_t g_imageSize = 0;
+bvr::pattern_scan::ProcessImage g_image{};
 
-// Reserved for the substrate hooks (commit 2+): nonzero exactly while a
-// depth-0 hooked render call is in flight on that thread. The poll-gate
-// deferral (inside_hooked_call) and the calcview in/out attribution key on
-// these from day one so the camera-side plumbing lands once.
+// UGameEngine::Draw is `ret 0x10` with a live ECX this (the engine object) -
+// __fastcall passthrough with a dummy EDX slot and 4 stack params is
+// register/stack/cleanup-identical (same trick as the BS1 build detour).
+using DrawFn = void(__fastcall*)(void* ecx, void* edx, void* a1, void* a2, void* a3,
+                                 void* a4);
+// FContentStreamingManager view hand-off: `ret 0xC`, live ECX this,
+// args (FVector* loc, FRotator* rot, void* obj). Telemetry hook only.
+using StreamFn = void(__fastcall*)(void* ecx, void* edx, void* loc, void* rot, void* a3);
+
+struct HookSlot {
+    const char* name = nullptr;
+    void* target = nullptr;
+    void* original = nullptr; // trampoline; cast to the slot's signature
+    bool created = false;     // game thread only
+    std::atomic<bool> enabled{false};
+};
+HookSlot g_draw{"draw"};
+HookSlot g_stream{"stream"};
+
+// Nonzero exactly while a depth-0 hooked render call is in flight on that
+// thread. The poll-gate deferral (inside_hooked_call) and the calcview
+// in/out attribution key on these.
 std::atomic<uint32_t> g_activeTid{0};
 std::atomic<int> g_activeDepth{0};
 std::atomic<uint32_t> g_calcInside{0};
 std::atomic<uint32_t> g_calcOutside{0};
+std::atomic<uint32_t> g_lastCalcTid{0};
+
+// Telemetry (detour threads write, beat/overlay read).
+std::atomic<uint32_t> g_drawEntries{0};
+std::atomic<uint32_t> g_streamEntries{0};
+std::atomic<uint32_t> g_lastDrawTid{0};
+std::atomic<uint32_t> g_drawUs{0};
+std::atomic<uint32_t> g_callerRvas[4]{};
+std::atomic<int> g_dumpRemaining{0}; // stream-args dump lines left
+// Draw-head camera probe: what Draw sees in the viewport camera actor's
+// cached fields (the tick-side CalcView product = the pass-2 poke target).
+std::atomic<float> g_camSrcLoc[3]{};
+std::atomic<int32_t> g_camSrcRot[3]{};
+std::atomic<uint32_t> g_camActorProbes{0};
+
+// Heartbeat bookkeeping - beat thread (the Draw thread) only.
+uint64_t g_lastBeatMs = 0;
+uint32_t g_beatDraws = 0, g_beatStreams = 0, g_beatCalcIn = 0, g_beatCalcOut = 0;
+uint64_t g_beatPresents = 0;
 
 // One-shot CalcView stack scan request.
 std::atomic<int> g_calcstackPending{0};
@@ -48,6 +86,17 @@ std::atomic<int> g_calcstackPending{0};
 uint32_t to_rva(const void* p) {
     uintptr_t d = reinterpret_cast<uintptr_t>(p) - reinterpret_cast<uintptr_t>(g_imageBase);
     return d < g_imageSize ? static_cast<uint32_t>(d) : 0xFFFFFFFFu;
+}
+
+void note_caller(uint32_t rva) {
+    for (auto& slot : g_callerRvas) {
+        uint32_t cur = slot.load(std::memory_order_relaxed);
+        if (cur == rva) return;
+        if (cur == 0) {
+            slot.store(rva, std::memory_order_relaxed);
+            return;
+        }
+    }
 }
 
 // --- kick samplers -----------------------------------------------------------
@@ -289,25 +338,208 @@ void log_game_stack() {
     BVR_LOG("[reentry] calcstack (game tid %u):%s", GetCurrentThreadId(), line);
 }
 
+// --- substrate hooks (commit 2: pass-through + telemetry only) ---------------
+
+bool install_slot(HookSlot& slot, uint32_t rva, void* detour, const uint8_t* prologue,
+                  size_t prologueLen) {
+    if (!g_imageBase) {
+        BVR_LOG("[reentry] no image base - init failed?");
+        return false;
+    }
+    if (slot.enabled.load(std::memory_order_relaxed)) {
+        BVR_LOG("[reentry] %s hook already enabled", slot.name);
+        return true;
+    }
+    slot.target = const_cast<uint8_t*>(g_imageBase) + rva;
+    if (!slot.created) {
+        if (!bvr::pattern_scan::is_memory_valid(slot.target, prologueLen) ||
+            memcmp(slot.target, prologue, prologueLen) != 0) {
+            BVR_LOG("[reentry] %s prologue mismatch at %p - build changed? REFUSING hook",
+                    slot.name, slot.target);
+            return false;
+        }
+        MH_STATUS st = MH_CreateHook(slot.target, detour,
+                                     reinterpret_cast<void**>(&slot.original));
+        if (st != MH_OK) {
+            BVR_LOG("[reentry] MH_CreateHook(%s) failed: %s", slot.name,
+                    MH_StatusToString(st));
+            return false;
+        }
+        slot.created = true;
+    }
+    MH_STATUS st = MH_EnableHook(slot.target); // self-enabling, never MH_ALL_HOOKS
+    if (st != MH_OK) {
+        BVR_LOG("[reentry] MH_EnableHook(%s) failed: %s", slot.name, MH_StatusToString(st));
+        return false;
+    }
+    g_lastBeatMs = 0; // reseed heartbeat bases on next beat
+    slot.enabled.store(true, std::memory_order_relaxed);
+    BVR_LOG("[reentry] %s hook ENABLED (target %p, rva 0x%X)", slot.name, slot.target, rva);
+    return true;
+}
+
+void disable_slot(HookSlot& slot) {
+    if (!slot.enabled.load(std::memory_order_relaxed)) return;
+    // Disable only - MH_RemoveHook would free the trampoline while another
+    // thread could still be returning through it.
+    MH_STATUS st = MH_DisableHook(slot.target);
+    slot.enabled.store(false, std::memory_order_relaxed);
+    BVR_LOG("[reentry] %s hook disabled (%s)", slot.name, MH_StatusToString(st));
+}
+
+// Draw-head camera probe: what the engine will render this frame, read from
+// the viewport camera actor's cached fields. Guarded - a1 can be anything
+// during teardown.
+void probe_cam_actor(void* a1) {
+    using namespace bvr::pattern_scan;
+    if (!a1 || !is_memory_valid(static_cast<uint8_t*>(a1) + patterns::kViewportCamActorOffset,
+                                sizeof(void*)))
+        return;
+    uint8_t* cam = *reinterpret_cast<uint8_t**>(static_cast<uint8_t*>(a1) +
+                                                patterns::kViewportCamActorOffset);
+    if (!cam || !is_memory_valid(cam + patterns::kCamActorLocOffset, 24)) return;
+    const float* loc = reinterpret_cast<const float*>(cam + patterns::kCamActorLocOffset);
+    const int32_t* rot = reinterpret_cast<const int32_t*>(cam + patterns::kCamActorRotOffset);
+    for (int i = 0; i < 3; ++i) {
+        g_camSrcLoc[i].store(loc[i], std::memory_order_relaxed);
+        g_camSrcRot[i].store(rot[i], std::memory_order_relaxed);
+    }
+    g_camActorProbes.fetch_add(1, std::memory_order_relaxed);
+}
+
+void heartbeat(uint64_t now) {
+    if (g_lastBeatMs == 0) {
+        g_lastBeatMs = now;
+        g_beatDraws = g_drawEntries.load(std::memory_order_relaxed);
+        g_beatStreams = g_streamEntries.load(std::memory_order_relaxed);
+        g_beatCalcIn = g_calcInside.load(std::memory_order_relaxed);
+        g_beatCalcOut = g_calcOutside.load(std::memory_order_relaxed);
+        g_beatPresents = bvr::d3d11_hook::present_count();
+        return;
+    }
+    if (now - g_lastBeatMs < 1000) return;
+    uint32_t draws = g_drawEntries.load(std::memory_order_relaxed);
+    uint32_t streams = g_streamEntries.load(std::memory_order_relaxed);
+    uint32_t calcIn = g_calcInside.load(std::memory_order_relaxed);
+    uint32_t calcOut = g_calcOutside.load(std::memory_order_relaxed);
+    uint64_t presents = bvr::d3d11_hook::present_count();
+    BVR_LOG("[reentry] beat: draws/s=%u presents/s=%llu stream/s=%u calc in/out=%u/%u "
+            "drawTid=%u presentTid=%u calcTid=%u drawUs=%u camSrc=(%.1f %.1f %.1f | "
+            "%d %d %d) callers=%X,%X,%X,%X",
+            draws - g_beatDraws, static_cast<unsigned long long>(presents - g_beatPresents),
+            streams - g_beatStreams, calcIn - g_beatCalcIn, calcOut - g_beatCalcOut,
+            g_lastDrawTid.load(std::memory_order_relaxed),
+            bvr::d3d11_hook::last_present_tid(),
+            g_lastCalcTid.load(std::memory_order_relaxed),
+            g_drawUs.load(std::memory_order_relaxed),
+            g_camSrcLoc[0].load(std::memory_order_relaxed),
+            g_camSrcLoc[1].load(std::memory_order_relaxed),
+            g_camSrcLoc[2].load(std::memory_order_relaxed),
+            g_camSrcRot[0].load(std::memory_order_relaxed),
+            g_camSrcRot[1].load(std::memory_order_relaxed),
+            g_camSrcRot[2].load(std::memory_order_relaxed),
+            g_callerRvas[0].load(std::memory_order_relaxed),
+            g_callerRvas[1].load(std::memory_order_relaxed),
+            g_callerRvas[2].load(std::memory_order_relaxed),
+            g_callerRvas[3].load(std::memory_order_relaxed));
+    g_lastBeatMs = now;
+    g_beatDraws = draws;
+    g_beatStreams = streams;
+    g_beatCalcIn = calcIn;
+    g_beatCalcOut = calcOut;
+    g_beatPresents = presents;
+}
+
+void __fastcall DrawDetour(void* ecx, void* edx, void* a1, void* a2, void* a3, void* a4) {
+    uint32_t tid = GetCurrentThreadId();
+    g_lastDrawTid.store(tid, std::memory_order_relaxed);
+    note_caller(to_rva(_ReturnAddress()));
+    g_drawEntries.fetch_add(1, std::memory_order_relaxed);
+    int depth = g_activeDepth.fetch_add(1, std::memory_order_relaxed);
+    if (depth == 0) {
+        g_activeTid.store(tid, std::memory_order_relaxed);
+        probe_cam_actor(a1);
+    }
+
+    LARGE_INTEGER t0, t1, freq;
+    QueryPerformanceCounter(&t0);
+    reinterpret_cast<DrawFn>(g_draw.original)(ecx, edx, a1, a2, a3, a4);
+    QueryPerformanceCounter(&t1);
+    QueryPerformanceFrequency(&freq);
+    g_drawUs.store(static_cast<uint32_t>((t1.QuadPart - t0.QuadPart) * 1000000 /
+                                         freq.QuadPart),
+                   std::memory_order_relaxed);
+
+    if (depth == 0) {
+        g_activeTid.store(0, std::memory_order_relaxed);
+        heartbeat(GetTickCount64());
+    }
+    g_activeDepth.fetch_sub(1, std::memory_order_relaxed);
+}
+
+void __fastcall StreamViewDetour(void* ecx, void* edx, void* loc, void* rot, void* a3) {
+    g_streamEntries.fetch_add(1, std::memory_order_relaxed);
+    if (g_dumpRemaining.load(std::memory_order_relaxed) > 0) {
+        g_dumpRemaining.fetch_sub(1, std::memory_order_relaxed);
+        const float* l = static_cast<const float*>(loc);
+        const int32_t* r = static_cast<const int32_t*>(rot);
+        bool ok = bvr::pattern_scan::is_memory_valid(loc, 12) &&
+                  bvr::pattern_scan::is_memory_valid(rot, 12);
+        if (ok)
+            BVR_LOG("[reentry] stream view: tid=%u loc=(%.1f %.1f %.1f) rot=(%d %d %d) "
+                    "obj=%p",
+                    GetCurrentThreadId(), l[0], l[1], l[2], r[0], r[1], r[2], a3);
+    }
+    reinterpret_cast<StreamFn>(g_stream.original)(ecx, edx, loc, rot, a3);
+}
+
 } // namespace
 
 void init(const bvr::pattern_scan::ProcessImage& image) {
     g_imageBase = image.base;
     g_imageSize = image.size;
+    g_image = image;
 }
 
 void handle_command(const char* args) {
     char verb[16] = {};
     int consumed = 0;
     if (sscanf_s(args, "%15s%n", verb, static_cast<unsigned>(sizeof verb), &consumed) != 1) {
-        BVR_LOG("[reentry] command needs a verb: kick on|off|kick2 on|off|"
-                "calcstack|status (substrate verbs land once the RVAs are derived)");
+        BVR_LOG("[reentry] command needs a verb: hook [draw|stream]|unhook|dump <n>|"
+                "kick on|off|kick2 on|off|calcstack|status");
         return;
     }
     const char* rest = args + consumed;
     while (*rest == ' ' || *rest == '\t') ++rest;
 
-    if (strcmp(verb, "kick") == 0) {
+    if (strcmp(verb, "hook") == 0) {
+        if (strncmp(rest, "stream", 6) == 0) {
+            install_slot(g_stream, patterns::kStreamViewRva,
+                         reinterpret_cast<void*>(&StreamViewDetour),
+                         patterns::kStreamViewPrologue,
+                         sizeof patterns::kStreamViewPrologue);
+        } else { // default: UGameEngine::Draw (the SR seam candidate)
+            // Build-identity gate first: the vtable slot chain must land on
+            // the constant (pure image reads; a wrong candidate refuses).
+            if (!patterns::verify_draw_chain(g_image)) return;
+            install_slot(g_draw, patterns::kSceneBuildRva,
+                         reinterpret_cast<void*>(&DrawDetour),
+                         patterns::kSceneBuildPrologue,
+                         sizeof patterns::kSceneBuildPrologue);
+        }
+    } else if (strcmp(verb, "unhook") == 0) {
+        disable_slot(g_draw);
+        disable_slot(g_stream);
+    } else if (strcmp(verb, "dump") == 0) {
+        int n = 0;
+        if (sscanf_s(rest, "%d", &n) != 1 || n <= 0) n = 8;
+        if (n > 32) n = 32;
+        g_dumpRemaining.store(n, std::memory_order_relaxed);
+        BVR_LOG("[reentry] dump armed: next %d stream-view calls%s", n,
+                g_stream.enabled.load(std::memory_order_relaxed)
+                    ? ""
+                    : " (stream hook is OFF - 'reentry hook stream' first)");
+    } else if (strcmp(verb, "kick") == 0) {
         kick_sampler(strncmp(rest, "on", 2) == 0);
     } else if (strcmp(verb, "kick2") == 0) {
         kick2_sampler(strncmp(rest, "on", 2) == 0);
@@ -315,21 +547,27 @@ void handle_command(const char* args) {
         g_calcstackPending.store(1, std::memory_order_relaxed);
         BVR_LOG("[reentry] calcstack armed (next CalcView dispatch logs a stack scan)");
     } else if (strcmp(verb, "status") == 0) {
-        BVR_LOG("[reentry] status: kick=%d kick2=%d calcview in/out %u/%u "
-                "(BS2 substrate hooks not derived yet - session 26 ladder)",
+        BVR_LOG("[reentry] status: draw=%s stream=%s kick=%d kick2=%d calcview in/out "
+                "%u/%u draws=%u streams=%u camProbes=%u",
+                g_draw.enabled.load(std::memory_order_relaxed) ? "on" : "off",
+                g_stream.enabled.load(std::memory_order_relaxed) ? "on" : "off",
                 g_kickSampling.load(std::memory_order_relaxed) ? 1 : 0,
                 g_kick2Sampling.load(std::memory_order_relaxed) ? 1 : 0,
                 g_calcInside.load(std::memory_order_relaxed),
-                g_calcOutside.load(std::memory_order_relaxed));
+                g_calcOutside.load(std::memory_order_relaxed),
+                g_drawEntries.load(std::memory_order_relaxed),
+                g_streamEntries.load(std::memory_order_relaxed),
+                g_camActorProbes.load(std::memory_order_relaxed));
     } else {
-        BVR_LOG("[reentry] unknown verb '%s' (BS2 has kick|kick2|calcstack|status; "
-                "hook/1t/stereo/vrstereo land after the substrate derivation)",
+        BVR_LOG("[reentry] unknown verb '%s' (BS2 has hook|unhook|dump|kick|kick2|"
+                "calcstack|status; 1t/stereo/vrstereo land after live verification)",
                 verb);
     }
 }
 
 void note_calcview() {
     uint32_t tid = GetCurrentThreadId();
+    g_lastCalcTid.store(tid, std::memory_order_relaxed);
     if (g_activeTid.load(std::memory_order_relaxed) == tid)
         g_calcInside.fetch_add(1, std::memory_order_relaxed);
     else
@@ -345,7 +583,9 @@ bool inside_hooked_call() {
 }
 
 bool hook_live() {
-    return g_trigger2Enabled.load(std::memory_order_relaxed);
+    return g_draw.enabled.load(std::memory_order_relaxed) ||
+           g_stream.enabled.load(std::memory_order_relaxed) ||
+           g_trigger2Enabled.load(std::memory_order_relaxed);
 }
 
 bool stereo_active() {
@@ -354,12 +594,20 @@ bool stereo_active() {
 
 void draw_debug_ui() {
     if (!ImGui::CollapsingHeader("Reentry probe (BS2 discovery)")) return;
-    ImGui::Text("samplers: kick %s  kick2 %s  calcview in/out %u/%u",
+    ImGui::Text("hooks: draw %s  stream %s  samplers: kick %s  kick2 %s",
+                g_draw.enabled.load(std::memory_order_relaxed) ? "ON" : "off",
+                g_stream.enabled.load(std::memory_order_relaxed) ? "ON" : "off",
                 g_kickSampling.load(std::memory_order_relaxed) ? "ON" : "off",
-                g_kick2Sampling.load(std::memory_order_relaxed) ? "ON" : "off",
+                g_kick2Sampling.load(std::memory_order_relaxed) ? "ON" : "off");
+    ImGui::Text("draws %u  streams %u  calcview in/out %u/%u  drawTid %u presentTid %u",
+                g_drawEntries.load(std::memory_order_relaxed),
+                g_streamEntries.load(std::memory_order_relaxed),
                 g_calcInside.load(std::memory_order_relaxed),
-                g_calcOutside.load(std::memory_order_relaxed));
-    ImGui::TextDisabled("control via seam: reentry kick|kick2|calcstack|status");
+                g_calcOutside.load(std::memory_order_relaxed),
+                g_lastDrawTid.load(std::memory_order_relaxed),
+                bvr::d3d11_hook::last_present_tid());
+    ImGui::TextDisabled(
+        "control via seam: reentry hook|unhook|dump|kick|kick2|calcstack|status");
 }
 
 } // namespace bvr::b2r::scenedraw

--- a/src/game/bioshock2r/scenedraw.h
+++ b/src/game/bioshock2r/scenedraw.h
@@ -1,0 +1,59 @@
+#pragma once
+// BS2 render-substrate discovery + (as the RVAs land) SequentialReentry.
+// Session 26 ladder, mirroring bioshock1r/scenedraw.h's SHAPE: instruments
+// first (this commit), pass-through hooks after the live derivation, then
+// structural 1t and the double build. NOTHING is hooked by default - every
+// instrument exists only after an explicit "reentry ..." seam command, so
+// default runs stay byte-identical to an unhooked game.
+//
+// Discovery instruments (no engine RVAs consumed except the statically
+// verified event Trigger method - patterns.h "render-substrate discovery"):
+//   reentry kick on|off    process-wide kernel32!SetEvent caller sampler.
+//                          BS2 twist vs BS1: the engine reaches SetEvent only
+//                          through tiny FF15 wrapper methods, so the direct
+//                          return RVA names the wrapper interior - each slot
+//                          therefore also DEEP-captures up to 3 further
+//                          call-preceded exe return RVAs from the sampling
+//                          thread's stack (first insertion only).
+//   reentry kick2 on|off   caller sampler hooked on the event-object Trigger
+//                          method itself (kEventTriggerRva): its return
+//                          address IS the engine-side virtual call site.
+//   reentry calcstack      one-shot game-thread stack scan at the next
+//                          CalcView dispatch.
+//   reentry status         counters + hook states.
+
+#include "core/hooks/pattern_scan.h"
+
+namespace bvr::b2r::scenedraw {
+
+// Stash the module image (base + size for RVA math). Creates no hooks.
+void init(const bvr::pattern_scan::ProcessImage& image);
+
+// The "reentry ..." grammar above. Game thread only (runs from the command
+// poller in the ProcessEvent detour).
+void handle_command(const char* args);
+
+// calcview_tail telemetry tap: attributes the dispatch as inside/outside a
+// hooked render call on this thread and services one-shot instrument
+// requests. Cheap (two relaxed atomics) - safe at BS2's dispatch rates.
+void note_calcview();
+
+// True while the current thread is executing a depth-0 hooked render call
+// (build/submit, once those hooks land). The command poller and the FOV
+// stale-restore defer while this holds: total ProcessEvent traffic is high,
+// so a deferred tick lands again within milliseconds - but a command that
+// installs/disables hooks must never run mid-build.
+bool inside_hooked_call();
+
+// True while any reentry hook is created AND enabled.
+bool hook_live();
+
+// M4 rung 2 gate: true while SequentialReentry stereo is on. The camera
+// module suppresses the AlternateEye sign while this holds (SR applies both
+// eye offsets itself). Always false until the substrate commits land.
+bool stereo_active();
+
+// Read-only telemetry section for the overlay (control is commands-only).
+void draw_debug_ui();
+
+} // namespace bvr::b2r::scenedraw

--- a/src/game/bioshock2r/scenedraw.h
+++ b/src/game/bioshock2r/scenedraw.h
@@ -48,10 +48,29 @@ bool inside_hooked_call();
 // True while any reentry hook is created AND enabled.
 bool hook_live();
 
-// M4 rung 2 gate: true while SequentialReentry stereo is on. The camera
-// module suppresses the AlternateEye sign while this holds (SR applies both
-// eye offsets itself). Always false until the substrate commits land.
+// M4 rung 2 gate: true while SequentialReentry stereo is on (draw hook live,
+// not poisoned). The camera module then renders pass 1 as the LEFT eye
+// (cache the driven camera, apply -IPD/2) and pass 2 as the RIGHT (replay
+// the cached base, +IPD/2); AlternateEye is suppressed.
 bool stereo_active();
+
+// ProcessEvent-seam head check: true when the current thread is executing
+// the SECOND (re-entry) Draw call. The camera dispatch handler must then
+// run ONLY the replay (second_pass_replay) - none of its normal body.
+bool second_pass_for_current_thread(float* yawDegOut);
+
+// One-toggle "VR stereo" request: posts the on/off intent; the game thread
+// applies camera mode + stereo outside any hooked call (the overlay checkbox
+// draws on the render thread and must never install hooks itself).
+// BS2 note: NO single-threading rung in the sequence - threaded-mode
+// doubling is the primary bet here (the Draw path has no submit handshake;
+// the endframe sync runs once per tick). 1t machinery gets derived only if
+// this proves unstable.
+void request_vrstereo(bool on);
+
+// Applies a pending request; called from the ProcessEvent poll lane, which
+// only ticks outside hooked calls. Cheap when nothing is pending.
+void apply_pending_vrstereo();
 
 // Read-only telemetry section for the overlay (control is commands-only).
 void draw_debug_ui();


### PR DESCRIPTION
## Summary

Session 26 closes the flat half of M10's last leg: BS2 SequentialReentry stereo, derived and
verified in one session - and running on the THREADED renderer, with none of BS1's
single-threading machinery (the standing "BS2 is not bound by BS1's methods" policy, applied
end to end).

- **Substrate derived fresh**: `UGameEngine::Draw` = RVA 0x4EE8D0 (engine vtable 0x10BD7DC
  slot +0x118 - the s24 RTTI candidate, now consumed; install path re-verifies the whole
  vtable-stub-body chain). Live instruments (`reentry kick` with a BS2 deep-caller extension,
  `reentry kick2` on `FEventWin::Trigger`) plus offline capstone walks; every RVA documented
  with its derivation in docs/bioshock2/ENGINE_NOTES.md, session-25 recon mislabels corrected.
- **SR flat gates all green**: pulse (presents == draws + pulses), continuous (2nd/s == draws/s,
  presents/s == 2x exact), stereo (per-eye camera delta 6.30 UU == ipd x worldScale EXACT,
  pass-2 CalcView replay 655/655), `vrstereo on` one-toggle READY, ~5 min soak clean.
- **Load safety**: pass 2 is deny-by-default on the single census-verified gameplay caller
  (0xCD5D7B) + calcview-silent + present-stall skips. Every new lever DEFAULT OFF.
- Pass-2 camera rides the ProcessEvent seam replay; the command poller + FOV stale-restore now
  defer while inside a hooked Draw (a BS2 improvement over BS1's mid-build polling).
- Core delta: one telemetry accessor (`d3d11_hook::last_present_tid()`).
- Carries closed: 0x106EE20 = plain APlayerController (RTTI); idle crash 0x4FF0FE triaged
  (transient-null viewport-window read in a focus-poll path).

## Test plan

- Flat gates measured live this session (log excerpts in docs/bioshock2/ENGINE_NOTES.md +
  STATUS.md session log); stereo-only policy respected throughout.
- In-headset depth + world-scale checklist for the user: docs/bioshock2/TESTING.md
  "In-headset stereo checklist" (world-scale calibration is unblocked for the first time).