### PR TITLE
Hang fix: retire the unfocused pace keepalive (untimed xrWaitFrame)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -613,6 +613,29 @@ runtime.
   caller gate: pass 2 doubles only Draws whose return RVA is the single census-verified
   gameplay dispatcher (0xCD5D7B) plus the calcview-silent and present-stall skips.
 
+- **2026-07-29 (session 26, HANG FIX, core - affects BOTH games): the unfocused
+  pace KEEPALIVE is retired; an unbounded `xrWaitFrame` is never worth
+  "insurance".** Field hang, found minutes after the BS2 stereo acceptance: the
+  user took the headset off, the session dropped FOCUSED -> VISIBLE, and the game
+  wedged solid (0.11 s CPU over 4 s, 1 running thread, `Not Responding`, kill
+  required) with NO crash, NO dump and NO fault line - the log simply stopped one
+  line after `xr: pace keepalive while VISIBLE`. Mechanism: the M8 stall guard
+  skipped the blocking wait while unfocused BUT let one real paced frame through
+  every 5 s as insurance, and `g_nextKeepaliveMs` starts at 0, so the FIRST
+  unfocused present ran `xrWaitFrame` - which takes no timeout and, with the
+  headset idle, never returned. On BS2 that call sits on the dedicated present
+  thread, so it back-pressured the game thread through the render command ring
+  and froze everything. The keepalive is now gone: once FOCUSED has been held,
+  unfocused presents ALWAYS skip the wait. Recovery never depended on it -
+  `pump_events` runs every present above the guard and the return to FOCUSED is a
+  session event, not something an app earns by submitting frames. Worst case
+  without it is "stays unfocused" (visible, recoverable, `vrpace off` restores the
+  old behavior for A/B); worst case with it was a wedged process. Paired with a
+  belt-and-braces guard: `on_present_begin` now closes any leaked open XR frame
+  before waiting, since waiting on a begun-but-never-ended frame is the other way
+  a runtime can block forever (the SR pair-hold is the only intended open-frame
+  state, and it returns long before that point).
+
 - **2026-07-29 (session 26, M10): BS2 pass-2 camera enters via the ProcessEvent seam
   replay, and commands can never execute mid-Draw.** The doubled Draw re-dispatches
   PlayerCalcView exactly once (live: 2nd-pass hits == second calls, 655/655), so the

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -588,7 +588,7 @@ kill. Both prerequisites below are now MET.):**
 - [x] `src/game/bioshock2r/` adapter: new patterns.cpp; expectation is near-total core reuse
       (landed session 24 - patterns + camera + adapter; the CalcView seam is ProcessEvent-based
       because BS2 inlined the event dispatch, see docs/bioshock2/ENGINE_NOTES.md)
-- [~] **Done when:** M3-level (6DOF mono) within one session of scan work; M4-level stereo within
+- [x] **Done when:** M3-level (6DOF mono) within one session of scan work; M4-level stereo within
       the milestone. Every core/adapter seam leak found → ARCHITECTURE decision log.
       (M3-level: session 24, one session as budgeted - flat 6DOF integer-exact, in-headset
       PASSED (fisheye/world-drag = the expected FOV-claim gap); seam-leak inventory in the
@@ -597,17 +597,22 @@ kill. Both prerequisites below are now MET.):**
       check killed the entire BS1 fg-porting question (viewmodel follows the world FOV
       natively), and the in-headset acceptance PASSED same day: fisheye gone, world-drag
       gone, restore edges exercised.
-      M4-level stereo: session 26, FLAT-COMPLETE - substrate derived in one session
+      M4-level stereo: session 26, COMPLETE and IN-HEADSET ACCEPTED (user, same day:
+      "looks awesome - very good for everything"; world scale fine at the default 100).
+      One deferred blemish the user volunteered: the viewmodel/hands read weird in
+      stereo, same class as BS1's - parked to its own milestone (leads in STATUS next
+      steps). Derivation: substrate derived in one session
       (UGameEngine::Draw 0x4EE8D0 via the live kick/kick2 samplers + offline capstone
       walks), and the policy gate paid out its biggest win yet: SequentialReentry runs
       on the THREADED substrate - no 1t, no flush-point, no drain guard, none of BS1's
       single-threading machinery ports. Pulse/continuous/stereo all flat-green:
       presents/s == 2 x draws/s exact, per-eye camera delta IPD-exact (6.30 UU), 2nd-pass
       CalcView replay 655/655, zero faults; `vrstereo on` one-toggle READY; every lever
-      default OFF; pass 2 deny-by-default on the single gameplay caller. Still open for
-      the milestone tick: the IN-HEADSET depth verdict (checklist in
-      docs/bioshock2/TESTING.md - depth reads, eye swap, comfort, world-scale
-      calibration now unblocked) and a user-driven load-crossing pass.)
+      default OFF; pass 2 deny-by-default on the single gameplay caller.
+      M10 is DONE: both acceptance clauses met (M3-level in one session of scan work,
+      M4-level stereo within the milestone, in-headset verified). Carried forward, not
+      blocking: the stereo viewmodel blemish, a user-driven load-crossing pass, and a
+      combat-scene perf profile.)
 
 ## Post-v1 backlog (not scheduled)
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,7 +2,27 @@
 
 > Handoff file. Rewrite "Current state" and "Next steps" every session; append to the session log.
 
-## Current state (2026-07-29, session 26 - M10: BS2 STEREO FLAT-COMPLETE on the THREADED substrate - no 1t needed, presents == 2x draws exact, per-eye delta IPD-exact, vrstereo one-toggle READY - branch s26-m10-bs2-stereo)
+## Current state (2026-07-29, session 26 - M10 STEREO ACCEPTED IN-HEADSET ("looks awesome"), plus a core HANG FIX found right after - branch s26-pace-hang-fix)
+
+**IN-HEADSET VERDICT (user, Quest 3 / VDXR): stereo ACCEPTED - "looks awesome, very good
+for everything".** Depth, comfort and scale all read right; the user did not need to move
+the world-scale slider off the default 100. One known-deferred blemish, volunteered by the
+user: **the viewmodel/hand models look weird and a bit wrong in stereo, same as BS1 did** -
+explicitly parked for a later milestone (see next steps; the likely mechanism is noted
+there and it is NOT the FOV apparatus, which s25 already cleared).
+
+**THEN THE HANG.** Minutes after the acceptance run the user reported the game not
+responding. Triage: NOT a crash - no dump, no fault, no poison. Process wedged at 0.11 s CPU
+over 4 s with one running thread, log stopped dead one line after `xr: pace keepalive while
+VISIBLE`. Root cause is CORE, affects both games, and predates the stereo work: the M8
+unfocused-pace guard let one real paced frame through every 5 s as "insurance", and
+`xrWaitFrame` takes no timeout - with the headset idle it never returned. On BS2 that call
+runs on the dedicated present thread, so it back-pressured the game thread through the
+render command ring and froze the process. **Fixed** (branch s26-pace-hang-fix): the
+keepalive is retired - once FOCUSED has been held, unfocused presents always skip the
+blocking wait; recovery was always event-driven (`pump_events` runs above the guard). Plus
+a belt-and-braces close of any leaked open XR frame before waiting. Built and installed to
+BOTH games; needs the user's headset-off/on re-test to confirm.
 
 **BS2 SequentialReentry is flat-green, and the headline is what it does NOT need: none of
 BS1's single-threading machinery.** The substrate was derived in one session (live
@@ -75,17 +95,32 @@ in case long soaks ever disprove this.
 
 ## Next steps
 
-1. **User in-headset run** (checklist: docs/bioshock2/TESTING.md "In-headset stereo
-   checklist"): depth verdict (L/R fused, not swapped), head-motion comfort (pair
-   pacing ships ON), THE WORLD-SCALE CALIBRATION (unblocked at last), IPD slider
-   verify, pause/load edges. Plus the load-crossing pass (quit-to-menu, CONTINUE) -
-   the menu needs a human driver on BS2.
-2. If the user reports instability under stereo: the 1t fallback derivation entry
+1. **Re-test the hang fix** (user, both games): put the headset on, get FOCUSED, then
+   take it off / let it idle for a minute, then put it back on. Expect one
+   `xr: pacing SKIPPED while VISIBLE` line, the flat window to keep running, and
+   `xr: FOCUSED again after N ms` on return - and NO freeze. Also worth one
+   Alt-Tab-away-and-back cycle.
+2. **BS2 viewmodel/hands in stereo** (the user's one reported blemish, "same as BS1").
+   Bounded diagnostic FIRST, do not assume the BS1 rig: BS2's foreground almost
+   certainly renders from a camera the SR pass-2 replay never touches (the Draw-head
+   probe already shows the cached camera-actor fields at viewport+0x48 hold a
+   DIFFERENT, static value than the live CalcView camera - `camSrc` in the beat line
+   never moved while the real camera did). If the fg scene node takes its view from
+   that path, both eyes get one camera and the weapon reads at the wrong depth -
+   which is exactly what "weird and a bit wrong" looks like. BS1's answer was the fg
+   scene-node ctor hook + per-eye camera substitution (`vrfgnode sync`); check
+   whether BS2 needs the same before porting any of it.
+3. **BS2 input / motion controllers** - the real playability unlock (M5-equivalent).
+   Core's synthetic-XInput lane is game-agnostic, but BS1 also needed an engine-side
+   drive (`input_drive.cpp`, UWindowsViewport::UpdateInput) because nothing calls it
+   in windowed mode; whether BS2 needs the same is unprobed.
+4. If stereo ever proves unstable under long play: the 1t fallback derivation entry
    points are banked in ENGINE_NOTES (render sync pair 0x1A69294/98, endframe fn
    0x501EA0, reader 0xB929F2).
-3. BS2 combat-scene stereo perf profile (needs a combat save).
-4. Record the BS2 FOV slider min/max endpoints when someone is in Graphics Options.
-5. BS1 carries: v0.4.1 to the external tester, 2K-account lead, seated recenter
+5. BS2 combat-scene stereo perf profile (needs a combat save); BS2 load-crossing pass
+   with stereo armed (the menu needs a human driver).
+6. Record the BS2 FOV slider min/max endpoints when someone is in Graphics Options.
+7. BS1 carries: v0.4.1 to the external tester, 2K-account lead, seated recenter
    designs, letterbox investigation.
 
 ## Previous state (2026-07-29, session 25 - M10: BS2 FOV DONE flat - readback claim == rendered, forced-headset-FOV write default OFF, discovery tooling ported, crash-dump loop fixed - branch s25-m10-bs2-fov)
@@ -2663,6 +2698,20 @@ dir unchanged). Carries closed: 0x106EE20 = plain APlayerController (RTTI); the
 path (rare idle race, dump cap already ships). Handoff: the in-headset depth +
 world-scale checklist is in docs/bioshock2/TESTING.md - world-scale tuning is
 unblocked for the first time.
+
+**Same evening - the in-headset verdict and a hang.** User ran the checklist and accepted
+stereo outright ("looks awesome, very good for everything"), world scale fine at the
+default 100, with one deferred blemish: the viewmodel/hand models look weird in stereo,
+same class as BS1's. Minutes later the game stopped responding. Triage found NO crash (no
+dump, no fault, no poison) - a hard wedge at 0 CPU, log ending one line after
+`xr: pace keepalive while VISIBLE`. The M8 unfocused-pace guard's 5 s "insurance" keepalive
+ran a blocking `xrWaitFrame` (no timeout) with the headset idle and never returned; on BS2
+that sits on the dedicated present thread and back-pressured the game thread through the
+render ring. Core fix on branch s26-pace-hang-fix: keepalive retired (unfocused presents
+always skip the wait; recovery was always event-driven via pump_events), plus a
+belt-and-braces close of any leaked open XR frame before waiting. Installed to both games,
+awaiting the user's headset-off/on re-test. Lesson worth keeping: a shipped "insurance"
+path that calls an untimed blocking API is a hang waiting for the right day.
 
 ### Session 25 - 2026-07-29 - BS2 FOV: readback + write landed flat, fg apparatus proven unnecessary
 

--- a/src/core/vr/openxr_runtime.cpp
+++ b/src/core/vr/openxr_runtime.cpp
@@ -221,18 +221,31 @@ std::atomic<bool> g_loggedFirstPair{false};
 // has been FOCUSED, losing FOCUSED switches pacing to SKIP: presents stop
 // calling the blocking wait entirely and the game runs free, while
 // pump_events keeps running every present so the return to FOCUSED is acted
-// on immediately. A low-cadence keepalive still runs one real paced frame in
-// case the runtime wants to see frames before re-granting FOCUSED -
-// event-driven recovery is the primary path, the keepalive is insurance.
+// on immediately.
 // The guard NEVER engages before the first FOCUSED: during bring-up
 // (SYNCHRONIZED -> VISIBLE -> FOCUSED) the runtime needs submitted frames to
 // advance its own state machine, so a naive "skip whenever not FOCUSED"
 // would deadlock session start.
-constexpr uint64_t kPaceKeepaliveMs = 5000;
+//
+// Session 26 - THE LOW-CADENCE KEEPALIVE IS GONE, and removing it is a HANG
+// FIX, not a tuning change. It used to let one real paced frame through every
+// 5 s while unfocused, as insurance in case a runtime wanted to see frames
+// before re-granting FOCUSED. But xrWaitFrame takes no timeout, so that one
+// frame is an UNBOUNDED block, and it bit in the field (2026-07-29, BS2 in
+// stereo, VDXR): the session dropped to VISIBLE with the headset idle, the
+// FIRST keepalive fired immediately (g_nextKeepaliveMs started at 0) and
+// never returned - the render thread stalled inside Present, back-pressured
+// the game thread through the command ring, and the process wedged at 0 CPU
+// with 'Not Responding' (kill required, no crash, no dump). Recovery never
+// depended on the keepalive: pump_events runs every present ABOVE this guard
+// and the return to FOCUSED arrives as a session EVENT, not something the app
+// earns by submitting frames. Worst case without it is "stays unfocused",
+// which is visible, recoverable and infinitely better than a wedged game.
+// `vrpace off` still restores the old always-pace behavior for A/B.
 std::atomic<bool> g_paceGuard{true};      // A/B knob (`vrpace off` = old behavior)
 std::atomic<bool> g_everFocused{false};   // written on the present thread
-uint64_t g_nextKeepaliveMs = 0;           // present thread only
-std::atomic<uint32_t> g_paceSkips{0}, g_paceKeepalives{0};
+uint64_t g_unfocusedSinceMs = 0;          // present thread only; 0 = not skipping
+std::atomic<uint32_t> g_paceSkips{0};
 std::atomic<uint32_t> g_lastWaitMs{0}; // last xrWaitFrame block, telemetry
 std::atomic<bool> g_simIdle{false};    // flat stand-in (`vrpace simidle on`)
 
@@ -307,13 +320,14 @@ bool pace_should_skip(XrSessionState state, bool everFocused, uint64_t now) {
     if (!g_paceGuard.load(std::memory_order_relaxed)) return false;
     if (state == XR_SESSION_STATE_FOCUSED) return false;
     if (!everFocused) return false; // bring-up: frames are how we REACH focused
-    if (now >= g_nextKeepaliveMs) {
-        g_nextKeepaliveMs = now + kPaceKeepaliveMs;
-        g_paceKeepalives.fetch_add(1, std::memory_order_relaxed);
-        BVR_LOG("xr: pace keepalive while %s (one paced frame so the runtime can "
-                "re-grant FOCUSED; skips so far %u)",
-                state_str(state), g_paceSkips.load(std::memory_order_relaxed));
-        return false;
+    // Unfocused after having held FOCUSED: skip the blocking wait ALWAYS (see
+    // the keepalive post-mortem above). One line per unfocused episode.
+    if (g_unfocusedSinceMs == 0) {
+        g_unfocusedSinceMs = now;
+        BVR_LOG("xr: pacing SKIPPED while %s (headset idle) - the game keeps "
+                "running; recovery is event-driven, no paced frame is issued "
+                "until the runtime re-grants FOCUSED",
+                state_str(state));
     }
     g_paceSkips.fetch_add(1, std::memory_order_relaxed);
     return true;
@@ -520,7 +534,7 @@ void teardown_session(const char* why) {
     g_system = XR_NULL_SYSTEM_ID;
     g_state = XR_SESSION_STATE_UNKNOWN;
     g_everFocused = false;
-    g_nextKeepaliveMs = 0;
+    g_unfocusedSinceMs = 0;
     g_framesSubmitted = 0;
     g_nextRetryMs = GetTickCount64() + 5000; // cooldown before the next attempt
 }
@@ -770,14 +784,14 @@ void pump_events() {
                     break;
                 }
                 case XR_SESSION_STATE_FOCUSED:
-                    if (g_everFocused &&
-                        g_paceSkips.load(std::memory_order_relaxed) > 0)
-                        BVR_LOG("xr: FOCUSED again - full pacing resumes (guard "
-                                "skipped %u presents, %u keepalives)",
-                                g_paceSkips.load(std::memory_order_relaxed),
-                                g_paceKeepalives.load(std::memory_order_relaxed));
+                    if (g_everFocused && g_unfocusedSinceMs != 0)
+                        BVR_LOG("xr: FOCUSED again after %llu ms unfocused - full "
+                                "pacing resumes (guard skipped %u presents)",
+                                static_cast<unsigned long long>(GetTickCount64() -
+                                                                g_unfocusedSinceMs),
+                                g_paceSkips.load(std::memory_order_relaxed));
                     g_everFocused = true;
-                    g_nextKeepaliveMs = 0;
+                    g_unfocusedSinceMs = 0;
                     break;
                 case XR_SESSION_STATE_STOPPING:
                     if (g_sessionBegun) {
@@ -897,6 +911,21 @@ void on_present_begin(IDXGISwapChain* swapchain) {
             g_projectionReady.store(false, std::memory_order_relaxed);
             return;
         }
+    }
+
+    // Belt and braces (session 26): never wait with an XR frame still begun.
+    // The pair-hold is the ONLY intended open-frame state and it returns far
+    // above this point, so reaching here with g_frameOpen set means a frame
+    // leaked - and waiting on a leaked frame is the other way a runtime can
+    // block forever. Close it and take the dropped frame instead.
+    if (g_frameOpen) {
+        XrFrameEndInfo leaked{XR_TYPE_FRAME_END_INFO};
+        leaked.displayTime = g_frameState.predictedDisplayTime;
+        leaked.environmentBlendMode = XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
+        xrEndFrame(g_session, &leaked);
+        g_frameOpen = false;
+        g_srPairOpen = false;
+        BVR_LOG("xr: closed a leaked open frame before waiting (pair aborted?)");
     }
 
     XrFrameWaitInfo fwi{XR_TYPE_FRAME_WAIT_INFO};
@@ -1809,8 +1838,7 @@ void draw_debug_ui() {
                            "projection NOT ready - drive is held off (see log)");
     uint32_t paceSkips = g_paceSkips.load(std::memory_order_relaxed);
     if (paceSkips)
-        ImGui::Text("pace guard: skipped %u waits, %u keepalives, last wait %u ms",
-                    paceSkips, g_paceKeepalives.load(std::memory_order_relaxed),
+        ImGui::Text("pace guard: skipped %u waits, last wait %u ms", paceSkips,
                     g_lastWaitMs.load(std::memory_order_relaxed));
     uint32_t mirrorBlits = g_mirrorBlits.load(std::memory_order_relaxed);
     if (mirrorBlits)
@@ -1936,12 +1964,12 @@ void handle_pace_command(const char* args) {
                    : "");
     } else {
         BVR_LOG("xr: pace guard %s | session %s everFocused=%d | skips %u "
-                "keepalives %u lastWait %u ms | simidle %s "
+                "lastWait %u ms | simidle %s (keepalive retired session 26 - it "
+                "was an unbounded xrWaitFrame block) "
                 "(vrpace on|off|simidle on|off|status)",
                 g_paceGuard.load(std::memory_order_relaxed) ? "ON" : "off",
                 state_str(g_state), g_everFocused.load(std::memory_order_relaxed) ? 1 : 0,
                 g_paceSkips.load(std::memory_order_relaxed),
-                g_paceKeepalives.load(std::memory_order_relaxed),
                 g_lastWaitMs.load(std::memory_order_relaxed),
                 g_simIdle.load(std::memory_order_relaxed) ? "ON" : "off");
     }


### PR DESCRIPTION
## The hang

Found minutes after the BS2 stereo in-headset acceptance. User took the headset off, the
session dropped FOCUSED -> VISIBLE, and the game wedged solid: **no crash, no dump, no fault
line** - 0.11 s CPU over 4 s, one running thread, `Not Responding`, kill required. The log
stops dead one line after `xr: pace keepalive while VISIBLE`.

**Root cause (core, affects BOTH games, predates the stereo work):** the M8 unfocused-pace
guard skipped the blocking wait while unfocused *but* let one real paced frame through every
5 s as insurance - and `g_nextKeepaliveMs` starts at 0, so the very first unfocused present
ran `xrWaitFrame`. That call takes no timeout and, with the headset idle, never returned. On
BS2 it sits on the dedicated present thread, so it back-pressured the game thread through the
render command ring and froze the whole process.

## The fix

- **Keepalive retired.** Once FOCUSED has been held, unfocused presents always skip the
  blocking wait. Recovery never depended on it: `pump_events` runs every present *above* the
  guard, and the return to FOCUSED is a session event, not something an app earns by
  submitting frames. Worst case now is "stays unfocused" (visible, recoverable); worst case
  before was a wedged process. `vrpace off` still restores the old behavior for A/B.
- **Belt and braces:** `on_present_begin` closes any leaked open XR frame before waiting -
  waiting on a begun-but-never-ended frame is the other way a runtime can block forever. The
  SR pair-hold is the only intended open-frame state and it returns long before that point.
- One line per unfocused episode instead of a keepalive every 5 s; the FOCUSED-again line now
  reports how long it was unfocused.

## Test plan

Installed to both games. Re-test: get FOCUSED, take the headset off for a minute, put it back
on. Expect `xr: pacing SKIPPED while VISIBLE`, the flat window still running, then
`xr: FOCUSED again after N ms` - and no freeze.