### PR TITLE
Sessions 27-28: BS1 stability, the resolution lane, and the two-lens defect behind the yaw warp

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,17 @@ BioShock Remastered is required. Free and open source, forever.
   technique on this exact game; this project ports and extends those techniques.
 - [praydog/REFramework](https://github.com/praydog/REFramework) (MIT) - reference implementation
   for OpenXR/D3D11 VR integration in a closed-source engine.
+- **[BioVRDev/Bioshock-Remastered-VR](https://github.com/BioVRDev/Bioshock-Remastered-VR)** - a
+  parallel native VR mod for the same game, and a genuinely friendly one. The two projects have
+  swapped findings in both directions: their README credits this one for the
+  reticle-via-console-Exec technique, the arm bone indices and the render-target HUD capture,
+  and their author has given explicit permission to reuse their code and concepts here. Ideas
+  taken from them so far: rendering at a near-square resolution matched to the headset panel
+  instead of widening the game's FOV, the "report the game's own symmetric FOV to the
+  compositor, never the headset's canted one" invariant, per-feature build guarding that logs
+  and stands down instead of trusting an address, and the startup config echo block. Files that
+  adapt their code carry an attribution comment naming the source. Worth a look, and worth
+  trying if this mod does not suit your setup.
 - Third-party libraries: see [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
 
 ## License

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -650,3 +650,48 @@ runtime.
   milliseconds later given ProcessEvent traffic), and the overlay's vrstereo checkbox
   posts a request that the same outside-hooked-calls lane applies (also the only lane
   that works at BS2's menu, which never runs PlayerCalcView).
+
+- **2026-07-30 (session 28): a measured value must carry the identity of WHAT it
+  measured, not just its freshness.** The yaw warp was a live instrument reporting the
+  foreground lens as the world lens. The value was fresh, structurally valid, correctly
+  decoded, and labelled `src=live` at the point of use - and it was 1.84x wrong because
+  it came from the wrong pass. Two habits caused it and both are now rules. (a) A
+  cross-check must discriminate the thing that can actually be confused. The decode
+  verified `2tanH` against `-tanH` and `-2tanV` against `tanV` - intra-axis, so it proved
+  each triple self-consistent and carried zero information about which lens or axis it
+  belonged to. The three structural zero slots that DO disambiguate were in the offline
+  decoder from day one and never ported. (b) A single sample is an assumption about
+  homogeneity. The frame is not homogeneous: it holds two lenses that agree only at
+  16:9, so "the first decodable draw" silently encoded "whichever pass draws first".
+  Sampling is now strided across the whole pass and voted, with the runner-up published
+  as a named second lens - the ambiguity is a reported quantity instead of an invisible
+  coin flip - and a round that lacks a clear majority or that failed to span its pass is
+  REFUSED rather than published, on the principle that holding a stale value the age gate
+  will expire beats publishing a confident wrong one. Corollary for consumers: a source
+  tag (`src=live`) says where a number came from, never that it is right, and the
+  session-27 elimination of the FOV hypothesis rested on exactly that confusion.
+
+- **2026-07-30 (session 28): an instrument that cannot fail its own hypothesis is not
+  evidence.** `fovaudit pose on` was built to check that the submitted layer pose matches
+  the pose the frame was rendered from, and it compares `projViews[0].pose.orientation`
+  against `g_consumedHeadQuat` - both stamped from the same `xrLocateViews` generation.
+  `delta 0.00 deg` through real head sweeps was therefore guaranteed by construction, and
+  it was written up as having eliminated the pose hypothesis. Rule: before trusting a null
+  result, name the two sources and check they are independent. Where the render-side truth
+  already exists (here: `g_eyeCamRot[eye]`, the rotator the drive actually wrote, stashed
+  per eye per tick), the audit must compare against THAT.
+
+- **2026-07-30 (session 28): a bounded promise must be enforced with a deadline, and a
+  latch must never sit above the event pump.** The SR pair-hold leaves an XR frame open
+  across two presents on the promise that the sibling present arrives within one build
+  (~1-4 ms measured). Its early return sat ABOVE `pump_events()`, so for as long as the
+  promise went unkept nothing polled XR events: session state froze, every guard below
+  became unreachable, and the only escape left in the whole function was the VR-disable
+  teardown. Alt-tab stops presenting mid-pair, so the promise went unkept indefinitely.
+  Two structural rules now: state that gates an early return is refreshed BEFORE that
+  return, and any "the next call will finish this" state carries a timestamp and a
+  force-abort path (500 ms here, ~125x the measured need). Also: recovery diagnostics must
+  not be gated on the same variables the failure corrupts - `pacing SKIPPED` required
+  `g_unfocusedSinceMs == 0` and `FOCUSED again` required it non-zero AND `g_everFocused`,
+  which STOPPING cleared, so after one stop the log went silent in both directions and a
+  stuck user's log read as "nothing happened".

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -695,3 +695,34 @@ runtime.
   `g_unfocusedSinceMs == 0` and `FOCUSED again` required it non-zero AND `g_everFocused`,
   which STOPPING cleared, so after one stop the log went silent in both directions and a
   stuck user's log read as "nothing happened".
+
+- **2026-07-30 (session 28): the pair-hold rules above stand, but the pair-hold was NOT
+  the alt-tab cause - and shipping it as one is the lesson.** The entry above reasoned from
+  code structure to a plausible mechanism and fixed it. The instrument shipped alongside it
+  then measured the real thing: `SUBMISSION IDLE (reason=pace guard: session not FOCUSED |
+  state=VISIBLE everFocused=1 pairOpen=0 ...)` repeating with no FOCUSED line until the VR
+  toggle. `pairOpen=0` on every line - the hold was never set. The structural fixes remain
+  correct and worth having; the attribution was wrong, and it was wrong for the same reason
+  the FOV hypothesis was wrong two commits earlier: a mechanism that explains the symptom is
+  not evidence that it caused it. Rule: when a fix is derived from reading code rather than
+  from a measurement, say so in the commit and ship the instrument that can refute it in the
+  same build. That is what made the third attempt at this bug class the one that worked.
+
+- **2026-07-30 (session 28): a guard must key on the hazard it exists to avoid, not on a
+  proxy for it - and an unbounded call belongs off the thread that must not block.** The M8
+  pace guard existed to dodge a blocking `xrWaitFrame`, but it keyed on SESSION STATE: any
+  present while not FOCUSED submitted nothing. Measured cost: 5772 presents skipped with
+  ZERO `xrWaitFrame blocked` lines in the whole session - not one slow wait to justify any of
+  it. Worse, it was self-sustaining: VDXR will not re-grant FOCUSED to an app that submits
+  nothing, so the guard's own effect kept its own precondition true. A circular wait, and the
+  reason the alt-tab freeze was permanent while flat rendering continued. It also falsifies
+  the session-26 note that recovery "is not something an app earns by submitting frames" - on
+  this runtime it is earned. The fix is structural rather than a better predicate:
+  `xrWaitFrame` takes no timeout and never can, so it now runs on a dedicated pace thread and
+  the present thread waits on the result with a deadline (200 ms FOCUSED so the headset still
+  paces the game, 20 ms otherwise). An unbounded block can no longer reach the thread the
+  game depends on, which retires the session-26 hang class permanently instead of trading it
+  for the freeze. Consequence to respect: a session must never be destroyed while that thread
+  is inside `xrWaitFrame` on it, so `teardown_session` defers and retries rather than handing
+  the runtime a freed handle - "stays up but idle" is an acceptable worst case, a
+  use-after-free is not.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -388,6 +388,26 @@ controller, like a native VR game. Explicitly NOT wanted: bent arms, elbows, IK,
 
 ## M8 - Release quick phase + HUD usability (~1–2 sessions)
 
+> **Session 28 (2026-07-30) closed both of session 27's open bugs, in-headset accepted.**
+> - [x] **Yaw warping on head turn at non-16:9 resolutions (RELEASE BLOCKER)** - the live
+>       rendered-FOV watch was reporting the FOREGROUND lens as the world lens (a frame carries
+>       two lenses with opposite aspect conventions that coincide only at 16:9), so the mismatch
+>       verdict latched during normal gameplay and the projection claim was substituted with the
+>       viewmodel frustum - a 1.84x under-claim. The watch now stride-samples across the whole
+>       pass and votes. Measured, not inferred: ENGINE_NOTES "Session 28".
+> - [x] **Viewmodel/hands moving with the head at non-16:9** - the SAME defect from the other
+>       side: one claim cannot serve two different lenses, so fixing the world moved the error
+>       onto the hands. The fg match constant is now `(4/3)*(h/w)` instead of a hardcoded `0.75`
+>       (which is that expression at 16:9), and `bones.cpp`'s world and fg lens models read the
+>       live aspect. Accepted in-headset with NO re-tune of the session-16 offsets.
+> - [x] **VR freezes permanently after alt-tab (RELEASE BLOCKER)** - a circular wait: the M8
+>       pace guard submitted nothing while unfocused, and VDXR will not re-grant FOCUSED to an
+>       app that submits nothing. `xrWaitFrame` moved to a dedicated pace thread with a deadline
+>       on the present thread, which also retires the session-26 hang class instead of trading it
+>       for this freeze. Third attempt at this bug class, first one built on a measurement.
+> - [x] Lens math verified DYNAMIC across resolutions (k=1.333333 at 2048x2048, exactly
+>       0.750000 at 1920x1080), so 16:9 is bit-identical to prior releases by construction.
+
 > **Restructured 2026-07-27 (session 16 part 4, user's call):** the selection wheels moved
 > to post-v1 (the current switching UI is good enough); in their place, a QUICK RELEASE
 > phase right after session 17, then HUD usability.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -158,6 +158,70 @@ in case long soaks ever disprove this.
 
 ## Next steps
 
+### OPEN BUG 1: VR freezes permanently after alt-tab (user-reported, session 27)
+
+Alt-tab out of the game and the headset image freezes; the game keeps rendering flat
+normally. Recovery requires toggling the VR enable off and back on. So Present keeps
+running but XR submission stops and never resumes.
+
+Prime suspect: `pace_should_skip` (openxr_runtime.cpp), from the M8 unfocused-pace guard as
+hardened by `22ed1b0` - once `everFocused` latches, unfocused presents ALWAYS skip the
+blocking `xrWaitFrame`, which returns early from `on_present_begin`, so nothing is submitted.
+That part is deliberate and is what fixed the session-26 hard hang. The bug is that it never
+RESUMES. Check in order:
+
+1. What actually changes on a Windows alt-tab: does the XR session leave FOCUSED, or does it
+   stay FOCUSED while only the Win32 window loses focus? `pump_events` runs above the guard,
+   so state should update either way - confirm against the session-state log lines.
+2. Whether anything the guard latches (`g_unfocusedSinceMs`, `g_everFocused`) fails to clear
+   on return, or whether the guard consults Windows focus rather than XR state.
+3. Whether a leaked open frame (`g_frameOpen` / `g_srPairOpen`) survives the skip: there is a
+   leaked-frame close before the wait, but the pair-hold returns EARLIER than that.
+4. Why the VR off/on toggle recovers. That path tears the session down, so diffing what it
+   clears against what the resume path clears should name the stuck variable outright.
+
+Also note the engine pauses CalcView while the window is unfocused (the harness scripts
+depend on this), so the game thread may stop driving the camera - check whether that starves
+something the submit path needs.
+
+### OPEN BUG 2: yaw warping on head turn at non-16:9 resolutions
+
+Reported in-headset at 2048x2048. Turning the head makes the world warp; pitch is reportedly
+clean. **Independent of the FOV slider** - sweeping the whole range changed only the visible
+angular extent, never the distortion. That property is the most valuable constraint we have.
+
+**What has been ruled out, and what is merely unproven:**
+
+- The FOV formula was changed three times this session and reverted all three times. The
+  cause was NOT the engine changing behaviour but the rendered-FOV watch being untrustworthy:
+  at the same option and the same aspect it reported values differing by exactly 9/16 (1:1 at
+  option 130 gave both 2.1445 and 1.2063; 1:1 at option 100 gave both 1.1918 and 0.6704).
+  9/16 is the 16:9 vertical factor, so the watch is sometimes decoding the VERTICAL tangent
+  into its horizontal slot. **Fix the instrument before touching projection math again**: the
+  cb0 layout has a built-in cross-check (`2tanH, 0, -tanH` against `-2tanV, tanV`) that should
+  make the two unambiguous and is evidently not being enforced. Several samples were also
+  accepted despite printing `age>9000ms`, i.e. stale by the rule the same line prints.
+- BioVRDev use the ORIGINAL formula (`halfV = atan(tan(halfH)*h/w)`) at a near-square
+  2750x2850 and report no warping. That is strong evidence the formula shape was never the
+  bug, and it should have been treated as a red flag against each derived "law" rather than as
+  an anomaly.
+- A stereo A/B was attempted and is CONFOUNDED: the overlay toggle is labelled
+  "1t + camera mode + stereo" and disables the head-driven camera too. With the head not
+  driving the camera, the compositor reprojects an unchanging image as you turn, which looks
+  exactly like warping. Stereo is therefore neither confirmed nor eliminated. A clean test
+  needs stereo off with camera mode still ON.
+
+**Strongest remaining hypothesis: the submitted POSE, not the submitted FOV.** A projection
+layer is submitted with both a pose and an fov; if the pose handed to the compositor does not
+match the pose the frame was actually rendered from, the compositor reprojects incorrectly and
+the world swims as the head turns - and that error is completely independent of the FOV value,
+which is exactly the observed signature. Look at `projViews[eye].pose` versus the pose the
+camera drive used for that frame, including staleness across the pair-hold.
+
+Secondary: the claim's source was observed as `src=live`, meaning it latched a measured
+tangent instead of deriving from the option, and was still reporting the option-130 value
+after the slider moved to 100. Stale regardless of which formula is correct.
+
 **Session 27 stage plan** (branch `s27-b1r-stability-and-resolution`; stage 1 done):
 
 1. **In-headset re-test of stage 1** (user, BS1). This is the release gate for a stability

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,7 +2,90 @@
 
 > Handoff file. Rewrite "Current state" and "Next steps" every session; append to the session log.
 
-## Current state (2026-07-30, session 27 - BS1 STABILITY: the object scanner was the freeze, and probably the crash - branch s27-b1r-stability-and-resolution)
+## Current state (2026-07-30, session 28 - OPEN BUG 2 ROOT-CAUSED AND FIXED: there are TWO lenses and the watch was reading the wrong one - branch s27-b1r-stability-and-resolution)
+
+**The yaw warp is not a pose bug, not a formula bug, and not a stereo bug. The instrument was
+reading the viewmodel's lens and the projection claim was following it.** Full derivation with
+every number in `docs/bioshock1/ENGINE_NOTES.md` "Session 28".
+
+**The mechanism, end to end.** A BS1R frame carries TWO perspective lenses that use OPPOSITE
+aspect conventions: the world pass is `tanH = tan(option/2)` with `tanV = tanH*(h/w)`, the
+foreground pass is `tanV = tan(fgFov/2)*3/4` with `tanH = tanV*(w/h)`. **They coincide exactly at
+16:9 and diverge by `(16/9)*(h/w)` everywhere else** - 1.78x at 1:1, 1.84x at 2750x2850. The live
+fov watch took the FIRST decodable draw of each interval, and the foreground draws are the first
+draws of the main pass on a 576-byte tier that cleared its 320-byte gate, carrying the same
+screen-ray block at the same floats. So off 16:9 the watch reported the VIEWMODEL lens as the
+rendered world lens. That made `fov_mismatch()` latch permanently ON during normal gameplay,
+which routed the projection claim through the `fovMm && stereoCine` branch and tagged the layer
+with the viewmodel frustum: `tanH 0.6468` over a world rendering `tanH 1.1918`. **A 1.84x
+under-claim, so the compositor mis-reprojects every head rotation by `atan(k*tan(d)) - d` -
+several degrees at ordinary turn rates, snapping back when the head stops.**
+
+That explains every constraint at once, including the two that made it look unexplainable:
+FOV-slider independence (`k` has no option term), the 16:9 cleanliness (the lenses coincide
+there), and **BioVRDev not warping at the same resolution** (they submit the option-derived claim
+and have no mismatch detector - and under the measured law their claim is simply correct).
+
+**Two session-27 eliminations were honest measurements that could not have caught it**, and both
+are corrected in ENGINE_NOTES: `src=live` was read as proof the claim tracked the render (the
+label was true, the lens was wrong - a source tag is not a correctness proof), and the pose audit
+compares `projViews[0].pose` against `g_consumedHeadQuat`, which is stamped from the SAME locate
+generation the tag comes from, so `delta 0.00 deg` was guaranteed by construction. **That audit
+cannot eliminate the pose hypothesis** - it only proves the locate-to-tag plumbing is intact.
+
+**Killed by measurement, no headset time needed:**
+
+- **Head roll survives to the render.** `simhead 0 0 40` + `reentry dump`: the engine's own render
+  submit gets `rot=(0,28303,7281)=(0.0,155.5,40.0)deg` and the screenshot shows the world rolled
+  40 deg. BS1R does NOT need BioVRDev's render-thread roll re-write.
+- **Both SR eyes render from a bit-identical rotation**, `rot=(0,28303,0)` on both passes, with
+  locations 6.36 UU apart laterally (== ipd 63.4 mm at worldScale 100) and `dz` going 0 -> 4.1 UU
+  when roll is applied. The per-eye camera rig is correct.
+- The world-lens law is the ORIGINAL assumption. The session-27 un-retraction was wrong (it
+  confirmed the fg lens three times); reverting all three formula rewrites was right.
+
+**What shipped (flat-verified at 2048x2048, the resolution the bug was reported at):**
+
+- `hud_capture.cpp` votes instead of guessing: up to 8 cb0 heads per interval at a **stride**
+  derived from the previous interval's distinct-buffer count so the sample spans the whole pass
+  (first-8 sampling gave the viewmodel 5/8 votes - measured), clustered, majority wins, runner-up
+  published as the fg lens. Structural zero-slot validation ported from the offline decoder.
+  Majority + coverage guards refuse a marginal round rather than publish it.
+- The age gate moved INTO `fov_watch()` (default 500 ms); every line says `FRESH` or
+  `STALE - DO NOT CONCLUDE` in words; `fovaudit` reports both lenses, the vote split, the stride
+  and the live aspect on one line plus a `laws` line - no conclusion needs two lines again.
+- `fovaudit`'s option-derived column no longer falls back to a hardcoded 9/16 with no session.
+- The claim substitution logs itself once, with the reason.
+- **Alt-tab freeze (OPEN BUG 1): the ordering bug is fixed.** `pump_events()` now runs ABOVE the
+  pair-hold early return - it used to return first, so while a hold was set no XR events were
+  polled at all, `g_state` could never update, and nothing below could re-arm; alt-tab stops the
+  game presenting mid-pair, so a LEFT-tagged hold survived the whole unfocused window with no
+  sibling coming, and the ONLY path that cleared it was the `!g_enabled` teardown - which is
+  exactly why the VR toggle was the sole recovery. The hold is now aged (500 ms, ~125x the
+  measured 1-4 ms build time) and force-aborts through the existing leaked-frame close; a leaked
+  frame is closed before the pace guard can return; `g_unfocusedSinceMs` clears on STOPPING and
+  `g_paceSkips` is per-episode (both suppressed the only two log lines that would have told a
+  stuck user anything); and a 5 s `xr: SUBMISSION IDLE (reason=...)` heartbeat now names the exact
+  guard that is firing.
+- `vrstereo stereoonly on|off` + an overlay checkbox: drops ONLY the doubling and leaves 1t and
+  the head drive alone. Verified flat (`2nd=153/s -> 0/s -> 163/s`, `1t=1` throughout). The
+  one-toggle keeps its exact behaviour and label. Every previous "is it stereo?" A/B was
+  confounded because the one-toggle also kills the head drive.
+- `Bioshock.ini` restored to 2048x2048 via `vrres`, relaunch-verified.
+
+**Stage 2 measurement (b) is answered as a by-product, and it condemns a shipped constant.** The
+foreground match writes `fg = 2*atan(tan(worldHalf)*0.75)`; matching the world needs
+`(4/3)*(h/w)`, which is `0.75` **only at 16:9**. So the shipped constant under-lenses the
+viewmodel by `1.7778/aspect` - 1.78x at the square backbuffer the README recommends. That is the
+"hands look huge" report, quantified, and the fix reduces to `0.75` at 16:9 so it cannot
+invalidate the session-16 calibration. **Deliberately NOT shipped yet**: it changes viewmodel
+scale visibly and must not confound the warp re-test.
+
+**Also flagged:** VR PRESET 1's 129.5/130 FOV write was derived under the WRONG law
+(`tan(option/2)*9/16*a = tan(H/2)`). Under the real world law, option 100 at a square backbuffer
+renders exactly 100x100 deg, so 130 over-widens by 30 deg. A stage-2 policy fix, not a bug.
+
+## Previous state (2026-07-30, session 27 - BS1 STABILITY: the object scanner was the freeze, and probably the crash - branch s27-b1r-stability-and-resolution)
 
 **Stage 1 of four is in and flat-verified on the real game.** The work is driven by a third
 crash report from the same external machine (v0.4.1, `0xC0000374` STATUS_HEAP_CORRUPTION at
@@ -158,7 +241,52 @@ in case long soaks ever disprove this.
 
 ## Next steps
 
-### OPEN BUG 1: VR freezes permanently after alt-tab (user-reported, session 27)
+### THE ONE THING BLOCKING EVERYTHING: in-headset re-test of the session-28 build
+
+The warp fix and the alt-tab fix are both flat-verified but neither symptom is flat-observable.
+One run answers both. Checklist (user drives; report back from the log):
+
+1. Launch, VR PRESET 1, get to gameplay at **2048x2048** (the ini is already set).
+2. Turn your head left/right deliberately, fast and slow. **Expected: no warping.**
+3. Pitch sweeps, then head-TILT sweeps (roll has never been tried in-headset; the horizon should
+   stay level - flat says roll reaches the render, so this should already be right).
+4. If any warping remains: untick **"...stereo doubling ONLY (A/B - keeps the head drive)"** in
+   the overlay. That is the un-confounded stereo A/B, new this session. If the warp survives with
+   doubling off, it is not the stereo path at all.
+5. **Alt-tab away for ~10 s, then back.** Expected: the headset image resumes on its own. In the
+   log expect `xr: FOCUSED again after N ms`, or - if it still freezes - one
+   `xr: SUBMISSION IDLE (reason=...)` line every 5 s naming the exact guard, which pins it
+   outright.
+6. Log gates for me afterwards: `mismatch=0` in `fovaudit`, no `[hud] rendered-fov mismatch ON`
+   line, `lenses=2` with the WORLD tangent equal to `tan(option/2)`, and the submit line reading
+   `src=readback` (NOT `src=live`).
+7. Optional short control leg at **1920x1080** - yaw sweeps only - to confirm 16:9 was always
+   clean for the reason now understood rather than by luck.
+
+Then: land the foreground `0.75 -> (4/3)*(h/w)` fix (measured, held back so it cannot confound
+this run), and the VR PRESET FOV policy correction.
+
+### OPEN BUG 1 (FIXED session 28, needs the headset confirm): VR freezes permanently after alt-tab (user-reported, session 27)
+
+> **Session 28: root-caused and fixed - `pace_should_skip` was NOT the culprit.** The real defect
+> was ordering: `if (g_srPairOpen) return;` sat ABOVE `pump_events()`, so while an SR pair-hold was
+> set no XR events were polled, `g_state` could never update, and no guard below could re-arm.
+> Alt-tab stops the game presenting mid-pair, so a LEFT-tagged hold survived the whole unfocused
+> window with no sibling coming - and the only path above it that cleared anything was the
+> `!g_enabled` teardown, which is exactly why the VR toggle was the sole recovery (STATUS's own
+> check 4 predicted the diff would "name the stuck variable outright", and it did). Fixed by
+> moving the pump above the hold, aging the hold (500 ms) so a stale one force-aborts through the
+> existing leaked-frame close, closing a leaked frame before the pace guard can return, clearing
+> `g_unfocusedSinceMs` on STOPPING, making `g_paceSkips` per-episode, and adding the
+> `xr: SUBMISSION IDLE (reason=...)` heartbeat. Note for the record: nothing in `src/` reads Win32
+> focus (zero matches for `GetForegroundWindow`/`WM_ACTIVATE`/`GetFocus`), so an alt-tab reaches
+> the guard only if the runtime itself drops FOCUSED. Still open, not fixed blind:
+> `xrWaitSwapchainImage` uses `XR_INFINITE_DURATION` - the last unbounded block on the present
+> thread.
+
+Original write-up kept below for the record.
+
+
 
 Alt-tab out of the game and the headset image freezes; the game keeps rendering flat
 normally. Recovery requires toggling the VR enable off and back on. So Present keeps
@@ -184,7 +312,24 @@ Also note the engine pauses CalcView while the window is unfocused (the harness 
 depend on this), so the game thread may stop driving the camera - check whether that starves
 something the submit path needs.
 
-### OPEN BUG 2: yaw warping on head turn at non-16:9 resolutions
+### OPEN BUG 2 (ROOT-CAUSED AND FIXED session 28, needs the headset confirm): yaw warping on head turn at non-16:9 resolutions
+
+> **Session 28: the frame carries TWO lenses and the watch was reading the viewmodel's.** World
+> pass is `tanH = tan(option/2)`, `tanV = tanH*(h/w)`; foreground pass is
+> `tanV = tan(fgFov/2)*3/4`, `tanH = tanV*(w/h)`. Identical at 16:9, `(16/9)*(h/w)` apart
+> elsewhere. The watch took the first decodable draw and the fg draws come first, so off 16:9
+> `fov_mismatch()` latched ON in normal gameplay and the claim was substituted with the viewmodel
+> frustum - a 1.84x under-claim, which is the warp. Fixed by stride-sampled majority voting plus
+> the structural validation the offline decoder always had. See the "Current state" block above
+> and ENGINE_NOTES "Session 28" for every number.
+>
+> Corrections to the analysis below, both important: the FOV hypothesis was eliminated on the
+> strength of `src=live` (true label, wrong lens - a source tag is not a correctness proof), and
+> **the pose audit is structurally incapable of detecting a render-vs-submit mismatch** because
+> both sides come from the same locate generation, so "pose latching is NOT the cause" over-claims.
+> Roll and per-eye render orientation ARE now genuinely eliminated, by dump measurement.
+
+Original write-up kept below for the record.
 
 Reported in-headset at 2048x2048. Turning the head makes the world warp; pitch is reportedly
 clean. **Independent of the FOV slider** - sweeping the whole range changed only the visible
@@ -2867,6 +3012,79 @@ and it resumes.
   (install.ps1 backs theirs up automatically).
 
 ## Session log (newest first)
+
+### Session 28 - 2026-07-30 - the yaw warp: TWO lenses, and the instrument was reading the wrong one
+
+Priority was "pinpoint before fixing", with three formula rewrites reverted last session off a
+bad instrument as the reason. So: no projection math was touched until the cause was measured.
+
+Started by re-reading the session-27 log rather than the code, and got four eliminations from it
+directly - no `[hud] letterbox` line anywhere (so the head drive was never suspended), no
+`xr: cinematic quad ON` (so `cinematic_active()` never latched and the per-eye offset was never
+suppressed), `g_lbUnsqueeze` default off (the capture is a plain full-rect copy), and the XR
+swapchain equal to the backbuffer (so no image/fov aspect mismatch). That left the claim and the
+pose, and the two things the session-27 write-up said were eliminated.
+
+**Roll first, because it was the one BioVRDev fixed and we had not.** No headset needed:
+`SubmitDetour` already logs the loc/rot the engine's own render submit receives, behind
+`reentry dump`. `simhead 0 0 40` -> `rot=(0,28303,7281)=(0.0,155.5,40.0)deg` and the screenshot
+shows the world rolled 40 deg. Roll survives; BS1R does not need the render-thread re-write. The
+same dump also proved both SR passes submit a bit-identical rotation with a 6.36 UU lateral
+offset (== ipd 63.4 at worldScale 100) that gains a 4.1 UU `dz` under roll - the per-eye rig is
+correct, which retires the session-27 "next and most specific" suspect too.
+
+**Then the decisive one, via the trustworthy path instead of the suspect one.**
+`dumpframe full 2` + `tools/decode-framedump.ps1` - the offline decoder, which has always applied
+the structural zero-slot validation the live watch does not - found **TWO tangent clusters in one
+frame** at 2750x2850: `1.1918/1.2351` on 154 draws and `0.6468/0.6704` on 24 draws, 20 of them on
+the 576-byte foreground tier. A `vrfgfov off` A/B identified them outright: only the second
+cluster moved, landing on `0.4330127`, the native fg vertical already hardcoded in `patterns.h`.
+Repeating at option 130 gave `2.1445/2.2225` for the world - `tan(65)` exactly. So the world lens
+is horizontal-anchored (the ORIGINAL assumption, and BioVRDev's), the foreground lens is
+vertical-anchored, they coincide only at 16:9, and the session-27 "law B" was the fg lens
+confirmed three times.
+
+**The bug then falls out.** The watch sampled the FIRST decodable draw; the fg draws are the first
+draws of the pass on a tier that clears its size gate, carrying the same block at the same floats,
+and the two cross-checks the decode ran are intra-axis so they carry no lens information. Off
+16:9 that makes `fov_mismatch()` latch ON in normal gameplay, which routes the claim through the
+`fovMm && stereoCine` branch and tags the projection layer with the viewmodel frustum - a 1.842x
+under-claim at 2750x2850. Every constraint in the report follows: slider-independent (`k` has no
+option term), clean at 16:9 (the lenses coincide), yaw-dominant, and BioVRDev not warping at the
+same resolution because their un-substituted option-derived claim is simply correct. The
+session-27 `src=live` reading was a true label around the wrong lens.
+
+Also recorded, because it cost a session: **the pose audit cannot detect what it was built to
+detect.** It diffs `projViews[0].pose` against `g_consumedHeadQuat`, and both come from the same
+`xrLocateViews` generation, so `delta 0.00 deg` was guaranteed by construction.
+
+**Shipped:** the watch now stride-samples up to 8 cb0 heads per interval (a first-8 sample gave
+the viewmodel 5/8 votes - measured, and the reason the first cut of the fix still failed),
+clusters them, and publishes the majority as the world lens with the runner-up as the fg lens,
+behind the offline decoder's structural checks plus majority and coverage guards that refuse a
+marginal round. The age gate moved into `fov_watch()` and every line now says FRESH or
+STALE-DO-NOT-CONCLUDE in words. `fovaudit` reports both lenses, the vote split, the stride and
+the live aspect on one line, plus a `laws` line. Flat gate at 2048x2048:
+`WORLD tanH=1.191754 (6/8 votes) | FG 0.670361 | lenses=2 mismatch=0`, both 15 ms FRESH,
+`ambiguous rounds 1` (the coverage guard catching the menu->gameplay transient), and no
+`rendered-fov mismatch ON` line anywhere - where session 27 had one within seconds.
+
+**Alt-tab (OPEN BUG 1) turned out to be an ordering bug, not the pace guard.**
+`if (g_srPairOpen) return;` sat above `pump_events()`, so a pair-hold blindfolded the event pump
+entirely: `g_state` frozen, nothing below able to re-arm, and the `!g_enabled` teardown the only
+escape - which is precisely why the VR toggle was the only recovery. Pump moved above the hold,
+hold aged at 500 ms with a force-abort through the existing leaked-frame close, leaked frames
+closed before the pace guard can return, `g_unfocusedSinceMs` cleared on STOPPING and
+`g_paceSkips` made per-episode (those two gates had silenced the only two lines that would have
+explained anything), plus a 5 s `SUBMISSION IDLE (reason=...)` heartbeat naming the firing guard.
+
+**Plus:** `vrstereo stereoonly on|off` and an overlay checkbox that drop only the doubling and
+leave 1t and the head drive alone - the A/B that was confounded every previous time, verified
+flat. `Bioshock.ini` restored to 2048x2048. And stage 2's blocked fg measurement fell out of the
+same dumps: matching the world needs `(4/3)*(h/w)`, so the shipped `0.75` under-lenses the
+viewmodel by `1.7778/aspect` - 1.78x at the square backbuffer the README recommends, which is the
+"hands look huge" report quantified. Deliberately held back so it cannot confound the warp
+re-test.
 
 ### Session 26 - 2026-07-29 - BS2 stereo: substrate derived and SR flat-green on the THREADED renderer, no 1t
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,7 +2,70 @@
 
 > Handoff file. Rewrite "Current state" and "Next steps" every session; append to the session log.
 
-## Current state (2026-07-29, session 26 - M10 STEREO ACCEPTED IN-HEADSET ("looks awesome"), plus a core HANG FIX found right after - branch s26-pace-hang-fix)
+## Current state (2026-07-30, session 27 - BS1 STABILITY: the object scanner was the freeze, and probably the crash - branch s27-b1r-stability-and-resolution)
+
+**Stage 1 of four is in and flat-verified on the real game.** The work is driven by a third
+crash report from the same external machine (v0.4.1, `0xC0000374` STATUS_HEAP_CORRUPTION at
+the MAIN MENU 85 s in, whole stack in ntdll) plus widespread freeze reports. Full forensics
+in `docs/bioshock1/ENGINE_NOTES.md` "Session 27".
+
+**What was wrong.** `patterns::scan_for_vtable_object` swept the whole 4 GB address space at
+a 4-byte stride, in one blocking call on the game thread, accepting any
+`MEM_PRIVATE | PAGE_READWRITE` region - which is also the signature of a thread stack. Three
+consequences, all in that log: stacks were swept and the sweep matched its OWN argument
+spill (the two "vtable match" lines sit 0x40 below the crashing thread's esp); a candidate
+that passed only two predicates then reached three unguarded writes, so a freed or
+stack-resident address could be poked every frame; and one pass measured over 3 s of blocked
+game thread, which is the freeze. The session-22 dormancy "fix" did not hold because it was
+a caller-local counter that any momentary success zeroed, and because `aim.cpp`'s gameplay
+predicate deliberately counts the menu attract scene as gameplay, so full walks ran at the
+main menu - the exact window that tester dies in.
+
+**What shipped, measured on a boot-to-gameplay run:**
+
+- New `core/hooks/heap_scan` - thread stacks/TEBs excluded exactly via TEB stack bounds
+  (plus a guard-page probe), the needle only ever compared XOR-masked, a live-heap-block
+  fast path, and the region walk kept only as a 4 ms sliced fallback.
+  **`UShockUserSettings` now resolves in 56-62 ms with exactly one match** (was 3+ s and
+  three matches, two of them our own stack). Engine ACTORS are not in a heap-block prefix
+  and still need the sweep: its ~3.8 s of work now spreads over 888 slices and **the camera
+  heartbeat holds 1600-2100 calls/s across all of it with no dip.**
+- UObject class-chain corroboration on every candidate and revalidation, the FOV window
+  narrowed to the engine UI's 75-130, a structural dormancy latch only an explicit re-arm
+  clears, the weapon scan gated on the strict gameplay view, and fail-closed on ambiguity.
+- **Host build fingerprint gate.** Every storefront ships the same `BioshockHD.exe`, so an
+  Epic/GOG/repatched build was accepted and then mis-addressed. Verified BOTH directions:
+  correct build logs "host build VERIFIED"; a deliberately wrong expected timestamp prints
+  the running-vs-expected numbers, refuses object scans once, keeps the pattern-derived
+  CalcView hook (build-independent), and the game boots to gameplay fully playable.
+- Engine-exec seam hardened: per-slot stub thunks that record being entered, an esp
+  comparison across the call that repairs and latches the seam off on imbalance, and the
+  re-assert moved off its 15 s timer to the gameplay transition plus a 5 min net
+  (8 exec calls per boot -> 4).
+- `crash::install()` first, and the swapchain hooks before the OpenXR instance, so a runtime
+  that blocks on its streamer can no longer cost us the Present detour and with it
+  `crash::rearm()`.
+- Real-size `ResizeBuffers` now QUEUES the XR swapchain rebuild for a point in the frame
+  loop with no XR frame open, closing the documented-open half of the session-23
+  `0xDEDEDEDE` VDXR use-after-free.
+- `XR_ERROR_RUNTIME_UNAVAILABLE` now explains itself: SteamVR has never shipped a 32-bit
+  OpenXR runtime, so Index/Vive/Steam Link users land there every time.
+
+**Two negative results that change the plan.** `SETRES` through the viewport Exec seam
+FAULTS (`exe+0x4C2353`, near-null, no `ResizeBuffers` follows) even though `set ...` through
+the same machinery works every run and the stack stays balanced - that seam has advertised
+`SETRES` support since it was derived and had never been called. So a live in-session
+resolution change is off the table until root-caused, and the game-ini lane becomes the
+PRIMARY mechanism. And the world-lens aspect law is still unmeasured: at 1920x1080
+`tanV/tanH = 9/16` exactly, but 9/16 IS the render aspect there, so this run cannot
+distinguish "derived from aspect" from "hardcoded". The foreground-lens aspect fix is
+therefore unproven and must not ship yet.
+
+**Also fixed:** `-Game` was positional on `game-cmd.ps1`, so every bare
+`game-cmd.ps1 "..."` failed validation and `boot.ps1`'s menu-press loop had been silently
+doing nothing since the BS2 harness commit.
+
+## Previous state (2026-07-29, session 26 - M10 STEREO ACCEPTED IN-HEADSET ("looks awesome"), plus a core HANG FIX found right after - branch s26-pace-hang-fix)
 
 **IN-HEADSET VERDICT (user, Quest 3 / VDXR): stereo ACCEPTED - "looks awesome, very good
 for everything".** Depth, comfort and scale all read right; the user did not need to move
@@ -94,6 +157,57 @@ in case long soaks ever disprove this.
   their checklist).
 
 ## Next steps
+
+**Session 27 stage plan** (branch `s27-b1r-stability-and-resolution`; stage 1 done):
+
+1. **In-headset re-test of stage 1** (user, BS1). This is the release gate for a stability
+   hotfix. Checklist: launch, VR PRESET 1, play a few minutes across a level load. Expect
+   `host build VERIFIED`, one `UShockUserSettings scan via heap` line in tens of ms, a
+   1.000 s camera heartbeat metronome with no gaps, exactly 4 `engine exec` lines per boot,
+   and no `IMBALANCE` / `exec fault` / `crash:` lines. Also: change the game's video
+   resolution once mid-session and confirm `XR swapchain rebuild QUEUED` followed by
+   `performing the queued XR swapchain rebuild` and a clean recovery - that path only
+   matters with a live session, so it cannot be verified flat.
+2. **Stage 2, resolution / FOV / apparent scale.** Blocked on two measurements before any
+   code: (a) the world-lens aspect law, which needs a non-16:9 backbuffer and therefore the
+   ini lane plus a relaunch; (b) the FOREGROUND-lens aspect law, decoded from the fg draws'
+   cb0 block at a non-16:9 resolution. (b) decides between two contradictory fixes: if the
+   fg vertical half-tangent stays `tan(F/2)*3/4` and the horizontal follows the live aspect,
+   then `camera.cpp:1202`'s hardcoded `0.75` is `(4/3)/(16/9)` and is wrong everywhere else,
+   magnifying the viewmodel by `1.7778/aspect` (1.78x at a square backbuffer, which is what
+   the README currently tells users to run) - and fixing it restores the session-16
+   in-headset calibration rather than invalidating it. If instead the fg is
+   aspect-independent, `0.75` is always right and "hands are huge" is something else. Do NOT
+   ship the lens change before that dump. Then: derive the target from
+   `xrEnumerateViewConfigurationViews` (never called today), write the game ini's four
+   viewport keys plus the FOV locks with read-back verification, add `vrres` and overlay
+   presets, and keep the 129.5 circumscribing claim as the 16:9 safety net.
+   Extra hazards to close before any live resize lane: device-identity and hwnd-identity
+   checks in the overlay, and `input_drive`'s `g_armed` re-arm on a client/viewport rebuild
+   (without it motion controllers die silently after a resolution change).
+3. **Stage 3, cutscenes and the aim dot.** Measure the black-bar mechanism first: the Nexus
+   "Fullscreen Cutscenes" mod is a `HUDPC.swf` edit that zeroes a sprite named
+   `WidescreenBars`, which contradicts our own session-22 dump reading (engine clears to
+   black and draws a vertically shrunken tonemap quad). Install it, replay the Gatherer's
+   Garden Electro Bolt sequence, and see whether the bars go and whether the content is
+   squeezed. Then either suppress that one gameswf draw or fix the unsqueeze. Add `vrcine`
+   modes off / authored / authored+look, gating the hands, aim and laser drives on the
+   letterbox exactly as the head drive already is (closes ROADMAP's session-22 round-5
+   item - the authored cinematic hands currently only survive when the controllers are
+   idle). Add a single toggleable aim dot on the verified aim ray.
+4. **Stage 4, SteamVR/OpenVR.** SteamVR has never shipped a 32-bit OpenXR runtime, so
+   Lighthouse and Steam Link users cannot start VR at all; stage 1 now says so in the log.
+   Real fix is a native OpenVR backend behind the `bvr::vr` facade. Independently,
+   `openxr_input.cpp` suggests bindings for only `oculus/touch_controller` and
+   `khr/simple_controller`, so on SteamVR with Index or Vive wands, or on WMR, sticks,
+   triggers, grips and every face button are dead even when a session does start - add
+   those profiles.
+5. **Follow-ups opened by stage 1**: root-cause the `SETRES` fault; an `offsets.ini`
+   override so a non-Steam user can supply their own RVAs without a release; deriving
+   `GObjObjects` to retire object scanning entirely; the config echo block, proxy breadcrumb
+   and OpenXR API-layer enumeration from the diagnostics list.
+
+**Carried from session 26:**
 
 1. **Re-test the hang fix** (user, both games): put the headset on, get FOCUSED, then
    take it off / let it idle for a minute, then put it back on. Expect one

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,6 +7,14 @@
 **IN-HEADSET (user, Quest 3 / VDXR): the warping is FIXED.** Two things came back with it, and one
 of them is the important one.
 
+### 0. IN-HEADSET VERDICT: ACCEPTED - "without changing anything it's perfect, both the world and the gun/hand models"
+
+**Both are geometrically correct at the same time, on the first try, with NO re-tune.** That last
+part is a real finding, not just good news: the session-16 hand offsets in `vrpreset.ini` were
+suspected of having absorbed some of the 1.78x lens error, and they had not. They were correct all
+along and the fg lens was the only thing wrong - so the calibration work from sessions 13-16
+stands unmodified, and the `vrfgfov legacy on` A/B was not needed.
+
 ### 1. "The hand and gun move when the headset moves" - the SAME defect, other side
 
 Not a regression in the hands machinery. **One projection layer carries ONE fov claim for the whole

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -211,7 +211,36 @@ angular extent, never the distortion. That property is the most valuable constra
   exactly like warping. Stereo is therefore neither confirmed nor eliminated. A clean test
   needs stereo off with camera mode still ON.
 
-**Strongest remaining hypothesis: the submitted POSE, not the submitted FOV.** A projection
+**ELIMINATED BY MEASUREMENT (end of session 27):**
+
+- **FOV mismatch is NOT the cause.** At BioVRDev's exact config (2750x2850, ini FOV 100, both
+  locks pinned) the submit line read `src=live`, meaning the claim is derived from the MEASURED
+  rendered tangent and therefore tracks the render by construction - and the warping persisted
+  anyway. Checking `src=` on that line hours earlier would have ruled FOV out before three
+  formula rewrites. (That run also confirmed the law a third time and exactly:
+  `tanV = 0.670361 = tan(50)*9/16`, `tanV/tanH = 1.0364 = 2850/2750`. So the law is real, the
+  last revert was wrong, and it is ALSO irrelevant to this bug because the live path was
+  already keeping claim and render aligned.)
+- **Pose latching is NOT the cause.** `fovaudit pose on` during head sweeps reported
+  `delta 0.00 deg` on every sample with real yaw motion (61 -> 1 -> -2 -> 11 deg). The
+  comparison is not vacuous: it diffs `projViews[0].pose` against `g_consumedHeadQuat`, which
+  the game-thread camera drive publishes independently. `g_viewsContent` already holds the
+  previous locate generation deliberately, with a comment describing this exact artifact.
+
+**NEXT AND MOST SPECIFIC: the two eyes may be tagged with different ORIENTATIONS.**
+
+The pose audit only inspects `projViews[0]` - the left eye. Nothing checks eye 1. Under
+SequentialReentry both eyes are rendered in ONE game tick from ONE head sample, differing only
+by an IPD position offset, so both layers must carry the SAME orientation. But the stereo
+branch tags each eye with `g_eyePose[eye]`, a pose stored at THAT eye's capture, and the two
+captures happen on different presents. If those orientations differ, the compositor reprojects
+the two eyes differently, the images disagree during a turn, and that reads exactly as the
+world warping - independent of FOV, and consistent with the left eye's pose being provably
+correct. Check: log `projViews[0].pose` vs `projViews[1].pose` orientation during a turn; a
+non-zero orientation delta is the bug. Fix shape: tag both eyes with the single orientation the
+tick was rendered from, keeping only the position offset per eye.
+
+**Superseded hypothesis (kept for the record): the submitted POSE, not the submitted FOV.** A projection
 layer is submitted with both a pose and an fov; if the pose handed to the compositor does not
 match the pose the frame was actually rendered from, the compositor reprojects incorrectly and
 the world swims as the head turns - and that error is completely independent of the FOV value,

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,7 +2,77 @@
 
 > Handoff file. Rewrite "Current state" and "Next steps" every session; append to the session log.
 
-## Current state (2026-07-30, session 28 - OPEN BUG 2 ROOT-CAUSED AND FIXED: there are TWO lenses and the watch was reading the wrong one - branch s27-b1r-stability-and-resolution)
+## Current state (2026-07-30, session 28 - the warp is FIXED IN-HEADSET; the hands moving with the head was the same defect from the other side, now lens-matched - branch s27-b1r-stability-and-resolution)
+
+**IN-HEADSET (user, Quest 3 / VDXR): the warping is FIXED.** Two things came back with it, and one
+of them is the important one.
+
+### 1. "The hand and gun move when the headset moves" - the SAME defect, other side
+
+Not a regression in the hands machinery. **One projection layer carries ONE fov claim for the whole
+eye image, and the world and viewmodel were rendered through DIFFERENT frustums**, so only one
+could be right at a time: the old bug claimed the fg lens (hands right, world warping); fixing the
+world moved the same 1.78x error onto the hands. The only state where both are correct is MATCHED
+lenses - which is the `(4/3)*(h/w)` fix that was measured last session and deliberately held back
+so it could not confound the warp test. It is now required, and it landed.
+
+Second, coupled cause: `bones.cpp` asserted that with the lens match armed "k collapses to 1".
+True at 16:9 only - at a square backbuffer the real ratio was 1.7778, so the render lock's depth
+constraint AND its head-split lateral cancel were mis-scaled, and that cancel is exactly the term
+that stops the rig sliding under head motion. `world_ndc` had the same hardcoded `9/16` for the
+world lens. Both now read the live aspect; `k` genuinely collapses to 1.
+
+**Flat gate - the same instrument that found the original bug.** At 2048x2048 the dump went from
+TWO tangent clusters to **ONE**, with the 576-byte foreground tier now inside the world cluster
+(`tanH=1.1918 tanV=1.1918`, b0tiers `[320:57 576:39 832:36]`). `fovaudit` reports `lenses=1` and
+`fg lens match ON (last written 115.6 deg, k=1.333333)`; the engine accepted the wider write
+without clamping. `vrfgfov legacy on|off` restores/removes the split, verified both directions -
+an instant in-headset A/B.
+
+**Not confirmable flat, and not assumed:** the bone-solve half. No XR session means no controller
+poses, so the hands drive never engages (`inst=0 writes=0 solves=0`) and `render_lock_delta` is
+never entered. Its lens geometry is proven; the solve needs the headset.
+
+**Carry:** the session-16 hand offsets in `vrpreset.ini` were tuned against the OLD 1.78x-narrow fg
+lens at a square backbuffer, so some of those numbers may have been compensating for the lens
+error. A re-tune may be wanted now the projection is honest.
+
+Corroboration from the other repo, and it was already in our own notes: `docs/RESEARCH.md` records
+BioVRDev's fg fov as `2*atan(tan(fov/2)*(4/3)/aspect)` - i.e. `(4/3)*(h/w)`, exactly this fix,
+noted since session 20 and never acted on. Our `0.75` is that expression evaluated at 16:9.
+
+### 2. Game FOV Write had to be turned off in-headset - and the corrected law says why
+
+`apply_vr_preset` forced it ON, pushing option 130. That 130 came from the "129.5 circumscribing"
+arithmetic, which solved `tan(option/2)*9/16*aspect = tan(H/2)` - **derived from the disproved
+law**. Under the measured law `tanH = tan(option/2)` with no aspect term, so option 100 at a square
+backbuffer already renders exactly 100x100 deg, and 130 over-widens by 30 deg (and drags the fg
+lens to ~141 deg with it). The preset no longer arms the write; the global default was already
+false, that line was the only thing turning it on. `gfov <deg>` still arms it manually.
+
+### 3. Alt-tab is NOT fixed, and the new instrument named the real cause
+
+My pair-hold hypothesis was **wrong** - the log says `pairOpen=0`. The actual state:
+
+```
+xr: session state VISIBLE
+xr: SUBMISSION IDLE (reason=pace guard: session not FOCUSED | state=VISIBLE everFocused=1
+                     pairOpen=0 skips=5772 frames=5022)
+```
+
+and **no `FOCUSED` line ever follows** until `session teardown (disabled in overlay)`. So VDXR drops
+the session to VISIBLE on alt-tab and never re-grants FOCUSED, because **we stop submitting frames
+while unfocused and the runtime will not promote an app that submits nothing** - a circular wait.
+This directly contradicts the session-26 comment that "recovery is event-driven, not something an
+app earns by submitting frames": measured, on VDXR, it IS earned. Note also **zero
+`xrWaitFrame blocked` lines in the entire session**, so the guard skipped 5000-9000 presents
+without a single slow wait to justify it - it keys on session state when the thing it must avoid is
+a slow wait. Fix shape (user deferred it: hands first): keep submitting while VISIBLE but run
+`xrWaitFrame` on a dedicated thread so the present thread waits with a timeout and can never be
+wedged - which also permanently retires the session-26 hang class. Nothing in `src/` reads Win32
+focus, so alt-tab reaches us only through the runtime's own state.
+
+## Previous state (2026-07-30, session 28 part 1 - OPEN BUG 2 ROOT-CAUSED: there are TWO lenses and the watch was reading the wrong one)
 
 **The yaw warp is not a pose bug, not a formula bug, and not a stereo bug. The instrument was
 reading the viewmodel's lens and the projection claim was following it.** Full derivation with

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -86,7 +86,30 @@ backbuffer already renders exactly 100x100 deg, and 130 over-widens by 30 deg (a
 lens to ~141 deg with it). The preset no longer arms the write; the global default was already
 false, that line was the only thing turning it on. `gfov <deg>` still arms it manually.
 
-### 3. Alt-tab is NOT fixed, and the new instrument named the real cause
+### 3. Alt-tab: FIXED per the measurement, needs the in-headset confirm
+
+`xrWaitFrame` now runs on a dedicated pace thread. The present thread posts one request at a time
+(keeping wait:begin at 1:1) and waits on the result with a deadline - 200 ms while FOCUSED so the
+headset still paces the game, 20 ms otherwise so an unresponsive runtime cannot drag the flat window
+down; on timeout it gives up and a later present consumes the same outstanding result.
+`pace_should_skip` no longer skips merely for being unfocused, which is what lets FOCUSED be
+re-granted. `teardown_session` refuses to destroy a session while a wait is in flight on it (a
+use-after-free inside the runtime) and defers instead. `vrpace thread off` restores the exact
+pre-session-28 inline behaviour; `vrpace status` reports handoffs and timeouts.
+
+**Flat coverage is regression-only** - with no XR session flat the off-thread path never runs
+(`handoffs 0`), so the fix itself needs the headset. Expect on alt-tab away and back:
+`xr: FOCUSED again after N ms`, the headset image resuming by itself, and NO
+`SUBMISSION IDLE` heartbeat persisting. This is the third attempt at this bug class and the first
+one built on a measurement of it rather than a hypothesis.
+
+**Why this design and not a smaller one:** the minimal fix (submit while unfocused, but skip when
+waits get slow) needs a periodic probe wait, and an unbounded probe wait IS the session-26 keepalive
+that hung. Moving the call off the present thread is the only shape that fixes alt-tab without
+reinstating that hang class - and it retires the hang class permanently, because an unbounded block
+can no longer reach the thread the game depends on.
+
+### 3a. The measurement that named it (kept - it refuted my own first fix)
 
 My pair-hold hypothesis was **wrong** - the log says `pairOpen=0`. The actual state:
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -86,7 +86,13 @@ backbuffer already renders exactly 100x100 deg, and 130 over-widens by 30 deg (a
 lens to ~141 deg with it). The preset no longer arms the write; the global default was already
 false, that line was the only thing turning it on. `gfov <deg>` still arms it manually.
 
-### 3. Alt-tab: FIXED per the measurement, needs the in-headset confirm
+### 3. Alt-tab: FIXED AND ACCEPTED IN-HEADSET ("the alt tab is working again")
+
+Both of session 27's open bugs are now closed and confirmed on the real headset. Details of the
+fix below; the thing to carry forward is that it took three attempts and only the one built on a
+measurement worked - the first two (retiring the keepalive in session 26, the pair-hold ordering
+earlier this session) were both derived from reading the code, and both were wrong about the cause
+while being correct as hardening.
 
 `xrWaitFrame` now runs on a dedicated pace thread. The present thread posts one request at a time
 (keeping wait:begin at 1:1) and waits on the result with a deadline - 200 ms while FOCUSED so the
@@ -370,32 +376,67 @@ in case long soaks ever disprove this.
 
 ## Next steps
 
-### THE ONE THING BLOCKING EVERYTHING: in-headset re-test of the session-28 build
+### BOTH session-27 open bugs are CLOSED and in-headset accepted. Nothing is blocked.
 
-The warp fix and the alt-tab fix are both flat-verified but neither symptom is flat-observable.
-One run answers both. Checklist (user drives; report back from the log):
+Stage 1 (stability), the resolution lane, the yaw warp, the viewmodel/head coupling and the
+alt-tab freeze are all done and confirmed on the real headset. Stage 2 is substantially complete -
+both of its blocking measurements landed this session. What remains:
 
-1. Launch, VR PRESET 1, get to gameplay at **2048x2048** (the ini is already set).
-2. Turn your head left/right deliberately, fast and slow. **Expected: no warping.**
-3. Pitch sweeps, then head-TILT sweeps (roll has never been tried in-headset; the horizon should
-   stay level - flat says roll reaches the render, so this should already be right).
-4. If any warping remains: untick **"...stereo doubling ONLY (A/B - keeps the head drive)"** in
-   the overlay. That is the un-confounded stereo A/B, new this session. If the warp survives with
-   doubling off, it is not the stereo path at all.
-5. **Alt-tab away for ~10 s, then back.** Expected: the headset image resumes on its own. In the
-   log expect `xr: FOCUSED again after N ms`, or - if it still freezes - one
-   `xr: SUBMISSION IDLE (reason=...)` line every 5 s naming the exact guard, which pins it
-   outright.
-6. Log gates for me afterwards: `mismatch=0` in `fovaudit`, no `[hud] rendered-fov mismatch ON`
-   line, `lenses=2` with the WORLD tangent equal to `tan(option/2)`, and the submit line reading
-   `src=readback` (NOT `src=live`).
-7. Optional short control leg at **1920x1080** - yaw sweeps only - to confirm 16:9 was always
-   clean for the reason now understood rather than by luck.
+### 1. Stage 2 leftovers (small, and one is a policy decision, not a bug)
 
-Then: land the foreground `0.75 -> (4/3)*(h/w)` fix (measured, held back so it cannot confound
-this run), and the VR PRESET FOV policy correction.
+- **The VR PRESET FOV policy is now UNSET, deliberately, and wants a decision.** The preset used to
+  force option 130 from the "129.5 circumscribing" arithmetic, which was derived from the lens law
+  session 28 disproved; it no longer writes any FOV, so the render FOV is whatever the user's ini
+  says (100 at 2048x2048 = exactly 100x100 deg, which is close to ideal for a Quest-class eye, and
+  is what the user tested and accepted). The principled version is to set the option from the
+  HEADSET's own horizontal FOV, which needs item 2. Until then the current behaviour is correct by
+  accident-free reasoning rather than by measurement of the specific headset.
+- **`xrEnumerateViewConfigurationViews` is still never called.** It is the missing input for both a
+  correct FOV policy and a derived render target (`recommendedImageRect`), and its absence is why a
+  runtime-side resolution slider does nothing for this mod (the Dream Air user datapoint).
+- Overlay device-identity and hwnd-identity checks, and `input_drive`'s `g_armed` re-arm on a
+  client/viewport rebuild - without the latter, motion controllers die silently after a live
+  resolution change.
+- `SETRES` through the viewport Exec seam still FAULTS (`exe+0x4C2353`); the ini lane is primary and
+  works, so this is a diagnostic curiosity rather than a blocker.
 
-### OPEN BUG 1 (FIXED session 28, needs the headset confirm): VR freezes permanently after alt-tab (user-reported, session 27)
+### 2. Stage 3: cutscenes and the aim dot (the next real milestone)
+
+Measure the black-bar mechanism FIRST - the Nexus "Fullscreen Cutscenes" mod is a `HUDPC.swf` edit
+zeroing a sprite named `WidescreenBars`, which contradicts our own session-22 dump reading (engine
+clears to black and draws a vertically shrunken tonemap quad). Install it, replay the Gatherer's
+Garden Electro Bolt sequence, and see whether the bars go and whether the content is squeezed. Then
+either suppress that one gameswf draw or fix the unsqueeze. Then `vrcine off|authored|authored+look`
+with the hands, aim and laser drives gated on the letterbox exactly as the head drive already is
+(closes ROADMAP's session-22 round-5 item - authored cinematic hands currently only survive when the
+controllers are idle). Then a single toggleable aim dot on the verified aim ray.
+
+### 3. Stage 4: SteamVR/OpenVR and the dead interaction profiles
+
+SteamVR has never shipped a 32-bit OpenXR runtime, so Lighthouse and Steam Link users cannot start
+VR at all (stage 1 now says so in the log). Real fix is a native OpenVR backend behind the
+`bvr::vr` facade. Independently and much cheaper: `openxr_input.cpp` suggests bindings for only
+`oculus/touch_controller` and `khr/simple_controller`, so on SteamVR with Index or Vive wands, or on
+WMR, sticks/triggers/grips/face buttons are all dead even when a session does start. Add those
+profiles - that is a contained win worth doing before the backend.
+
+### 4. Release
+
+Gate per the user: stages 2 and 3 done, then bump off 0.4.1 and build **Release** - everything
+tested this session and last has been Debug. Worth one soak on the Release build before packaging,
+because the pace thread is new and Debug timing is not Release timing.
+
+### 5. Carried diagnostics / follow-ups
+
+- Root-cause the `SETRES` fault; an `offsets.ini` override so a non-Steam user can supply RVAs
+  without a release; deriving `GObjObjects` to retire object scanning entirely; the config echo
+  block, proxy breadcrumb and OpenXR API-layer enumeration from the diagnostics list.
+- BS2 carries are unchanged (viewmodel-in-stereo diagnostic, input/motion controllers, FOV slider
+  endpoints) - plus the new session-28 lens/resolution checklist now banked in
+  `docs/bioshock2/ENGINE_NOTES.md`, which should be run BEFORE any BS2 non-16:9 support.
+- v0.4.1 to the external tester; 2K-account lead; seated recenter designs.
+
+### OPEN BUG 1 (CLOSED session 28, in-headset accepted): VR freezes permanently after alt-tab (user-reported, session 27)
 
 > **Session 28: root-caused and fixed - `pace_should_skip` was NOT the culprit.** The real defect
 > was ordering: `if (g_srPairOpen) return;` sat ABOVE `pump_events()`, so while an SR pair-hold was
@@ -441,7 +482,7 @@ Also note the engine pauses CalcView while the window is unfocused (the harness 
 depend on this), so the game thread may stop driving the camera - check whether that starves
 something the submit path needs.
 
-### OPEN BUG 2 (ROOT-CAUSED AND FIXED session 28, needs the headset confirm): yaw warping on head turn at non-16:9 resolutions
+### OPEN BUG 2 (CLOSED session 28, in-headset accepted): yaw warping on head turn at non-16:9 resolutions
 
 > **Session 28: the frame carries TWO lenses and the watch was reading the viewmodel's.** World
 > pass is `tanH = tan(option/2)`, `tanV = tanH*(h/w)`; foreground pass is
@@ -3206,6 +3247,63 @@ hold aged at 500 ms with a force-abort through the existing leaked-frame close, 
 closed before the pace guard can return, `g_unfocusedSinceMs` cleared on STOPPING and
 `g_paceSkips` made per-episode (those two gates had silenced the only two lines that would have
 explained anything), plus a 5 s `SUBMISSION IDLE (reason=...)` heartbeat naming the firing guard.
+
+---
+
+**IN-HEADSET ROUND 1: the warp was GONE, and two things came back with it.** The user had to turn
+"Game FOV Write" off, alt-tab was still stuck, and - the important one - **the hand/gun model
+started moving with the headset**, the thing sessions 13-16 were spent fixing.
+
+**The hands were not a regression. They were the same defect from the other side.** One projection
+layer carries ONE fov claim for the whole eye image, and the world and viewmodel were rendered
+through different frustums, so only one could be geometrically correct at a time: the old bug
+claimed the fg lens (hands right, world warping) and fixing the world moved the same 1.78x error
+onto the hands. Only MATCHED lenses make both right - which is the `(4/3)*(h/w)` constant measured
+earlier the same session and deliberately held back so it could not confound the warp test. It
+became required rather than optional, and it landed. A second, coupled cause was in `bones.cpp`,
+whose `render_lock_delta` asserted that with the match armed "k collapses to 1" - true at 16:9 only,
+so at a square backbuffer the depth constraint AND the head-split lateral cancel were mis-scaled,
+and that cancel is exactly the term that stops the rig sliding under head motion. `world_ndc` had
+the same hardcoded `9/16` for the WORLD lens. Both read the live aspect now.
+
+The user's instruction to use "the previous version and the other repo as research" paid off
+directly: `docs/RESEARCH.md` has recorded since session 20 that BioVRDev use
+`2*atan(tan(fov/2)*(4/3)/aspect)` - exactly this fix, written down and never acted on. Our `0.75`
+is that expression evaluated at 16:9.
+
+Flat gate, same instrument that found the original bug: the dump went from two clusters to **ONE**,
+with the 576-byte fg tier now inside the world cluster. `vrfgfov legacy on|off` restores and removes
+the split, both directions verified, giving an instant in-headset A/B.
+
+**IN-HEADSET ROUND 2: "without changing anything it's perfect, both the world and the gun/hand
+models."** No re-tune. That closed an open question in the process: the session-16 hand offsets were
+suspected of having absorbed part of the 1.78x lens error while being tuned against it, and they had
+not - they were correct all along, which retroactively validates the sessions 13-16 method as having
+solved for the rig rather than papering over a projection error. It also confirms the bone-solve half
+that flat could not reach (no XR session means no controller poses, so `render_lock_delta` is never
+entered flat).
+
+**Alt-tab, third attempt, and the first one built on a measurement.** The instrument shipped in
+round 1 refuted round 1's own fix: `pairOpen=0` on every `SUBMISSION IDLE` line, so the pair-hold was
+never the cause. The real one is a circular wait - VDXR drops to VISIBLE on alt-tab and will not
+re-grant FOCUSED to an app that submits nothing, and the M8 guard made us submit nothing, so the
+guard's effect kept its own precondition true. Corroborating: ZERO `xrWaitFrame blocked` lines in the
+whole session, i.e. 5772 presents skipped without one slow wait to justify any of it - the guard
+keyed on session STATE when the hazard is a slow WAIT. Since `xrWaitFrame` takes no timeout and never
+can, it moved to a dedicated pace thread with the present thread waiting on the result behind a
+deadline (200 ms FOCUSED, 20 ms otherwise). That retires the session-26 hang class permanently
+instead of trading it for the freeze, and `teardown_session` now defers rather than hand the runtime
+a freed session handle. **User: "the alt tab is working again".** Both session-27 open bugs closed.
+
+**Two user questions answered with measurements rather than assurances.** Is it dynamic across
+resolutions? Verified at two aspects: 2048x2048 -> `k=1.333333` / fg 115.6 deg, and 1920x1080 ->
+`k=0.750000` / fg 83.6 deg - exactly the old hardcoded constant at 16:9, which is what protects the
+sessions 13-16 calibration by construction. Checking it also found and closed a fragility: the
+backbuffer dims were published only inside the letterbox watch's RGBA8 format whitelist and
+staging-allocation success, so a user on another format would have silently reverted to the 16:9
+constants and got the 1.78x viewmodel error back. And the whole defect class is now banked for
+BioShock 2 in its ENGINE_NOTES as an ordered CHECKLIST rather than constants to copy - starting with
+"does BS2 even have two lenses", which session 25's native-fg finding suggests it may not.
 
 **Plus:** `vrstereo stereoonly on|off` and an overlay checkbox that drop only the doubling and
 leave 1t and the head drive alone - the A/B that was confounded every previous time, verified

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -49,6 +49,34 @@ Corroboration from the other repo, and it was already in our own notes: `docs/RE
 BioVRDev's fg fov as `2*atan(tan(fov/2)*(4/3)/aspect)` - i.e. `(4/3)*(h/w)`, exactly this fix,
 noted since session 20 and never acted on. Our `0.75` is that expression evaluated at 16:9.
 
+### 1b. It is dynamic: the lens math follows any resolution, no relaunch needed for the math
+
+Everything aspect-dependent reads the LIVE backbuffer every frame instead of caching at init:
+`bvr::hud::backbuffer_dims` is published at the head of the present detour, the fg match constant
+is recomputed per CalcView, `bones.cpp` reads it per solve, and the XR claim derives from the
+rebuilt swapchain dims. One fragility was found and closed while checking this: the dims used to be
+published only INSIDE the letterbox watch's RGBA8 format whitelist and staging-allocation success,
+so a user on another backbuffer format would have silently fallen back to the 16:9 constants and got
+the 1.78x viewmodel error back. Correct lens geometry must not depend on whether an unrelated
+black-bar detector could allocate, so the dims read is now unconditional and first.
+
+At 16:9 the corrected constant evaluates to exactly `0.75`, so 16:9 rendering is bit-identical to
+everything that shipped before - which is what protects the sessions 13-16 calibration by
+construction rather than by luck.
+
+### 1c. Banked for BioShock 2 (user ask): `docs/bioshock2/ENGINE_NOTES.md`
+
+A new section records the BS1 defect class as an ordered CHECKLIST for BS2 rather than a set of
+constants to copy: does BS2 even have two lenses (session 25's native-fg finding says it may not),
+how to identify which cluster is the foreground (toggle the fg write and see which one moves - not
+by draw count or cb tier, both of which were shared on BS1), why two backbuffers are needed to
+distinguish the two candidate world laws at all, that `src=live` is a provenance tag and not a
+correctness proof, that the aspect-general fg constant is `(4/3)*(h/w)` but its `4/3` and `3/4` are
+BS1's measured foreground spec and must be re-measured, and a grep list of the four places BS1 had
+hardcoded aspect constants that were all silently correct at 16:9. The fixed watch is core and
+game-agnostic, so on BS2 `fovaudit` reporting `lenses=2` off 16:9 is already the alarm - the
+diagnosis BS1 lacked is in place before BS2 needs it.
+
 ### 2. Game FOV Write had to be turned off in-headset - and the corrected law says why
 
 `apply_vr_preset` forced it ON, pushing option 130. That 130 came from the "129.5 circumscribing"

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -384,13 +384,22 @@ both of its blocking measurements landed this session. What remains:
 
 ### 1. Stage 2 leftovers (small, and one is a policy decision, not a bug)
 
-- **The VR PRESET FOV policy is now UNSET, deliberately, and wants a decision.** The preset used to
-  force option 130 from the "129.5 circumscribing" arithmetic, which was derived from the lens law
-  session 28 disproved; it no longer writes any FOV, so the render FOV is whatever the user's ini
-  says (100 at 2048x2048 = exactly 100x100 deg, which is close to ideal for a Quest-class eye, and
-  is what the user tested and accepted). The principled version is to set the option from the
-  HEADSET's own horizontal FOV, which needs item 2. Until then the current behaviour is correct by
-  accident-free reasoning rather than by measurement of the specific headset.
+- **The VR PRESET FOV policy is CLOSED, by the user's call 2026-07-30, and the reasoning matters.**
+  The preset no longer writes any FOV and should not. The user's account of WHY they had been
+  raising it: *"I was just changing the FOV since I wasn't able to put the screen in full view and
+  have no black bars. But now since I can change the resolution however I want then it's good."*
+  **Those black bars were an ASPECT problem, not a FOV problem, and cranking the option was
+  compensating for the wrong axis.** A headset eye is roughly square; a 16:9 render claimed at 16:9
+  fills a wide short rectangle inside it and leaves unfilled bands top and bottom, and the only way
+  to cover them by widening FOV is to over-render horizontally and throw the pixels away. Matching
+  the render ASPECT to the eye instead - a square backbuffer - makes the claimed frustum the right
+  shape, and then a sane FOV fills the eye exactly. Under the corrected world law option 100 at
+  2048x2048 renders exactly 100x100 deg against a Quest 3 eye of roughly 100x96, which is very
+  nearly an exact fill: the reason 100 + square works is arithmetic, not luck.
+  So the standing policy is **set the aspect with the resolution lane, leave the FOV alone**, and
+  the old "crank the option to 130" reflex is retired along with the law it came from.
+  `vrfov`/`gfov` remain as manual levers, default off. This also means the resolution lane was not
+  just a sharpness feature - it is the mechanism that made the FOV write unnecessary.
 - **`xrEnumerateViewConfigurationViews` is still never called.** It is the missing input for both a
   correct FOV policy and a derived render target (`recommendedImageRect`), and its absence is why a
   runtime-side resolution slider does nothing for this mod (the Dream Air user datapoint).
@@ -420,11 +429,20 @@ VR at all (stage 1 now says so in the log). Real fix is a native OpenVR backend 
 WMR, sticks/triggers/grips/face buttons are all dead even when a session does start. Add those
 profiles - that is a contained win worth doing before the backend.
 
-### 4. Release
+### 4. Release - HELD until stage 3 is finished (user's call 2026-07-30)
 
-Gate per the user: stages 2 and 3 done, then bump off 0.4.1 and build **Release** - everything
-tested this session and last has been Debug. Worth one soak on the Release build before packaging,
-because the pace thread is new and Debug timing is not Release timing.
+The user considered releasing at the end of session 28 and then explicitly deferred: *"let's hold
+off on the release till we finish stage 3 that way I can make sure everything also works and not
+weird for example in cinematics and the like."* The reasoning is sound and worth honouring rather
+than re-litigating: session 28 changed the projection claim, the foreground lens and the frame
+pacing, and **cinematics are the one place those three interact that has NOT been exercised** - the
+cinematic path has its own claim substitution branch, its own letterbox gating of the head drive,
+and its own quad fallback. Shipping before stage 3 would put an untested combination of the three
+in front of an external tester.
+
+So: stage 3 first, in-headset, then bump off 0.4.1 and build **Release** - everything tested in
+sessions 27 and 28 has been Debug. Worth one soak on the Release build before packaging, because
+the pace thread is new and Debug timing is not Release timing.
 
 ### 5. Carried diagnostics / follow-ups
 

--- a/docs/bioshock1/ENGINE_NOTES.md
+++ b/docs/bioshock1/ENGINE_NOTES.md
@@ -2711,10 +2711,18 @@ session there are no controller poses, so the hands drive never engages (`inst=0
 solves=0`) and `render_lock_delta` is never entered. The lens geometry it depends on is proven;
 the solve itself needs the headset.
 
-**Carry:** the session-16 hand offsets in `vrpreset.ini` were tuned in-headset against the OLD,
-1.78x-narrow fg lens at a square backbuffer, so part of those numbers may have been compensating
-for the lens error. They may want a re-tune now that the projection is honest. `vrfgfov legacy on`
-is the comparison lever.
+**IN-HEADSET: ACCEPTED, and the carry closed itself.** User verdict: "without changing anything
+it's perfect, both the world and the gun/hand models". The open question was whether the
+session-16 hand offsets in `vrpreset.ini` had absorbed part of the 1.78x lens error while being
+tuned against it - **they had not.** No re-tune, no offset change, no need for the
+`vrfgfov legacy on` comparison. The offsets were right all along and the fg lens was the only thing
+wrong, which retroactively validates the sessions 13-16 calibration method: it was solving for the
+rig, not papering over a projection error.
+
+This also confirms the bone-solve half that flat could not reach. `render_lock_delta`'s head-split
+lateral cancel is the term that stops the rig sliding under head motion, and it depends on
+`k == 1`; the rig is now stable in-headset, so `k` really does collapse to 1 with the lenses
+matched and the live-aspect model is right.
 
 ### 5. The foreground-lens aspect law, and the `0.75` it condemns
 

--- a/docs/bioshock1/ENGINE_NOTES.md
+++ b/docs/bioshock1/ENGINE_NOTES.md
@@ -2403,6 +2403,14 @@ followed, so the resolution change never began. Notes:
 
 ### RETRACTED - the "Hor+ with a fixed vertical" law below is NOT established
 
+> **RESOLVED in session 28 - see "Session 28: two lenses, and the one the watch was reading"
+> at the end of this file.** Both readings in the table below were real, fresh and correct
+> measurements *of different lenses*: the frame carries a world lens AND a foreground lens, and
+> off 16:9 they differ by `(16/9)*(h/w)`. `2.1445` is the world lens at 1:1 option 130 and
+> `1.2063` is the foreground lens at the same moment. Staleness was never the explanation. The
+> retraction was right to refuse the law; the session-27 un-retraction was wrong; the ORIGINAL
+> assumption (option is a true horizontal) is what the world pass actually does.
+
 **Read this before acting on the section that follows.** A third reading contradicts it. Same
 backbuffer (2048x2048), same `option=130`, two different results:
 
@@ -2508,6 +2516,170 @@ eye: 17.6 MP useful out of 33.2 MP rendered, ~53% efficiency, matching the ~54% 
 already recorded above. The same sharpness is available near-square for ~18 MP. It also caps
 how aggressively a derived target may clamp: 33 MP is a resolution a real user is happily
 running, so any total-pixel ceiling must be generous and overridable.
+
+## Session 28: two lenses, and the one the watch was reading
+
+**This closes OPEN BUG 2 (yaw warping at non-16:9) and settles both lens laws.** Everything
+below is measured, not derived: `dumpframe full` at 2750x2850 decoded by
+`tools/decode-framedump.ps1` (which has always applied the structural zero-slot validation the
+live watch did not), at two FOV options, on both SR eyes, plus a `vrfgfov on/off` A/B that
+identifies the clusters by which one moves.
+
+### 1. THE HEADLINE: a frame carries TWO perspective lenses, and off 16:9 they DIFFER
+
+At 16:9 they coincide exactly, which is why every measurement from session 21 to session 27 saw
+a single cluster and why every "law" derived from a single reading was a coin flip.
+
+```
+WORLD pass:      tanH = tan(option/2)          <- aspect-INDEPENDENT
+                 tanV = tanH * (h/w)           <- vertical follows the window ("Vert+")
+
+FOREGROUND pass: tanV = tan(fgFov/2) * 3/4     <- aspect-INDEPENDENT (the 4:3 spec)
+                 tanH = tanV * (w/h)           <- horizontal follows the window ("Hor+")
+```
+
+The two conventions are exact opposites, and their ratio is `(16/9)*(h/w)` - 1.0 at 16:9,
+1.7778 at 1:1, 1.8425 at 2750x2850.
+
+Measured, 2750x2850 (aspect 0.964912), `decode-framedump.ps1` cluster output:
+
+| option | vrfgfov | world cluster (draws) | fg cluster (draws) |
+|---:|---|---|---|
+| 100 | on | tanH **1.1918** tanV **1.2351** (154) | tanH 0.6468 tanV 0.6704 (24) |
+| 100 | off | tanH **1.1918** tanV **1.2351** (138) | tanH 0.4178 tanV **0.4330** (24) |
+| 130 | on | tanH **2.1445** tanV **2.2225** (163) | tanH 1.1640 tanV 1.2063 (24) |
+
+Every number is exact: `tan(50) = 1.191754`, `1.191754 * 2850/2750 = 1.235090`,
+`tan(65) = 2.144507`, `2.144507 * 2850/2750 = 2.222514`. The `vrfgfov off` row is the identifier
+- **only the second cluster moved**, and it landed on `0.4330127`, the native foreground vertical
+already hardcoded in `patterns.h`'s `kFgCbFingerprint[6]` (`tan(30)*3/4`). Both eye windows (q0
+and q1) are identical, so this is not an eye-attribution artifact.
+
+**So the world lens is what this project originally assumed, and what BioVRDev assume too.** The
+submission formula in `openxr_runtime.cpp` (`halfV = atan(tan(halfH) * swapH/swapW)`) has been
+correct at every aspect all along, and it was correct to revert all three session-27 rewrites.
+
+### 2. THE BUG: the live watch was reading the foreground lens, and the claim followed it
+
+`core/gfx/hud_capture.cpp` sampled the cb0 head of the **first** DSV-bound `DrawIndexed` of each
+present interval whose VS b0 was >= 320 bytes. Three facts make that the viewmodel:
+
+- the foreground draws are **the first draws of the main pass** (recorded since session 21);
+- the foreground tier is **576 bytes** (`patterns.h` `kFgCbBytes`), which clears the 320 gate;
+- the foreground block carries the screen-ray helper at the **same floats 12..18**, so the
+  decode cannot tell it apart - and the two cross-checks the decode did run (`f[12]/2` against
+  `-f[14]`, `-f[17]/2` against `f[18]`) are **intra-axis**: they confirm each triple is
+  self-consistent and carry no information about which lens or which axis it belongs to. The
+  three structural zero slots that *would* disambiguate (`f[13]`, `f[15]`, `f[16]`) were never
+  tested, although the offline decoder has always tested them.
+
+Consequences, in order:
+
+1. `fov_mismatch()` compared the FOREGROUND tangent against `tan(option/2)`. Off 16:9 that ratio
+   is 0.54, far outside the +-10% window, so **the verdict latched ON during normal gameplay**
+   and stayed on - visible in the session-27 log as one `[hud] rendered-fov mismatch ON` line at
+   03:50:56 and no `off` line for the rest of the session.
+2. A latched `fovMm` with `g_cineStereo` (default true) routes the projection claim through the
+   `fovMm && stereoCine` branch in `on_present_end`, which replaces the option-derived claim with
+   **the live watch's tangent** - i.e. with the viewmodel frustum. That is the `src=live` on the
+   session-27 submit line: `tanH=0.646840 tanV=0.670361 ... src=live swap=2750x2850`, over a
+   world actually rendering `tanH=1.1918`. **A 1.842x under-claim of the submitted frustum.**
+3. The compositor was therefore told the image spans +-32.9 deg horizontally when it spans
+   +-50 deg. Everything reads magnified by 1.84x in tangent space, and every head rotation is
+   mis-reprojected: a feature dead ahead at display time is displaced by
+   `atan(k*tan(delta)) - delta`, several degrees at ordinary turn rates, snapping back the moment
+   the head stops. **That is the warp.**
+
+Why the observed signature is exactly this and nothing else:
+
+- **FOV-slider independent** (the strongest constraint in the report): the error is
+  `k = (16/9)*(h/w)`, which has no option term at all. Sweeping the slider changes the visible
+  extent and never the distortion.
+- **Aspect-gated**: at 16:9 the two lenses coincide, the verdict never latches, the claim stays
+  `src=readback` and is correct. 1920x1080 is clean *by construction*.
+- **Yaw-dominant, pitch clean**: the tangent error is uniform, but yaw excursions in play are far
+  larger and faster than pitch, so the reprojection error is felt on yaw.
+- **BioVRDev do not warp at the same 2750x2850**: they submit the option-derived claim and have
+  no mismatch detector, so nothing ever substitutes the fg lens - and under the law above their
+  claim is simply correct. The contradiction that made this look unexplainable was the clue.
+
+Why the two session-27 eliminations, both honestly measured, could not catch it:
+
+- **`src=live` was read as proof of correctness.** The reasoning was "live means derived from the
+  measured rendered tangent, therefore it tracks the render by construction". The label was true;
+  the lens it tracked was the wrong one. A source tag is not a correctness proof.
+- **The pose audit is structurally blind.** It compares `projViews[0].pose.orientation` against
+  `g_consumedHeadQuat`, and `g_consumedHeadQuat` is stamped inside `get_head_pose()` from the same
+  `xrLocateSpace`/`xrLocateViews` generation the tag comes from. `delta 0.00 deg` was guaranteed
+  by construction. It proves the locate-to-tag plumbing is intact and says nothing about whether
+  the tag matches the pose the frame was RENDERED from. Recorded here so the next reader does not
+  re-derive it: **that audit cannot eliminate the pose hypothesis, and the session-27 write-up
+  over-claimed when it said pose latching was ruled out.**
+
+### 3. Two suspects killed by measurement along the way
+
+- **Head roll is NOT erased between tick and render.** BioVRDev record that this engine erases
+  camera roll and ship a render-thread roll re-write; BS1R does not need one. `simhead 0 0 40`
+  then `reentry dump`: the engine's own render submit receives
+  `rot=(0,28303,7281)=(0.0,155.5,40.0)deg` - roll intact - and the screenshot shows the world
+  rolled 40 deg. So the layer pose (which carries roll) matches the render, and roll is not a
+  claim/render mismatch on this game.
+- **Per-eye render orientation is provably identical.** The same dump shows both SR passes
+  submitting `rot=(0,28303,0)` bit-identical, with locations 6.36 UU apart laterally
+  (`ipd 63.4 mm` at worldScale 100 = 6.34 UU) and `dz = 0` at roll 0, becoming
+  `dz = 4.1 UU` at roll 40 - the session-22 full-rotation right axis working as designed.
+
+### 4. What shipped
+
+- **`hud_capture.cpp` rewritten to vote, not to guess.** Up to 8 cb0 heads per interval into one
+  640-byte staging buffer, sampled at a **stride** derived from the previous interval's distinct
+  cb0 count so the samples span the whole pass (a first-8 sample is dominated by the foreground:
+  measured 5/8 votes for the viewmodel at 2048x2048 before the stride went in). Clusters are
+  voted; the winner is published as the world lens and the runner-up as the fg lens.
+  `decode_ray_block` now enforces the offline decoder's structural zero slots, absolute
+  0.001 pair agreement, and bounds on both axes. Two guards refuse a round rather than publish a
+  marginal one: **majority** (a winner must exceed half the decoded samples) and **coverage** (a
+  round whose stride was stale, so it only spanned the head of the pass, is discarded - this is
+  the scene-change transient, and it fires exactly once entering gameplay).
+- **The age gate moved into `fov_watch()`**, default 500 ms, `0` meaning "give it to me anyway
+  and I will label it". Every printed line now says `FRESH` or
+  `STALE - DO NOT CONCLUDE` in words. `fovaudit live` reports both lenses, the vote split, the
+  stride, the sample count and the backbuffer aspect on one line, plus a `laws` line stating the
+  expectation for the live aspect - no conclusion needs two log lines cross-referenced again.
+- **The `fovaudit` option-derived column no longer falls back to a hardcoded 9/16** when there is
+  no XR session. It uses the real backbuffer dims (`bvr::hud::backbuffer_dims`). Flat is where
+  the measuring happens, and that fallback was wrong at every aspect but 16:9.
+- **The claim substitution announces itself** once per session with the age and the reason, so an
+  unexplained `src=live` can never hide a lens swap again.
+
+Flat verification at 2048x2048 (the resolution the README recommends and the bug was reported
+at): `WORLD tanH=1.191754 tanV=1.191754 (hfov 100.00 deg, 6/8 votes)`,
+`FG tanH=0.670361 tanV=0.670361`, `lenses=2 mismatch=0 cineActive=0`, both ages 15 ms FRESH,
+`ambiguous rounds 1` (the coverage guard doing its job at the menu->gameplay transition), and
+**no `rendered-fov mismatch ON` line anywhere in the run** where session 27 had one within
+seconds of reaching gameplay.
+
+### 5. The foreground-lens aspect law, and the `0.75` it condemns
+
+Stage 2's blocked measurement (b) is answered by the same dumps. `camera.cpp`'s foreground match
+writes `fg = 2*atan(tan(worldHalf) * 0.75)`. Matching the world needs the fg VERTICAL to equal
+the world vertical:
+
+```
+tan(fgHalf) * 3/4 = tan(option/2) * (h/w)
+  =>  tan(fgHalf) = tan(option/2) * (4/3) * (h/w)
+  =>  the constant is (4/3)*(h/w), which is 0.75 ONLY at 16:9
+```
+
+Checked against the measurement at 2750x2850 option 100: `tan(50)*1.3333*1.03636 = 1.64676`,
+`fgFov = 117.4 deg`, `fg tanV = 1.64676*0.75 = 1.23507` == the world's `1.2351`, and
+`fg tanH = 1.23507*0.96491 = 1.19175` == the world's `1.1918`. Exact.
+
+So the shipped `0.75` under-lenses the viewmodel by `1.7778/aspect` - **1.78x at a square
+backbuffer, which is what the README tells users to run**, and 1.84x at 2750x2850. That is the
+"hands look huge" report, quantified. The fix reduces to `0.75` exactly at 16:9, so it cannot
+invalidate the session-16 in-headset calibration. NOT shipped yet: it changes viewmodel scale
+visibly and must not confound the warp re-test.
 
 ### Superseded: the earlier "still unmeasured" note on the world lens aspect law
 

--- a/docs/bioshock1/ENGINE_NOTES.md
+++ b/docs/bioshock1/ENGINE_NOTES.md
@@ -2401,7 +2401,83 @@ followed, so the resolution change never began. Notes:
 - This is also the first real exercise of the exec failure latch: the fault disabled the
   seam for the session with one clear line, instead of being retried every 15 s.
 
-### Still unmeasured: the world lens aspect law
+### MEASURED: the world lens is Hor+ with a fixed vertical, and the option is 16:9-referenced
+
+Two `fovaudit live` readings of the rendered projection, same `option=130`, different
+backbuffer, taken through the ini lane below:
+
+| backbuffer | aspect | rendered tanH | rendered tanV |
+|---|---:|---:|---:|
+| 1920x1080 | 1.7778 | 2.1445 | 1.2063 |
+| 2048x2048 | 1.0000 | **1.2063** | **1.2063** |
+
+**The vertical did not move. The horizontal collapsed.** So the law is the OPPOSITE of what
+this project and BioVRDev both assumed:
+
+```
+tanV = tan(option/2) * 9/16     <- the option is a 16:9-REFERENCED horizontal, and what the
+                                   engine actually derives from it is the VERTICAL
+tanH = tanV * (live aspect)     <- horizontal follows the window. Hor+.
+```
+
+Both rows fit exactly: `tan(65) * 9/16 = 1.2063`, and `1.2063 * 1.7778 = 2.1445`. At 16:9 the
+two conventions coincide (`tanH == tan(option/2)`), which is why this went unnoticed through
+every session so far - every measurement had been taken at 16:9.
+
+Cross-check against the other mod's independently measured table: BioVRDev record
+`GameFovDegrees=100 -> 100.0h / 67.7v` at 16:9, and `tan(50)*9/16 = 0.6703 ->
+2*atan(0.6703) = 68.4 deg` vertical, `0.6703*16/9 = tan(50)` horizontal. Their numbers are
+this law, not the one their spec reasons with.
+
+**Consequence 1 - our submitted claim is wrong at any non-16:9 aspect.** Submission takes
+`hfovDeg` from the option readback and derives `halfV = atan(tan(halfH) * swapH/swapW)`
+(openxr_runtime.cpp). At 16:9 that reproduces the render exactly. At 1:1 it claims 130x130
+against a rendered 100.7x100.7 - a 1.78x horizontal stretch for the compositor to
+reproject, i.e. the yaw-warp signature. The mod already detects it: that run logged
+`mismatch=1`. The fix is to build the claim from the measured law
+(`tanV = tan(option/2)*9/16`, `tanH = tanV*aspect`) instead of assuming the option is a true
+horizontal.
+
+**Consequence 2 - "render square and keep FOV 100" under-shoots badly.** At 1440x1440 with
+option 100 the engine renders ~68x68 deg, not 100x100. That advice appears in BioVRDev's
+SPEC and is contradicted by their own table.
+
+**Consequence 3 - the pinned 130 is accidentally correct at square aspect.** Solving
+`tan(option/2)*9/16*a = tan(H/2)` for `H=100, a=1.0` gives `option = 129.5`, which is what
+VR PRESET 1 already writes (capped at the engine UI's 130). So at a square resolution the
+shipped config renders ~100.7x100.7 - very nearly the ideal for a Quest-class eye. No FOV
+policy change is needed there; the claim is the bug, not the render.
+
+### The ini lane works, and the engine honours a square backbuffer
+
+`%APPDATA%\BioshockHD\Bioshock\Bioshock.ini`, section `[WinDrv.WindowsClient]`. ANSI, CRLF.
+
+**FOUR sections carry the same viewport key names** - the PC driver at line 429 plus
+`[XeDrv.XenonClient]` (468), `[DurangoDrv.DurangoClient]` (500) and `[OrbisDrv.OrbisClient]`
+(532). A key replacement that is not section-scoped writes a console driver section and looks
+like it succeeded. Every write in `game_ini.cpp` is scoped to the PC section, writes BOTH the
+windowed and fullscreen pairs (UE2 reads whichever mode it starts in), backs up once to
+`.bvr-bak-res`, writes via temp + `ReplaceFileW`, and re-reads to verify.
+
+Verified end to end: `vrres 2048x2048` -> `viewport set to 2048x2048 ... verified` -> relaunch
+-> `first Present: backbuffer 2048x2048`. The engine accepts a non-display-mode square size in
+windowed mode without complaint.
+
+Two caveats. The write survived process exit in testing, but the harness hard-kills the
+process, which skips the game's orderly `SaveConfig` - whether a clean quit through the menu
+clobbers it is NOT yet tested. And `HorizontalFOV=130` currently sits in the shipped user ini,
+which is the mod's own live FOV write having been saved by the game at some earlier exit.
+
+A user datapoint that corroborates the whole thesis, independently: on a Dream Air they found
+their runtime's own resolution slider did nothing (it cannot - nothing in the mod reads
+`recommendedImageRect`), and editing this file to 7680x4320 made the image "super crisp". At
+our 130 option and 16:9, only about 4120x4270 of that 7680x4320 falls inside a ~49x50 deg
+eye: 17.6 MP useful out of 33.2 MP rendered, ~53% efficiency, matching the ~54% figure
+already recorded above. The same sharpness is available near-square for ~18 MP. It also caps
+how aggressively a derived target may clamp: 33 MP is a resolution a real user is happily
+running, so any total-pixel ceiling must be generous and overridable.
+
+### Superseded: the earlier "still unmeasured" note on the world lens aspect law
 
 At 1920x1080 the live watch reads `tanH=2.1445 tanV=1.2063`, i.e. `tanV/tanH = 0.5625 =
 9/16` exactly, consistent with `tanH = tan(option/2)` and a vertical derived from the

--- a/docs/bioshock1/ENGINE_NOTES.md
+++ b/docs/bioshock1/ENGINE_NOTES.md
@@ -2659,6 +2659,63 @@ at): `WORLD tanH=1.191754 tanV=1.191754 (hfov 100.00 deg, 6/8 votes)`,
 **no `rendered-fov mismatch ON` line anywhere in the run** where session 27 had one within
 seconds of reaching gameplay.
 
+### 4b. The hands moving with the head was the SAME defect, seen from the other side
+
+Reported immediately after the warp fix landed in-headset: the world stopped warping and **the
+hand/gun model started moving with the headset** - the thing sessions 13-16 were spent fixing.
+It is not a regression in the hands machinery. It is one claim serving two lenses.
+
+**One projection layer carries ONE fov claim for the whole eye image, and the world and the
+viewmodel were rendered through DIFFERENT frustums.** So only one of them can be geometrically
+correct at a time:
+
+| claim | world | viewmodel |
+|---|---|---|
+| fg lens `0.6704` (the pre-session-28 bug) | 1.78x wrong -> **warps** | correct |
+| world lens `1.1918` (after the watch fix) | correct | 1.78x wrong -> **moves with the head** |
+| lenses MATCHED, either claim | correct | correct |
+
+The error is angular gain: a viewmodel feature at fg-angle `t` is displayed at
+`atan(tan(t)*1.7778)`, so it swings 1.78x too far as the head turns - which reads exactly as the
+gun sliding off the hand. Fixing the world did not break the hands; it moved a pre-existing 1.78x
+error from the world onto the hands, and the only state where both are right is matched lenses.
+
+**Second, coupled cause, in the bone solve.** `bones.cpp render_lock_delta` carried the comment
+"with the lens match armed the rig renders through the WORLD lens ... the lens ratio k collapses
+to 1". That was TRUE at 16:9 and false everywhere else: with the shipped `0.75` the real ratio at
+a square backbuffer is 1.7778, so the depth constraint `wStar = k*df` and the head-split lateral
+cancel were both mis-scaled - and the lateral cancel is precisely the term that stops the rig
+sliding under head motion. `world_ndc` had the same hardcoded `9/16` for the WORLD lens, which is
+independently wrong off 16:9. Both now read the live backbuffer aspect via
+`bvr::hud::backbuffer_dims`, and with the matched fg write `k` genuinely collapses to 1 - the
+assumption is earned rather than asserted.
+
+**Flat gate, and it is the same instrument that found the original bug.** At 2048x2048,
+`decode-framedump.ps1` went from two clusters to **ONE**:
+
+```
+before:  cluster tanH=1.1918 tanV=1.1918  draws=154  b0tiers[320:47 576:42 832:65]
+         cluster tanH=0.6704 tanV=0.6704  draws=24   b0tiers[576:20 832:4]
+after:   cluster tanH=1.1918 tanV=1.1918  draws=132  b0tiers[320:57 576:39 832:36]
+```
+
+The 576-byte foreground tier is now INSIDE the world cluster - the fg draws carry the world's
+tangents. `fovaudit` agrees: `lenses=1`, `fg lens match ON (last written 115.6 deg, k=1.333333)`.
+The engine accepted the wider write without clamping (115.6 deg at option 100 square; measured
+`tan(57.8)*0.75 = 1.1918` == the world vertical, exact). `vrfgfov legacy on` puts the second
+cluster back and `legacy off` removes it again, verified both directions - an instant in-headset
+A/B.
+
+**What flat CANNOT confirm**, stated so nobody assumes it was: the bone-solve half. With no XR
+session there are no controller poses, so the hands drive never engages (`inst=0 writes=0
+solves=0`) and `render_lock_delta` is never entered. The lens geometry it depends on is proven;
+the solve itself needs the headset.
+
+**Carry:** the session-16 hand offsets in `vrpreset.ini` were tuned in-headset against the OLD,
+1.78x-narrow fg lens at a square backbuffer, so part of those numbers may have been compensating
+for the lens error. They may want a re-tune now that the projection is honest. `vrfgfov legacy on`
+is the comparison lever.
+
 ### 5. The foreground-lens aspect law, and the `0.75` it condemns
 
 Stage 2's blocked measurement (b) is answered by the same dumps. `camera.cpp`'s foreground match

--- a/docs/bioshock1/ENGINE_NOTES.md
+++ b/docs/bioshock1/ENGINE_NOTES.md
@@ -2401,7 +2401,39 @@ followed, so the resolution change never began. Notes:
 - This is also the first real exercise of the exec failure latch: the fault disabled the
   seam for the session with one clear line, instead of being retried every 15 s.
 
-### MEASURED: the world lens is Hor+ with a fixed vertical, and the option is 16:9-referenced
+### RETRACTED - the "Hor+ with a fixed vertical" law below is NOT established
+
+**Read this before acting on the section that follows.** A third reading contradicts it. Same
+backbuffer (2048x2048), same `option=130`, two different results:
+
+| sample | rendered tanH | tanV | age |
+|---|---:|---:|---|
+| in gameplay, right after boot | 1.2063 | 1.2063 | 16 ms (fresh) |
+| later, same session | **2.1445** | **2.1445** | 9016 ms (STALE) |
+
+`2.1445 = tan(65)` exactly, which is what the ORIGINAL assumption predicts (option is a true
+horizontal, vertical follows aspect). So the rendered projection is not a clean function of
+(option, aspect) - something else varies between samples, and the 9 s stale age means the
+second one may not be a gameplay world draw at all.
+
+The law below was derived from a single pair of readings and does not survive the third. The
+code changes it motivated (submission claim, suggested-option formula, and the fov-mismatch
+verdict) were written, built, and then **reverted unbuilt-upon** rather than shipping a
+plausible-but-unproven formula into the submission path - the mismatch verdict in particular
+feeds `vr::cinematic_active()`, so getting it wrong drops normal gameplay onto the big-screen
+quad.
+
+What went wrong methodologically: every sample was taken through `fovaudit live`, whose value
+can be stale, and the state at sample time (gameplay world draw vs menu vs scripted camera)
+was not pinned. A correct measurement needs the sample age checked (<500 ms), the view state
+confirmed as strict gameplay, and - crucially - a LIVE XR SESSION, because the submitted side
+of the comparison does not exist flat (`swap=0x0`, `submitted tanH=0.000000`). Flat testing
+cannot close this one.
+
+Keep from below: the ini lane and the square-backbuffer results are independently verified and
+stand. The pixel-efficiency arithmetic stands. The FOV law does not.
+
+### UNPROVEN (see retraction above): the world lens is Hor+ with a fixed vertical
 
 Two `fovaudit live` readings of the rendered projection, same `option=130`, different
 backbuffer, taken through the ini lane below:

--- a/docs/bioshock1/ENGINE_NOTES.md
+++ b/docs/bioshock1/ENGINE_NOTES.md
@@ -2355,3 +2355,57 @@ heaps/blocks walked and the exclusion-span count.
 bytes were actually readable behind the array pointer, so a plausible count paired with a
 bad pointer was a multi-kilobyte write into whatever followed. The SEH guard on `write_n`
 made that survivable, not correct; the span is now validated before the pair is trusted.
+
+### Measured: where each object actually lives
+
+From a boot-to-gameplay run with the new scanner (12-core machine, 1920x1080, no headset):
+
+| object | found by | cost | matches |
+|---|---|---|---|
+| `UShockUserSettings` | **live-heap path**, block prefix | **62 ms**, 271k blocks over 10 heaps | 1, accepted, class `ShockUserSettings` (FName index 2137) |
+| `APlayerWeapon` | region sweep only | 3773 ms of work over **888 slices** | 4, none accepted |
+
+So the settings singleton IS a Win32 heap allocation near its block start, and the fast
+path resolves it two orders of magnitude quicker than the old blocking walk. Engine ACTORS
+are not found in a heap-block prefix - either they sit deeper in their block or they come
+from a pool `HeapWalk` does not describe. The block probe prefix was widened from 64 to 256
+bytes to give the first case a chance; if actor scans still fall through to the sweep, the
+remaining option is enumerating `GObjObjects` (not yet derived), which would retire object
+scanning altogether.
+
+The important part is that the sweep's 3.8 s of work no longer arrives as a 3.8 s stall:
+across all 888 slices the camera heartbeat held 1600-2100 calls/s with no dip.
+
+### `SETRES` through the viewport Exec seam FAULTS - do not ship a live resolution change on it
+
+Measured directly, in gameplay, with the seam that already handles `set ...` successfully:
+
+```
+[b1r] exec fault: eip=106B2353 (exe+0x4C2353) fault-addr=000099DA
+[b1r] viewport exec FAULTED on 'setres 1400x1400w' (SEH caught ...)
+```
+
+A near-null dereference deep inside the engine's own Exec chain, and no `ResizeBuffers`
+followed, so the resolution change never began. Notes:
+
+- The stack stayed BALANCED (the new esp check did not fire), so this is not the
+  FOutputDevice stub's argument-count hazard. `set ShockPlayer ...` through the same
+  machinery works on every run, so the seam itself is sound - something specific to
+  `SETRES` is unhappy, most likely wanting a real output device or a different `this`.
+- `patterns.h` has advertised `UWindowsViewport::Exec` as handling `SETRES`/
+  `TOGGLEFULLSCREEN` since it was derived. Nothing had ever actually called it. It is now
+  measured, and the answer is no.
+- Consequence for the resolution work: the persistence lane (writing the game's own
+  `Bioshock.ini` viewport keys before launch) is the PRIMARY mechanism, not the fallback.
+  A live in-session change stays unavailable until this fault is root-caused.
+- This is also the first real exercise of the exec failure latch: the fault disabled the
+  seam for the session with one clear line, instead of being retried every 15 s.
+
+### Still unmeasured: the world lens aspect law
+
+At 1920x1080 the live watch reads `tanH=2.1445 tanV=1.2063`, i.e. `tanV/tanH = 0.5625 =
+9/16` exactly, consistent with `tanH = tan(option/2)` and a vertical derived from the
+render aspect. But 9/16 IS the render aspect here, so this run cannot distinguish
+"vertical derived from aspect" from "vertical hardcoded to 9/16". Discriminating it needs a
+non-16:9 backbuffer, and with `SETRES` dead that now requires an ini change plus a
+relaunch. Until then the foreground-lens aspect correction is unproven and must not ship.

--- a/docs/bioshock1/ENGINE_NOTES.md
+++ b/docs/bioshock1/ENGINE_NOTES.md
@@ -2224,3 +2224,134 @@ Evidence from the surviving logs of that machine:
 
 Still open: defer swapchain destruction on REAL size changes to a safe point in the
 frame loop (never between xrBeginFrame/xrEndFrame); the pacing oscillation.
+
+## Session 27 - the object scanner was the freeze, and probably the crash
+
+A third report from the same external machine (`bvr_20260729_163118.dmp` + log, v0.4.1)
+crashed at the MAIN MENU 85 s in with `0xC0000374` (STATUS_HEAP_CORRUPTION) raised from
+ntdll's heap-verification path: whole stack in ntdll, `fault addr 0`, tid 4072. A heap
+fail-fast always reports the allocator operation that NOTICED, never the write that did
+the damage, so there is no mod frame on that stack by construction. The log, though,
+identifies the object scanner as the only mod machinery active in that window.
+
+### The region filter admitted thread stacks, and the sweep matched its own argument
+
+`region_scannable` accepted `MEM_COMMIT | MEM_PRIVATE | PAGE_READWRITE` under a comment
+saying "the object lives on the heap". That filter excludes `MEM_IMAGE` and `MEM_MAPPED`;
+it does NOT exclude stacks, TEBs or PEBs, which are all exactly
+`MEM_PRIVATE | PAGE_READWRITE`. Every thread stack in the process was therefore swept.
+
+The two false positives in the log prove the mechanism exactly:
+
+```
+[b1r] UShockUserSettings vtable match @ 00D3F1B0 HorizontalFOV=643373088
+[b1r] UShockUserSettings vtable match @ 00D3F1F0 HorizontalFOV=1444230
+crash: eip=76F86F73 esp=00D3F230 ebp=00D3F268
+```
+
+Both are 0x40 apart and sit 0x40 to 0x80 BELOW the crashing thread's esp. The old
+`scan_region` took eight arguments, so `wantVtable` - the value being searched for - was
+pushed onto the scanning thread's own stack on every call, and nested frames held a
+second copy. **The sweep was finding its own argument spill.** The shape had been noted
+three times before (STATUS sessions 18 and 22, bioshock2 ENGINE_NOTES) as a curiosity for
+the per-callsite accept filter to reject, never as a safety problem. `value_scan.cpp` had
+carried self-match hygiene since it was written; the vtable scanner never did.
+
+### Two predicates were guarding three unguarded writes
+
+The entire identity test was `dword0 == imageBase + 0xDA3878` plus `int32 at +0x8C` in
+`[40,170]`. `is_memory_valid` checks page protection only, so it cannot distinguish a live
+allocation from a freed block or a stack slot. And the consumer WRITES: three sites (the
+CalcView FOV write, its restore, and the scenedraw stale-restore) poked an int32 at
+`+0x8C` with no SEH and no ownership check.
+
+The leading explanation for the `0xC0000374`, consistent with every detail including tid
+4072 being the scanning thread: a freed UShockUserSettings-shaped block keeps its vtable
+dword until the allocator reuses it, the cache revalidation kept calling it valid, and an
+int32 written into it smashed free-list bookkeeping. Two related paths: a stack slot whose
+`+0x8C` happened to fall in `[40,170]` would have been accepted and written every
+CalcView, and `g_savedGameFov` captured from object A could be restored into object B
+after a re-scan.
+
+### The freeze was the same code, measured
+
+One UShockUserSettings pass in that log spans 16:30:07.804 to 16:30:10.896 - over 3 s of
+blocked game thread, inside `eventPlayerCalcView`. Across each APlayerWeapon pass the
+camera heartbeat drops from ~90 to 16 calls/s. Cost per futile pass had already been
+measured at 1-4 s (STATUS session 18).
+
+Why it kept happening despite the session-22 fix:
+
+- `hfov_option_ptr` had a 2000 ms rate limit and **no backoff and no dormancy at all**.
+- The weapon resolver's dormancy was a caller-local `static uint32_t nullResolves` that
+  **any single momentary success zeroed**. `weapon_valid()` is two chained vtable compares
+  on memory the mod does not own, so a stack slot or a churning heap block satisfies it
+  transiently, the counter resets, and the walks resume. That is the ~3 s cadence in the
+  log.
+- `aim.cpp`'s comment "no cutscene/menu heap scans" was false: its `g_gameplayView`
+  deliberately counts the menu attract scene as gameplay, which is how full 4 GB walks
+  came to run at the main menu - the exact window this tester dies in.
+
+### What replaced it
+
+`core/hooks/heap_scan.{h,cpp}`, game-agnostic:
+
+- **Thread stacks, TEBs and PEBs excluded exactly.** Once per pass every thread is
+  enumerated (`Thread32First` plus `NtQueryInformationThread` -> `TebBaseAddress` ->
+  `NT_TIB.StackBase/StackLimit`), the whole stack ALLOCATION is excluded rather than just
+  its committed part, and the current thread is added unconditionally. A
+  guard-page-below probe is a second line for a thread that could not be opened, and
+  threads we failed to query are counted and logged rather than silently swept.
+- **The needle is never a live value.** The comparison is
+  `(*p ^ mask) == (needle ^ mask)`, so the raw vtable address does not exist in the
+  sweep's frame at all.
+- **A live-heap fast path first.** `heap_blocks()` walks the BUSY blocks of every process
+  heap under `HeapLock`, testing only blocks large enough to hold the object and probing a
+  few aligned offsets to allow for an allocator header. Two wins: tens of milliseconds
+  instead of seconds, and HeapWalk only reports ALLOCATED blocks, so a freed block cannot
+  be handed to a caller that is about to write to it. `HeapUnlock` runs on the fault path
+  too - a fault escaping with a heap lock held would wedge that heap for the life of the
+  process.
+- **The region sweep survives only as a sliced fallback**, for an engine that allocates
+  from its own VirtualAlloc'd pools. 4 ms wall-clock budget per slice, resumable from a
+  saved cursor, so no single call can stall a frame.
+- **No logging or allocation inside the SEH guard.** MSVC under `/EHsc` does not run C++
+  destructors during SEH unwinding, so a fault taken while the log mutex was held left it
+  held for the life of the process - a silent-freeze class that was live in every accept
+  filter that logged. Candidates, plus four diagnostic ints each, are recorded into a POD
+  array and formatted after the guard returns.
+
+Per-game policy in `patterns.cpp`:
+
+- **UObject corroboration.** `object_class_name()` already walked
+  `obj -> +0x30 UClass* -> UClass vtable identity -> +0x28 FName index -> GNames` with
+  every step validated. Requiring a non-null result is a far stronger test than the vtable
+  dword alone. Deliberately NOT compared against an expected name - the live instance
+  could be a subclass, and rejecting it would silently disable FOV control - so the
+  resolved name is logged instead, and tightening it later is one line backed by real data.
+- **The FOV plausibility window narrowed to the options UI's own 75-130**, from 40-170.
+- **A structural dormancy latch** for both scanners, backported from bioshock2r: a success
+  clears the miss COUNT, only an explicit `hfov_scan_rearm()` or
+  `aim::weapon_scan_rearm()` clears dormancy. Both are called from the one event that
+  plausibly created what they were looking for - the gameplay-view transition in
+  `CalcViewDetour`.
+- **The weapon scan gate moved to the strict `body::is_gameplay_view`**, so it cannot run
+  at the menu.
+- **Fail closed on ambiguity**: more than one accepted candidate refuses to bind at all.
+
+### Diagnostics that were actively misleading
+
+`accept_weapon` returns `false` on every path and communicates through
+`WeaponScanCtx::best`, which was never logged. So
+`APlayerWeapon scan: 1 vtable match(es), chosen=00000000` was **unconditional and
+structurally meaningless** - an external log could not say whether the resolver had
+succeeded or failed. It now reports the real outcome (ATTACHED to the rig / nearest to the
+gun spot / NONE), and the summary line carries the path taken, elapsed ms, slices,
+heaps/blocks walked and the exclusion-span count.
+
+### Also hardened here
+
+`resolve_skel` bounded the bone count at 128 but never checked that `count * sizeof(Qts)`
+bytes were actually readable behind the array pointer, so a plausible count paired with a
+bad pointer was a multi-kilobyte write into whatever followed. The SEH guard on `write_n`
+made that survivable, not correct; the span is now validated before the pair is trusted.

--- a/docs/bioshock2/ENGINE_NOTES.md
+++ b/docs/bioshock2/ENGINE_NOTES.md
@@ -288,3 +288,86 @@ Menu-controller note: the 0x106EE20 view-actor vtable is plain **APlayerControll
   that cracked the dead-thunk mystery; do it BEFORE hooking, not after.)
 - **Scan hygiene** (LAA: actors allocate above 2 GB, so any future heap scan walks the full 4 GB
   range; no scans on a cadence - BS1 needed backoff AND dormancy; prologue-gate every hook).
+
+## Resolution, lens laws and the viewmodel: what BS1 hit, and how to check BS2 (banked session 28)
+
+**Nothing here is a BS2 measurement.** It is the BS1 defect class written up as a checklist,
+because all three of BS1's session-27/28 bugs came from ONE cause and BS2 is likely to have the
+same shape. Per the standing policy (BS2 is not bound by BS1's methods): check whether the defect
+EXISTS before porting any of the cure, and **derive every number fresh** - the never-copy rule
+applies to lens constants exactly as it does to addresses.
+
+### The BS1 cause, in one sentence
+
+A frame carried TWO perspective lenses with OPPOSITE aspect conventions - the world pass fixed its
+HORIZONTAL half-tangent (`tanH = tan(option/2)`, `tanV = tanH*h/w`) and the foreground/viewmodel
+pass fixed its VERTICAL (`tanV = tan(fgFov/2)*3/4`, `tanH = tanV*w/h`) - and because they coincide
+EXACTLY at 16:9, every measurement taken at 1920x1080 for six sessions saw one lens and could not
+tell the two laws apart.
+
+### The three symptoms it produced, all the same defect
+
+1. **World warps on head turn at non-16:9.** The live fov watch sampled the FIRST decodable scene
+   draw, the fg draws come first, so off 16:9 it reported the VIEWMODEL lens as the world lens. The
+   mismatch verdict then latched ON during normal gameplay and the projection claim was substituted
+   with the viewmodel frustum - a 1.84x under-claim, so the compositor mis-reprojected every
+   rotation by `atan(k*tan(d)) - d`.
+2. **Viewmodel moves with the head.** ONE projection layer carries ONE fov claim for the whole eye
+   image, so while the two lenses differ only one of {world, viewmodel} can be geometrically
+   correct. Fixing (1) moved the same 1.78x error from the world onto the hands. Only MATCHED
+   lenses make both right.
+3. **A FOV policy derived from the wrong law.** BS1's "129.5 circumscribing" preset value solved
+   `tan(option/2)*9/16*aspect = tan(H/2)`, which is the law that turned out to be the FOREGROUND's.
+   Under the real world law the option needs no aspect term at all.
+
+### The checks for BS2, in order, each cheap
+
+1. **Does BS2 even have two lenses?** Run `dumpframe full` at a NON-16:9 backbuffer and decode with
+   `tools/decode-framedump.ps1` (it applies the structural zero-slot validation; the live watch is
+   the thing that got this wrong on BS1). **One cluster = BS2 does not have the split and symptoms
+   1-2 cannot occur.** There is real reason to expect this: session 25 measured that BS2's
+   foreground follows the world FOV NATIVELY (poking the option re-lensed the drill viewmodel with
+   the world), which is why none of BS1's fg counter-model was ported. If that holds off 16:9 too,
+   BS2 is already in the state BS1 had to be fixed into.
+2. **If there are two clusters**, identify which is the foreground before believing either: toggle
+   whatever writes the fg lens (BS1 used `vrfgfov on/off`) and re-dump. The cluster that MOVES is
+   the foreground. Do not infer it from draw counts or cb tier alone - on BS1 the 576/832 tiers were
+   shared between both clusters.
+3. **Derive BS2's world law from two backbuffers, not one.** Sweep the FOV option at 16:9 AND at a
+   square-ish backbuffer. If `tanH` is unchanged by aspect the option is a true horizontal (BS1's
+   world law); if `tanV` is unchanged, it is a 16:9-referenced horizontal. A single aspect cannot
+   distinguish them - that is the trap that cost BS1 two sessions.
+4. **Check the claim against the WORLD lens with a live session.** The submitted side does not exist
+   flat (`swap=0x0`, `submitted tanH=0.000000`), so this needs the headset. And note the BS1 lesson:
+   `src=live` on the audit line means "this came from the watch", NOT "this is correct". A source
+   tag is not a correctness proof.
+5. **If BS2 needs a fg match at all**, the aspect-general constant is `(4/3)*(h/w)`, NOT `0.75`.
+   `0.75` is that expression evaluated at 16:9. BioVRDev reached the same generalization
+   independently for BS1 (`2*atan(tan(fov/2)*(4/3)/aspect)`, RESEARCH.md) - but the `4/3` and `3/4`
+   in it are BS1's foreground spec, measured from its cb0 fingerprint. **Measure BS2's own fg spec
+   from its own dump before reusing those numbers.**
+6. **Grep BS2 for hardcoded aspect constants** before shipping any non-16:9 support. On BS1 the
+   coupled ones were the fg match constant, the bone solve's world model AND its fg model, and the
+   audit's option-derived fallback - four places, all `9/16` or `0.75`, all silently correct at
+   16:9. `bioshock2r/camera.cpp`'s `fovaudit` already carries the same `9/16` flat fallback.
+
+### Infrastructure BS2 inherits for free (core, already shared)
+
+`core/gfx/hud_capture.cpp`'s watch is game-agnostic and already fixed: it stride-samples up to 8
+cb0 heads across the whole pass, clusters them, publishes the majority as the world lens and the
+runner-up as the fg lens, enforces the structural zero-slot checks and a 500 ms age gate at the
+source, and refuses a round that lacks a clear majority or failed to span its pass.
+`bvr::hud::fov_watch_fg` / `fov_lens_count` / `backbuffer_dims` are available to b2r now.
+**So on BS2, `fovaudit` reporting `lenses=2` off 16:9 is the alarm, and `lenses=1` is the
+all-clear** - the diagnosis BS1 lacked is already in place before BS2 needs it.
+
+### Resolution changes are dynamic on BS1 - keep it that way on BS2
+
+Everything aspect-dependent reads the live backbuffer every frame rather than caching at init:
+`backbuffer_dims` is published unconditionally at the head of the present detour (deliberately
+BEFORE the letterbox watch's format whitelist and staging allocation, so lens correctness cannot
+depend on an unrelated detector managing to allocate), the fg match constant is recomputed per
+CalcView, the bone solve reads it per solve, and the XR claim derives from the rebuilt swapchain
+dims. A user changing resolution mid-session or via the ini therefore needs no relaunch for the
+lens math to follow. BS2's `SETRES` situation may differ; BS1's viewport-Exec `SETRES` FAULTS, so
+its ini lane is primary.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,6 +39,8 @@ add_library(bioshockvr SHARED
     core/vr/openxr_runtime.h
     core/util/log.cpp
     core/util/log.h
+    core/util/module_id.cpp
+    core/util/module_id.h
     core/util/crash.cpp
     core/util/crash.h
     game/adapter_registry.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,8 @@ add_library(bioshockvr SHARED
     core/gfx/hud_capture.h
     core/hooks/d3d11_hook.cpp
     core/hooks/d3d11_hook.h
+    core/hooks/heap_scan.cpp
+    core/hooks/heap_scan.h
     core/hooks/pattern_scan.cpp
     core/hooks/pattern_scan.h
     core/input/xinput_bridge.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,8 @@ add_library(bioshockvr SHARED
     game/bioshock1r/camera.cpp
     game/bioshock1r/camera.h
     game/bioshock1r/console_exec.cpp
+    game/bioshock1r/game_ini.cpp
+    game/bioshock1r/game_ini.h
     game/bioshock1r/console_exec.h
     game/bioshock1r/frame_context.h
     game/bioshock1r/hands.cpp

--- a/src/core/framework/framework.cpp
+++ b/src/core/framework/framework.cpp
@@ -65,11 +65,43 @@ void log_environment() {
             static_cast<unsigned long long>(mem.ullTotalPhys >> 20), laa ? "yes" : "NO",
             static_cast<unsigned long long>(
                 reinterpret_cast<uintptr_t>(si.lpMaximumApplicationAddress) >> 20));
+
+    // THE HOST EXE FINGERPRINT (session 27). Until now the log identified the
+    // mod's build but said nothing about the game's, while the adapters trust
+    // roughly a hundred absolute RVAs derived from one specific build. Every
+    // storefront ships the same file NAME, so exe-name matching cannot tell a
+    // Steam build from an Epic or GOG one - which means a different binary is
+    // detected as supported and then mis-scanned. This line is what lets a
+    // user's log answer "is this the build our addresses are for?" in one look.
+    if (hostNt) {
+        LARGE_INTEGER fileSize{};
+        wchar_t exeW[MAX_PATH]{};
+        if (GetModuleFileNameW(nullptr, exeW, MAX_PATH)) {
+            WIN32_FILE_ATTRIBUTE_DATA fad{};
+            if (GetFileAttributesExW(exeW, GetFileExInfoStandard, &fad)) {
+                fileSize.HighPart = static_cast<LONG>(fad.nFileSizeHigh);
+                fileSize.LowPart = fad.nFileSizeLow;
+            }
+        }
+        BVR_LOG("host exe: pe-timestamp 0x%08X size-of-image 0x%08X checksum 0x%08X "
+                "file-bytes %llu",
+                hostNt->FileHeader.TimeDateStamp, hostNt->OptionalHeader.SizeOfImage,
+                hostNt->OptionalHeader.CheckSum,
+                static_cast<unsigned long long>(fileSize.QuadPart));
+    } else {
+        BVR_LOG("host exe: PE headers unreadable - the build cannot be identified");
+    }
 }
 
 } // namespace
 
 void init() {
+    // The exception filter goes on FIRST (session 27). Everything below it -
+    // shell32 path lookups, MoveFileExW of the previous log, the PE header walk -
+    // used to run with no handler installed, so a fault in any of it produced
+    // neither a dump nor a log line.
+    crash::install();
+
     // Host detection is silent by contract (the log does not exist yet); the
     // game layer supplies the per-game data subdir so two games never share a
     // log/config folder.
@@ -81,8 +113,6 @@ void init() {
     BVR_LOG("host process: %s (base %p)", exePath, GetModuleHandleW(nullptr));
 
     log_environment();
-
-    crash::install();
 
     MH_STATUS status = MH_Initialize();
     if (status != MH_OK) {
@@ -96,12 +126,20 @@ void init() {
 
     game::init_adapter(); // fail-soft: scan/hook failure is logged, game runs flat
 
-    vr::init_instance(); // fail-soft: no runtime just means flat mode
-
+    // The swapchain hooks go in BEFORE the OpenXR instance (session 27). The
+    // first OpenXR call LoadLibrary's the runtime and every implicit API layer,
+    // and there is no timeout anywhere in that path - on a machine where the
+    // runtime is waiting on its streamer it can block indefinitely. With the
+    // old order that cost us the Present detour, and with it crash::rearm(),
+    // whose only caller is that detour: the session then ran with whatever
+    // exception filter had displaced ours (CSERHelper) and produced no dumps at
+    // all. This way a hanging runtime costs VR and nothing else.
     if (!d3d11_hook::install()) {
         BVR_LOG("D3D11 hook install failed - mod disabled, game runs flat");
         return;
     }
+
+    vr::init_instance(); // fail-soft: no runtime just means flat mode
 
     BVR_LOG("init complete; waiting for first Present");
 }

--- a/src/core/gfx/hud_capture.cpp
+++ b/src/core/gfx/hud_capture.cpp
@@ -327,20 +327,9 @@ void fov_watch_on_present(ID3D11DeviceContext* ctx) {
     float optHfov = bvr::vr::rendered_hfov_deg();
     bool mm = false;
     if (fresh && optHfov > 1.0f) {
-        // Compare the VERTICAL. Under the measured law the option fixes
-        // tanV = tan(option/2)*9/16 and the horizontal is derived from the render
-        // aspect, so the vertical is the aspect-FREE primitive: this needs no
-        // aspect input at all. Comparing the horizontal against tan(option/2) is
-        // only valid at 16:9, and on a near-square resolution it read as a
-        // permanent mismatch - which this verdict feeds to cinematic_active(), so
-        // it would latch normal gameplay onto the big-screen quad. Dividing by a
-        // live aspect is worse: the aspect would come from whichever render
-        // target happens to be bound, which flickers between the scene and HUD
-        // targets and made the verdict oscillate. A scripted camera still moves
-        // tanV, so the detector keeps doing its original job.
-        float expectTanV = tanf(optHfov * 0.5f * 3.14159265f / 180.0f) * (9.0f / 16.0f);
-        if (expectTanV > 0.01f) {
-            float r = g_fovTanV.load(std::memory_order_relaxed) / expectTanV;
+        float optTan = tanf(optHfov * 0.5f * 3.14159265f / 180.0f);
+        if (optTan > 0.01f) {
+            float r = g_fovTanH.load(std::memory_order_relaxed) / optTan;
             mm = r < 0.90f || r > 1.10f;
         }
     }

--- a/src/core/gfx/hud_capture.cpp
+++ b/src/core/gfx/hud_capture.cpp
@@ -295,18 +295,32 @@ void letterbox_watch(ID3D11DeviceContext* ctx, IDXGISwapChain* swapchain) {
         }
     }
 
-    // Queue this present's copy: three 1-px columns at 1/4, 1/2, 3/4 width.
-    if (g_lbPending || !swapchain) return;
+    if (!swapchain) return;
     ID3D11Texture2D* bb = nullptr;
     if (FAILED(swapchain->GetBuffer(0, IID_PPV_ARGS(&bb))) || !bb) return;
     D3D11_TEXTURE2D_DESC bd{};
     bb->GetDesc(&bd);
+
+    // Session 28: publish the backbuffer dims UNCONDITIONALLY, before any of the
+    // letterbox watch's own gates. Both lens laws are aspect-parameterised and
+    // read these (the foreground match constant in camera.cpp, the world and fg
+    // models in bones.cpp), so a user on a backbuffer format outside the watch's
+    // RGBA8 whitelist - or one where the staging allocation failed - would have
+    // silently fallen back to the 16:9 constants and got the 1.78x viewmodel
+    // error back. Correct lens geometry must not depend on whether an unrelated
+    // black-bar detector could allocate.
+    g_lbSrcW = bd.Width;
+    g_lbSrcH = bd.Height;
+
+    // Queue this present's copy: three 1-px columns at 1/4, 1/2, 3/4 width.
+    if (g_lbPending) {
+        bb->Release();
+        return;
+    }
     if ((bd.Format == DXGI_FORMAT_R8G8B8A8_UNORM ||
          bd.Format == DXGI_FORMAT_R8G8B8A8_UNORM_SRGB ||
          bd.Format == DXGI_FORMAT_B8G8R8A8_UNORM) &&
         ensure_lb_staging(ctx, bd.Height)) {
-        g_lbSrcW = bd.Width;
-        g_lbSrcH = bd.Height;
         for (int c = 0; c < kLbCols; ++c) {
             UINT x = bd.Width * (c + 1) / 4;
             D3D11_BOX box{x, 0, 0, x + 1, bd.Height, 1};

--- a/src/core/gfx/hud_capture.cpp
+++ b/src/core/gfx/hud_capture.cpp
@@ -68,20 +68,65 @@ bool g_hadHudLastInterval = false;
 std::atomic<unsigned> g_cHudDraws{0}, g_cRedirects{0}, g_cLeaks{0}, g_cIntervals{0};
 
 // ---- Session 22: live rendered-FOV watch (see hud_capture.h) ----------------
-// One 80-byte staging buffer: the first scene draw of an interval copies the
-// head of its VS b0 into it (CopySubresourceRegion, async); the copy is
-// mapped on a LATER present with DO_NOT_WAIT, so the pipeline never stalls.
-// Tangent layout (session 21, dump-verified): floats 12..18 hold the
-// screen-ray helper (2tanH, 0, -tanH, 0, 0, -2tanV, tanV); the two
-// derivations must agree or the block is not a perspective pass.
+// Staging buffer of kFovSlots x 80 bytes: through one present interval, each
+// scene draw whose VS b0 buffer OBJECT differs from the last copies the head of
+// that buffer into the next slot (CopySubresourceRegion, async); the whole
+// staging buffer is mapped on a LATER present with DO_NOT_WAIT, so the pipeline
+// never stalls. Tangent layout (session 21, dump-verified): floats 12..18 hold
+// the screen-ray helper (2tanH, 0, -tanH, 0, 0, -2tanV, tanV).
+//
+// SESSION 28 - WHY THIS SAMPLES MANY BLOCKS AND VOTES, instead of taking the
+// first one. A frame carries TWO perspective lenses, and off 16:9 they DIFFER:
+// the world pass is horizontal-anchored (tanH = tan(option/2), tanV follows the
+// window) while the FOREGROUND/viewmodel pass is vertical-anchored (tanV =
+// tan(fgFov/2)*3/4, tanH follows the window). At 16:9 the two coincide exactly,
+// which is why every measurement up to session 27 saw one cluster. Off 16:9 they
+// split by (16/9)*(h/w) - 1.84x at 2750x2850.
+// The old watch took the FIRST decodable draw of the interval, and the fg draws
+// are the first draws of the main pass on a 576-byte tier that clears the >=320
+// gate - so it reported the VIEWMODEL lens as the world lens, the mismatch
+// verdict latched permanently ON during normal gameplay, and the projection
+// layer was then tagged with the viewmodel frustum (openxr_runtime's
+// fovMm && stereoCine claim substitution). That 1.84x under-claim WAS the
+// session-27 yaw-warp bug. Measured: dumpframe at 2750x2850 option 100 ->
+// world 1.1918/1.2351 on 154 draws, fg 0.6468/0.6704 on 24 draws (20 of them
+// the 576-byte fg tier); `vrfgfov off` moved only the second cluster, to the
+// documented native fg pair 0.4178/0.4330.
+// So: sample several distinct blocks, cluster them, and publish the cluster the
+// MOST distinct buffers agree on. The world pass outnumbers the foreground pass
+// roughly 6:1, exactly as tools/decode-framedump.ps1 clusters it offline.
 constexpr UINT kFovCbBytes = 80; // floats 0..19
+constexpr int kFovSlots = 8;
 ID3D11Buffer* g_fovStaging = nullptr;
 bool g_fovPending = false; // copied, not yet mapped
 int g_fovPendingAge = 0;   // presents since the copy
-int g_fovTriesThisInterval = 0;
-bool g_fovCapturedThisInterval = false;
+int g_fovSlots = 0;        // slots filled in the round being collected
+int g_fovPendingSlots = 0; // slots the outstanding map must decode
+// STRIDE sampling (session 28, second cut). Taking the first kFovSlots distinct
+// buffers is NOT representative: the foreground pass draws FIRST, so 5 of the
+// first 8 distinct buffers were fg and the majority vote picked the viewmodel
+// lens anyway (measured at 2048x2048: "WORLD tanH=0.670361 ... 5/8 votes", which
+// is the fg pair). Spread the slots across the WHOLE pass instead, using the
+// previous interval's distinct-buffer count to pick the stride. The world pass
+// feeds ~300 distinct buffers to the foreground's ~24, so a spread sample wins
+// it by better than 10:1.
+int g_fovDistinct = 0;     // distinct cb0 objects seen this interval
+int g_fovDistinctPrev = 0; // ...and in the previous one, for the stride
+int g_fovStrideUsed = 1;   // stride the collected round actually used
+int g_fovCollectDistinct = 0; // distinct count of the interval it was collected in
+int g_fovAmbiguous = 0;    // rounds refused for want of a clear majority
+int g_fovUnspanned = 0;    // rounds refused because the sample missed the pass
+// Identity only - never dereferenced. A recycled pointer costs one skipped
+// sample, nothing more.
+ID3D11Buffer* g_fovLastCb = nullptr;
 std::atomic<float> g_fovTanH{0.0f}, g_fovTanV{0.0f};
 std::atomic<unsigned long long> g_fovStampMs{0};
+// The minority (foreground) lens, published for telemetry and for the fg-lens
+// aspect law. 0 = only one lens seen this round.
+std::atomic<float> g_fovFgTanH{0.0f}, g_fovFgTanV{0.0f};
+std::atomic<unsigned long long> g_fovFgStampMs{0};
+std::atomic<int> g_fovLenses{0}; // distinct perspective clusters last round
+float g_fovLoggedH = 0.0f, g_fovLoggedFgH = 0.0f;
 // Mismatch verdict (render thread writes; hysteresis over present intervals).
 std::atomic<bool> g_fovMismatchOn{false};
 int g_fovMismatchStreak = 0;
@@ -280,12 +325,36 @@ bool ensure_fov_staging(ID3D11DeviceContext* ctx) {
     ctx->GetDevice(&dev);
     if (!dev) return false;
     D3D11_BUFFER_DESC sd{};
-    sd.ByteWidth = kFovCbBytes;
+    sd.ByteWidth = kFovCbBytes * kFovSlots;
     sd.Usage = D3D11_USAGE_STAGING;
     sd.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
     HRESULT hr = dev->CreateBuffer(&sd, nullptr, &g_fovStaging);
     dev->Release();
     return SUCCEEDED(hr) && g_fovStaging;
+}
+
+// One screen-ray block -> tangents, with the STRUCTURAL validation that makes
+// the two axes unambiguous. The block is (2tanH, 0, -tanH, 0, 0, -2tanV, tanV)
+// at floats 12..18, so f[13], f[15] and f[16] must be zero; those three tests
+// are the whole axis-disambiguation, and the shipped watch omitted them until
+// session 28 (the two cross-checks it did run are intra-axis - H against H and
+// V against V - and carry no axis information at all). Ported from the offline
+// decoder tools/decode-framedump.ps1, which has always applied them.
+bool decode_ray_block(const float* f, float* tanH, float* tanV) {
+    float h1 = f[12] * 0.5f, h2 = -f[14];
+    float v1 = -f[17] * 0.5f, v2 = f[18];
+    if (!std::isfinite(h1) || !std::isfinite(h2) || !std::isfinite(v1) ||
+        !std::isfinite(v2))
+        return false;
+    if (fabsf(f[13]) > 0.001f || fabsf(f[15]) > 0.001f || fabsf(f[16]) > 0.001f)
+        return false; // not the ray block (or a non-perspective all-zero pass)
+    // 8.0 = tan(rather more than 160 deg half-angle); the offline decoder uses
+    // 4.0, loosened only because a forced claim can legitimately go wider.
+    if (h1 <= 0.05f || h1 >= 8.0f || v1 <= 0.05f || v1 >= 8.0f) return false;
+    if (fabsf(h1 - h2) > 0.001f || fabsf(v1 - v2) > 0.001f) return false;
+    *tanH = h1;
+    *tanV = v1;
+    return true;
 }
 
 // Map attempt + mismatch bookkeeping, once per present (from on_present).
@@ -296,32 +365,137 @@ void fov_watch_on_present(ID3D11DeviceContext* ctx) {
         HRESULT hr = ctx->Map(g_fovStaging, 0, D3D11_MAP_READ,
                               D3D11_MAP_FLAG_DO_NOT_WAIT, &m);
         if (SUCCEEDED(hr)) {
-            const float* f = static_cast<const float*>(m.pData);
-            float tanH1 = f[12] * 0.5f, tanH2 = -f[14];
-            float tanV1 = -f[17] * 0.5f, tanV2 = f[18];
+            // Decode every slot, then cluster. Votes are per distinct cb0
+            // buffer object, which is what makes the world pass win: it feeds
+            // far more distinct buffers than the foreground pass does.
+            float h[kFovSlots], v[kFovSlots];
+            int votes[kFovSlots] = {};
+            int n = 0;
+            for (int s = 0; s < g_fovPendingSlots && s < kFovSlots; ++s) {
+                const float* f = reinterpret_cast<const float*>(
+                    static_cast<const uint8_t*>(m.pData) + s * kFovCbBytes);
+                if (decode_ray_block(f, &h[n], &v[n])) ++n;
+            }
             ctx->Unmap(g_fovStaging, 0);
             g_fovPending = false;
-            bool ok = std::isfinite(tanH1) && std::isfinite(tanH2) &&
-                      std::isfinite(tanV1) && std::isfinite(tanV2) &&
-                      tanH1 > 0.05f && tanH1 < 20.0f && tanV1 > 0.05f &&
-                      fabsf(tanH1 - tanH2) <= 0.02f * tanH1 &&
-                      fabsf(tanV1 - tanV2) <= 0.02f * tanV1;
-            if (ok) {
-                g_fovTanH.store(tanH1, std::memory_order_relaxed);
-                g_fovTanV.store(tanV1, std::memory_order_relaxed);
-                g_fovStampMs.store(GetTickCount64(), std::memory_order_relaxed);
+            g_fovPendingSlots = 0;
+            g_fovSlots = 0;
+            g_fovLastCb = nullptr;
+
+            for (int i = 0; i < n; ++i)
+                for (int j = 0; j < n; ++j)
+                    if (fabsf(h[i] - h[j]) <= 0.01f * h[i] &&
+                        fabsf(v[i] - v[j]) <= 0.01f * v[i])
+                        ++votes[i];
+            int win = -1;
+            for (int i = 0; i < n; ++i)
+                // Tie-break on the WIDER pair: the world frustum contains the
+                // viewmodel's in every case measured so far (1.1918 vs 0.6468 at
+                // option 100, 2.1445 vs 1.1640 at 130). A heuristic, and only
+                // ever consulted on an exact vote tie.
+                if (win < 0 || votes[i] > votes[win] ||
+                    (votes[i] == votes[win] && h[i] > h[win]))
+                    win = i;
+            // A round only publishes on a CLEAR majority. Without this the
+            // instrument would silently swap lenses on a marginal split, which
+            // is the whole failure mode being fixed - better to hold the last
+            // good value and let the age gate expire it. Ambiguity is counted
+            // and surfaced by `fovaudit`, never swallowed.
+            if (win >= 0 && n > 1 && votes[win] * 2 <= n) {
+                ++g_fovAmbiguous;
+                win = -1;
             }
-            // Non-perspective/zero blocks fail silently - the stamp just ages.
+            // COVERAGE guard. The stride comes from the PREVIOUS interval, so
+            // the first round after a scene change can be collected with a
+            // stale (too small) stride and then only span the head of the pass
+            // - which is the foreground. Measured: entering gameplay from the
+            // menu carried stride 1 into a 148-buffer pass and that one round
+            // published the viewmodel lens (5/8 votes) before the next round
+            // corrected it. Refuse a round whose samples did not reach across
+            // the pass it was collected in.
+            if (win >= 0 && g_fovCollectDistinct >
+                                kFovSlots * g_fovStrideUsed * 2) {
+                ++g_fovUnspanned;
+                win = -1;
+            }
+            if (win >= 0) {
+                g_fovTanH.store(h[win], std::memory_order_relaxed);
+                g_fovTanV.store(v[win], std::memory_order_relaxed);
+                g_fovStampMs.store(GetTickCount64(), std::memory_order_relaxed);
+                // The widest cluster that is NOT the winner is the other lens
+                // (the foreground pass off 16:9). Published for the fg aspect
+                // law; at 16:9 the lenses coincide so there is only one cluster.
+                int other = -1;
+                for (int i = 0; i < n; ++i) {
+                    if (fabsf(h[i] - h[win]) <= 0.01f * h[win] &&
+                        fabsf(v[i] - v[win]) <= 0.01f * v[win])
+                        continue;
+                    if (other < 0 || h[i] > h[other]) other = i;
+                }
+                int lenses = 1;
+                if (other >= 0) {
+                    lenses = 2;
+                    g_fovFgTanH.store(h[other], std::memory_order_relaxed);
+                    g_fovFgTanV.store(v[other], std::memory_order_relaxed);
+                    g_fovFgStampMs.store(GetTickCount64(),
+                                         std::memory_order_relaxed);
+                }
+                g_fovLenses.store(lenses, std::memory_order_relaxed);
+                // One line, on change, carrying everything a conclusion needs -
+                // no cross-referencing two log lines ever again (session 28).
+                float fgH = other >= 0 ? h[other] : 0.0f;
+                if (fabsf(h[win] - g_fovLoggedH) > 0.002f ||
+                    fabsf(fgH - g_fovLoggedFgH) > 0.002f) {
+                    g_fovLoggedH = h[win];
+                    g_fovLoggedFgH = fgH;
+                    BVR_LOG("[hud] fov watch: %d lens(es) | WORLD tanH=%.6f "
+                            "tanV=%.6f (hfov %.2f deg, %d/%d votes) | FG "
+                            "tanH=%.6f tanV=%.6f | backbuffer %ux%u aspect %.5f "
+                            "| sampled %d of %d distinct cb0 (stride %d), "
+                            "ambiguous rounds %d",
+                            lenses, h[win], v[win],
+                            2.0f * atanf(h[win]) * 57.29578f, votes[win], n,
+                            other >= 0 ? h[other] : 0.0f,
+                            other >= 0 ? v[other] : 0.0f, g_lbSrcW, g_lbSrcH,
+                            g_lbSrcH ? static_cast<float>(g_lbSrcW) /
+                                           static_cast<float>(g_lbSrcH)
+                                     : 0.0f,
+                            n, g_fovCollectDistinct, g_fovStrideUsed,
+                            g_fovAmbiguous + g_fovUnspanned);
+                }
+            }
+            // No decodable block: the stamp just ages, and the age gate in
+            // fov_watch() then refuses the stale sample outright.
         } else if (g_fovPendingAge > 8) {
             g_fovPending = false; // copy stuck (device weirdness) - recapture
+            g_fovPendingSlots = 0;
+            g_fovSlots = 0;
+            g_fovLastCb = nullptr;
         }
+    } else if (!g_fovPending && g_fovSlots > 0) {
+        // Round collected during the interval just ended - arm the map. No new
+        // copies start until it resolves, so a round is never half-overwritten.
+        g_fovPendingSlots = g_fovSlots;
+        g_fovPending = true;
+        g_fovPendingAge = 0;
+        g_fovSlots = 0;
+        g_fovCollectDistinct = g_fovDistinct; // for the coverage guard
     }
-    g_fovCapturedThisInterval = false;
-    g_fovTriesThisInterval = 0;
+    // Per-interval roll: this interval's distinct-buffer count becomes the next
+    // interval's stride, and the identity cursor restarts so the first draw of
+    // the new interval counts.
+    if (g_fovDistinct > 0) g_fovDistinctPrev = g_fovDistinct;
+    g_fovDistinct = 0;
+    g_fovLastCb = nullptr;
 
     // Rendered-vs-option verdict with a 3-interval hysteresis, logged on
     // transition. Session-independent by design: this is the flat-testable
     // instrument (the descent shows ON with no headset attached).
+    // Session 28: this compares the WORLD lens against the option, and the two
+    // now agree at every aspect (world tanH == tan(option/2), measured). Before
+    // the vote fix it was comparing the FOREGROUND lens against the option, so
+    // off 16:9 it latched ON during normal gameplay and dragged the projection
+    // claim onto the viewmodel frustum. Keep it comparing world-vs-option only.
     unsigned long long stamp = g_fovStampMs.load(std::memory_order_relaxed);
     bool fresh = stamp && GetTickCount64() - stamp < 500;
     float optHfov = bvr::vr::rendered_hfov_deg();
@@ -476,23 +650,39 @@ void on_draw_indexed(ID3D11DeviceContext* ctx) {
     }
     if (!g_curDsvBound) return;
 
-    // Session 22 fov watch: grab the first decodable scene draw's cb0 head
-    // (bounded attempts - early depth-only passes can bind small buffers).
-    if (!g_fovCapturedThisInterval && !g_fovPending && ctx &&
-        g_fovTriesThisInterval < 8) {
-        ++g_fovTriesThisInterval;
+    // Session 22 fov watch, session 28 rewrite: sample the cb0 head of every
+    // draw whose VS b0 buffer OBJECT changed, up to kFovSlots per interval, and
+    // let the majority decide which lens is the world (see the block comment at
+    // the state declarations - taking only the FIRST draw reported the
+    // viewmodel lens as the world lens and that was the yaw-warp bug).
+    if (ctx) {
         ID3D11Buffer* cb0 = nullptr;
         ctx->VSGetConstantBuffers(0, 1, &cb0);
         if (cb0) {
-            D3D11_BUFFER_DESC bd{};
-            cb0->GetDesc(&bd);
-            // 320 = the smallest world-pass cb tier that carries the ray block.
-            if (bd.ByteWidth >= 320 && ensure_fov_staging(ctx)) {
-                D3D11_BOX box{0, 0, 0, kFovCbBytes, 1, 1};
-                ctx->CopySubresourceRegion(g_fovStaging, 0, 0, 0, 0, cb0, 0, &box);
-                g_fovPending = true;
-                g_fovPendingAge = 0;
-                g_fovCapturedThisInterval = true;
+            if (cb0 != g_fovLastCb) {
+                D3D11_BUFFER_DESC bd{};
+                cb0->GetDesc(&bd);
+                // 320 = the smallest world-pass cb tier that carries the ray
+                // block. The 576-byte foreground tier also clears this gate on
+                // purpose: the vote needs to SEE both lenses to report the fg
+                // one and to know how many there are.
+                if (bd.ByteWidth >= 320) {
+                    g_fovLastCb = cb0;
+                    // Count EVERY distinct buffer (that is what sets the next
+                    // interval's stride), copy only every stride-th one.
+                    int idx = g_fovDistinct++;
+                    int stride = g_fovDistinctPrev / kFovSlots;
+                    if (stride < 1) stride = 1;
+                    if (!g_fovPending && g_fovSlots < kFovSlots &&
+                        idx % stride == 0 && ensure_fov_staging(ctx)) {
+                        D3D11_BOX box{0, 0, 0, kFovCbBytes, 1, 1};
+                        ctx->CopySubresourceRegion(g_fovStaging, 0,
+                                                   g_fovSlots * kFovCbBytes, 0, 0,
+                                                   cb0, 0, &box);
+                        if (g_fovSlots == 0) g_fovStrideUsed = stride;
+                        ++g_fovSlots;
+                    }
+                }
             }
             cb0->Release();
         }
@@ -666,12 +856,51 @@ void get_counters(unsigned* hudDraws, unsigned* redirects, unsigned* leaks,
     if (intervalsWithHud) *intervalsWithHud = g_cIntervals.load(std::memory_order_relaxed);
 }
 
-bool fov_watch(float* tanH, float* tanV, unsigned long long* ageMs) {
+// Session 28: the age gate is enforced HERE, not left to each caller. It used
+// to return true for any sample ever taken - no decay, no max age - while only
+// two of four consumers applied 500 ms themselves, and the human-facing
+// `fovaudit live` line applied none. Several session-27 conclusions were drawn
+// from samples that printed age>9000ms, stale by the rule the same line printed.
+// maxAgeMs == 0 means "give me the sample whatever its age" and exists only so
+// the audit command can PRINT a stale value while labelling it STALE.
+bool fov_watch(float* tanH, float* tanV, unsigned long long* ageMs,
+               unsigned long long maxAgeMs) {
     unsigned long long s = g_fovStampMs.load(std::memory_order_relaxed);
     if (!s) return false;
+    unsigned long long age = GetTickCount64() - s;
+    if (ageMs) *ageMs = age;
+    if (maxAgeMs && age > maxAgeMs) return false;
     if (tanH) *tanH = g_fovTanH.load(std::memory_order_relaxed);
     if (tanV) *tanV = g_fovTanV.load(std::memory_order_relaxed);
-    if (ageMs) *ageMs = GetTickCount64() - s;
+    return true;
+}
+
+// The other lens in the frame (the foreground/viewmodel pass). Only non-zero
+// off 16:9, where the two lenses split - at 16:9 they coincide exactly and the
+// vote sees a single cluster. Same age contract as fov_watch.
+bool fov_watch_fg(float* tanH, float* tanV, unsigned long long* ageMs,
+                  unsigned long long maxAgeMs) {
+    unsigned long long s = g_fovFgStampMs.load(std::memory_order_relaxed);
+    if (!s || g_fovLenses.load(std::memory_order_relaxed) < 2) return false;
+    unsigned long long age = GetTickCount64() - s;
+    if (ageMs) *ageMs = age;
+    if (maxAgeMs && age > maxAgeMs) return false;
+    if (tanH) *tanH = g_fovFgTanH.load(std::memory_order_relaxed);
+    if (tanV) *tanV = g_fovFgTanV.load(std::memory_order_relaxed);
+    return true;
+}
+
+int fov_lens_count() { return g_fovLenses.load(std::memory_order_relaxed); }
+
+// Backbuffer dims as last sampled by the letterbox watch. Exposed because the
+// lens laws are aspect-parameterised and the audit used to fall back to a
+// hardcoded 9/16 whenever no XR session was up - i.e. flat, which is where all
+// the measuring happens. That fallback is wrong at every aspect but 16:9 and it
+// is exactly the kind of silent assumption session 28 was spent unpicking.
+bool backbuffer_dims(unsigned* w, unsigned* h) {
+    if (!g_lbSrcW || !g_lbSrcH) return false;
+    if (w) *w = g_lbSrcW;
+    if (h) *h = g_lbSrcH;
     return true;
 }
 
@@ -767,7 +996,9 @@ void release_resources() {
     g_processedThisInterval = false;
     if (g_fovStaging) { g_fovStaging->Release(); g_fovStaging = nullptr; }
     g_fovPending = false;
-    g_fovCapturedThisInterval = false;
+    g_fovPendingSlots = 0;
+    g_fovSlots = 0;
+    g_fovLastCb = nullptr;
     if (g_lbStaging) { g_lbStaging->Release(); g_lbStaging = nullptr; }
     g_lbH = 0;
     g_lbPending = false;

--- a/src/core/gfx/hud_capture.cpp
+++ b/src/core/gfx/hud_capture.cpp
@@ -327,9 +327,20 @@ void fov_watch_on_present(ID3D11DeviceContext* ctx) {
     float optHfov = bvr::vr::rendered_hfov_deg();
     bool mm = false;
     if (fresh && optHfov > 1.0f) {
-        float optTan = tanf(optHfov * 0.5f * 3.14159265f / 180.0f);
-        if (optTan > 0.01f) {
-            float r = g_fovTanH.load(std::memory_order_relaxed) / optTan;
+        // Compare the VERTICAL. Under the measured law the option fixes
+        // tanV = tan(option/2)*9/16 and the horizontal is derived from the render
+        // aspect, so the vertical is the aspect-FREE primitive: this needs no
+        // aspect input at all. Comparing the horizontal against tan(option/2) is
+        // only valid at 16:9, and on a near-square resolution it read as a
+        // permanent mismatch - which this verdict feeds to cinematic_active(), so
+        // it would latch normal gameplay onto the big-screen quad. Dividing by a
+        // live aspect is worse: the aspect would come from whichever render
+        // target happens to be bound, which flickers between the scene and HUD
+        // targets and made the verdict oscillate. A scripted camera still moves
+        // tanV, so the detector keeps doing its original job.
+        float expectTanV = tanf(optHfov * 0.5f * 3.14159265f / 180.0f) * (9.0f / 16.0f);
+        if (expectTanV > 0.01f) {
+            float r = g_fovTanV.load(std::memory_order_relaxed) / expectTanV;
             mm = r < 0.90f || r > 1.10f;
         }
     }

--- a/src/core/gfx/hud_capture.h
+++ b/src/core/gfx/hud_capture.h
@@ -85,13 +85,39 @@ void get_counters(unsigned* hudDraws, unsigned* redirects, unsigned* leaks,
 // (DO_NOT_WAIT, zero pipeline stalls); tangents decode from the screen-ray
 // block at floats 12..18 (the session-21 layout that decode-framedump.ps1
 // verifies offline).
-//   fov_watch     latest decoded tangents; false until the first decode
-//   fov_mismatch  hysteresis'd rendered-vs-option verdict (compares against
-//                 bvr::vr::rendered_hfov_deg(), logs transitions - the
-//                 flat-testable instrument; the VR runtime keys the cinematic
-//                 quad fallback on it)
-bool fov_watch(float* tanH, float* tanV, unsigned long long* ageMs);
+//
+// SESSION 28: a frame carries TWO perspective lenses and off 16:9 they DIFFER -
+// the world pass is horizontal-anchored (tanH = tan(option/2), tanV follows the
+// window aspect) while the foreground/viewmodel pass is vertical-anchored
+// (tanV = tan(fgFov/2)*3/4, tanH follows the window). They coincide exactly at
+// 16:9. The watch therefore samples SEVERAL distinct cb0 buffers per interval
+// and publishes the cluster the majority agree on as the world lens, with the
+// minority available as the fg lens. Taking the first decodable draw instead
+// reported the viewmodel lens as the world lens (the fg draws come first, on a
+// tier that clears the size gate), which latched the mismatch verdict ON during
+// normal gameplay and dragged the projection claim onto the viewmodel frustum -
+// a 1.84x under-claim at 2750x2850, and the session-27 yaw-warp bug.
+//
+//   fov_watch      latest WORLD-lens tangents. maxAgeMs is enforced here (the
+//                  gate used to be left to callers and half of them skipped it);
+//                  pass 0 only to print a value you will label STALE yourself.
+//   fov_watch_fg   the other lens, when there is one (false at 16:9)
+//   fov_lens_count distinct perspective clusters in the last decoded round
+//   fov_mismatch   hysteresis'd WORLD-rendered-vs-option verdict (compares
+//                  against bvr::vr::rendered_hfov_deg(), logs transitions - the
+//                  flat-testable instrument; the VR runtime keys the cinematic
+//                  quad fallback on it)
+bool fov_watch(float* tanH, float* tanV, unsigned long long* ageMs,
+               unsigned long long maxAgeMs = 500);
+bool fov_watch_fg(float* tanH, float* tanV, unsigned long long* ageMs,
+                  unsigned long long maxAgeMs = 500);
+int fov_lens_count();
 bool fov_mismatch();
+// Backbuffer dims (letterbox-watch sample). The lens laws are
+// aspect-parameterised, so anything printing an expectation must use these
+// rather than assume 16:9 - flat there is no XR session to read swap dims from,
+// and flat is where the measuring happens.
+bool backbuffer_dims(unsigned* w, unsigned* h);
 
 // Session 22 per-kind routing:
 //   screen_only   true while intervals are PURE gameswf with the world pass

--- a/src/core/hooks/heap_scan.cpp
+++ b/src/core/hooks/heap_scan.cpp
@@ -1,0 +1,374 @@
+#include "core/hooks/heap_scan.h"
+
+#include <windows.h>
+#include <tlhelp32.h>
+#include <winnt.h>
+
+#include <iterator>
+
+namespace bvr::heap_scan {
+namespace {
+
+// The sweep's search space. The game is Large-Address-Aware and after a long
+// session the engine allocates actors above 2 GB, so a 0x7FFF0000 cap made late
+// objects invisible (session 18 part 4). VirtualQuery simply fails past the top
+// on a non-LAA process, so the walk still terminates there.
+constexpr uintptr_t kScanLow = 0x10000;
+constexpr uintptr_t kScanHigh = 0xFFFE0000u;
+
+// The needle never exists un-masked in this frame; see the header. Any non-zero
+// constant works - this one is only a bit pattern, not a secret.
+constexpr uintptr_t kNeedleMask = 0xA5C3F00Du;
+
+// Deadline granularity. Checking the clock every dword would cost more than the
+// compare; 16 KB of dwords between checks bounds the overshoot to a few
+// microseconds while keeping the inner loop tight.
+constexpr uintptr_t kDeadlineChunk = 16 * 1024;
+
+int64_t qpc_freq() {
+    static int64_t freq = [] {
+        LARGE_INTEGER f{};
+        QueryPerformanceFrequency(&f);
+        return f.QuadPart ? f.QuadPart : 1;
+    }();
+    return freq;
+}
+
+int64_t qpc_now() {
+    LARGE_INTEGER c{};
+    QueryPerformanceCounter(&c);
+    return c.QuadPart;
+}
+
+uint64_t qpc_to_us(int64_t ticks) {
+    return static_cast<uint64_t>((ticks * 1000000LL) / qpc_freq());
+}
+
+// ---- thread stack / TEB exclusion -------------------------------------------
+
+using NtQueryInformationThreadFn = LONG(NTAPI*)(HANDLE, ULONG, PVOID, ULONG, PULONG);
+
+NtQueryInformationThreadFn nt_query_thread() {
+    static NtQueryInformationThreadFn fn = [] {
+        HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
+        return ntdll ? reinterpret_cast<NtQueryInformationThreadFn>(
+                           GetProcAddress(ntdll, "NtQueryInformationThread"))
+                     : nullptr;
+    }();
+    return fn;
+}
+
+// ThreadBasicInformation. Declared locally rather than pulled from a DDK header
+// - only TebBaseAddress is used and the layout has been stable since NT 3.1.
+struct ThreadBasicInfo {
+    LONG ExitStatus;
+    PVOID TebBaseAddress;
+    struct {
+        HANDLE UniqueProcess;
+        HANDLE UniqueThread;
+    } ClientId;
+    ULONG_PTR AffinityMask;
+    LONG Priority;
+    LONG BasePriority;
+};
+
+void add_span(ExcludeSet& set, uintptr_t lo, uintptr_t hi) {
+    if (hi <= lo) return;
+    if (set.count >= kMaxExcludes) {
+        set.truncated = true;
+        return;
+    }
+    set.spans[set.count].lo = lo;
+    set.spans[set.count].hi = hi;
+    ++set.count;
+}
+
+// The whole stack ALLOCATION, not just its committed part: the reserved pages
+// below StackLimit hold the guard page and grow into the same allocation, and a
+// region-granular sweep would otherwise clip the boundary.
+void add_stack_of_teb(ExcludeSet& set, const void* teb) {
+    if (!teb) return;
+    const auto* tib = static_cast<const NT_TIB*>(teb);
+    // Reading another thread's TEB is an ordinary same-process read, but the
+    // thread can exit underneath us, so guard it.
+    uintptr_t stackBase = 0, stackLimit = 0;
+    __try {
+        stackBase = reinterpret_cast<uintptr_t>(tib->StackBase);
+        stackLimit = reinterpret_cast<uintptr_t>(tib->StackLimit);
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        return;
+    }
+    if (!stackBase || !stackLimit || stackLimit >= stackBase) return;
+
+    MEMORY_BASIC_INFORMATION mbi{};
+    uintptr_t lo = stackLimit;
+    if (VirtualQuery(reinterpret_cast<void*>(stackLimit), &mbi, sizeof(mbi)) == sizeof(mbi) &&
+        mbi.AllocationBase)
+        lo = reinterpret_cast<uintptr_t>(mbi.AllocationBase);
+    add_span(set, lo, stackBase);
+
+    // The TEB itself is MEM_PRIVATE + PAGE_READWRITE and holds plenty of
+    // pointers into the image.
+    uintptr_t tebAddr = reinterpret_cast<uintptr_t>(teb);
+    add_span(set, tebAddr, tebAddr + 0x2000);
+}
+
+// A stack's committed area always has a PAGE_GUARD page directly below it (the
+// guard moves down as the stack grows), so a region whose predecessor page is
+// guarded is a stack body. Second line of defence for a thread we could not
+// open, and it needs no ntdll at all.
+bool preceded_by_guard_page(uintptr_t base) {
+    if (base <= 0x1000) return false;
+    MEMORY_BASIC_INFORMATION mbi{};
+    if (VirtualQuery(reinterpret_cast<void*>(base - 0x1000), &mbi, sizeof(mbi)) != sizeof(mbi))
+        return false;
+    return (mbi.Protect & PAGE_GUARD) != 0;
+}
+
+bool region_scannable(const MEMORY_BASIC_INFORMATION& mbi) {
+    if (mbi.State != MEM_COMMIT) return false;
+    if (mbi.Protect & (PAGE_GUARD | PAGE_NOACCESS)) return false;
+    // Engine objects live in private heap memory. MEM_IMAGE would match the
+    // module's own .data copies of the vtable pointer; MEM_MAPPED is file and
+    // section views.
+    if (mbi.Type != MEM_PRIVATE) return false;
+    switch (mbi.Protect & 0xFF) {
+        case PAGE_READWRITE:
+        case PAGE_EXECUTE_READWRITE:
+            return true;
+        default:
+            return false;
+    }
+}
+
+// The guarded inner sweep. No C++ objects, no logging, no allocation in this
+// frame or anything it calls: a fault here unwinds without running destructors.
+// Returns the address it stopped at (== end when the region is finished).
+uintptr_t sweep_region(uintptr_t begin, uintptr_t end, uintptr_t xorNeedle, uint32_t needBytes,
+                       Accept accept, void* user, Sweep* s, int64_t deadline) {
+    uintptr_t a = begin;
+    __try {
+        while (a + needBytes <= end) {
+            uintptr_t chunkEnd = a + kDeadlineChunk;
+            if (chunkEnd > end - needBytes + 1) chunkEnd = end - needBytes + 1;
+            for (; a < chunkEnd; a += 4) {
+                if ((*reinterpret_cast<const uintptr_t*>(a) ^ kNeedleMask) != xorNeedle) continue;
+                ++s->matches;
+                void* obj = reinterpret_cast<void*>(a);
+                int32_t probe[kProbeSlots] = {};
+                bool good = accept(obj, user, probe);
+                if (s->recorded < kMaxRecorded) {
+                    s->addr[s->recorded] = obj;
+                    for (int k = 0; k < kProbeSlots; ++k) s->probe[s->recorded][k] = probe[k];
+                    s->ok[s->recorded] = good;
+                    ++s->recorded;
+                }
+                if (good) {
+                    ++s->accepted;
+                    if (!s->first) s->first = obj;
+                }
+            }
+            if (qpc_now() >= deadline) return a;
+        }
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        // The region decommitted under us, or the accept filter read off the
+        // end of a candidate. Abandon the rest of this region and move on.
+        return end;
+    }
+    return end;
+}
+
+// A pooled allocator can put a fixed header in front of the object, so the
+// object need not sit exactly at the block start. Probing a few aligned offsets
+// costs a handful of compares per block and covers that; every hit still has to
+// survive the accept filter, so a wider probe cannot loosen identity.
+constexpr uint32_t kBlockProbeSpan = 64;
+
+// Guarded per-heap walk. The __except swallows and falls through to HeapUnlock,
+// so the unlock runs on both paths: a fault that escaped with the lock held
+// would wedge that heap for the life of the process, blocking every thread that
+// allocates from it. HeapLock is re-entrant for the calling thread, so an accept
+// filter that allocated (none may) could not self-deadlock either.
+void walk_one_heap(HANDLE heap, uintptr_t xorNeedle, uint32_t needBytes, Accept accept, void* user,
+                   Sweep* s) {
+    if (!HeapLock(heap)) return;
+    __try {
+        PROCESS_HEAP_ENTRY e{};
+        while (HeapWalk(heap, &e)) {
+            if (!(e.wFlags & PROCESS_HEAP_ENTRY_BUSY)) continue;
+            if (e.cbData < needBytes) continue;
+            ++s->blocks;
+            const uintptr_t blockLo = reinterpret_cast<uintptr_t>(e.lpData);
+            const uintptr_t blockHi = blockLo + e.cbData;
+            uintptr_t probeEnd = blockLo + kBlockProbeSpan;
+            if (probeEnd > blockHi) probeEnd = blockHi;
+            for (uintptr_t a = blockLo; a + needBytes <= blockHi && a < probeEnd; a += 4) {
+                if ((*reinterpret_cast<const uintptr_t*>(a) ^ kNeedleMask) != xorNeedle) continue;
+                ++s->matches;
+                void* obj = reinterpret_cast<void*>(a);
+                int32_t probe[kProbeSlots] = {};
+                bool good = accept(obj, user, probe);
+                if (s->recorded < kMaxRecorded) {
+                    s->addr[s->recorded] = obj;
+                    for (int k = 0; k < kProbeSlots; ++k) s->probe[s->recorded][k] = probe[k];
+                    s->ok[s->recorded] = good;
+                    ++s->recorded;
+                }
+                if (good) {
+                    ++s->accepted;
+                    if (!s->first) s->first = obj;
+                }
+            }
+        }
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        // Fall through to __finally; the rest of this heap is abandoned.
+    }
+    HeapUnlock(heap);
+}
+
+} // namespace
+
+bool ExcludeSet::overlaps(uintptr_t lo, uintptr_t hi) const {
+    for (int i = 0; i < count; ++i)
+        if (lo < spans[i].hi && spans[i].lo < hi) return true;
+    return false;
+}
+
+void snapshot_excludes(ExcludeSet& out, int* missed) {
+    out.count = 0;
+    out.truncated = false;
+    int miss = 0;
+
+    // The current thread first, unconditionally: it is the one whose frames
+    // hold the needle, and it needs no handle to find.
+    add_stack_of_teb(out, NtCurrentTeb());
+
+    auto query = nt_query_thread();
+    HANDLE snap = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
+    if (snap == INVALID_HANDLE_VALUE || !query) {
+        if (snap != INVALID_HANDLE_VALUE) CloseHandle(snap);
+        if (missed) *missed = -1; // "could not enumerate at all"
+        return;
+    }
+
+    const DWORD self = GetCurrentProcessId();
+    const DWORD selfTid = GetCurrentThreadId();
+    THREADENTRY32 te{};
+    te.dwSize = sizeof(te);
+    if (Thread32First(snap, &te)) {
+        do {
+            if (te.dwSize < FIELD_OFFSET(THREADENTRY32, th32OwnerProcessID) +
+                                sizeof(te.th32OwnerProcessID))
+                continue;
+            if (te.th32OwnerProcessID != self) continue;
+            if (te.th32ThreadID == selfTid) continue; // already added
+
+            HANDLE th = OpenThread(THREAD_QUERY_INFORMATION, FALSE, te.th32ThreadID);
+            if (!th) th = OpenThread(THREAD_QUERY_LIMITED_INFORMATION, FALSE, te.th32ThreadID);
+            if (!th) {
+                ++miss;
+                continue;
+            }
+            ThreadBasicInfo tbi{};
+            ULONG len = 0;
+            if (query(th, 0 /*ThreadBasicInformation*/, &tbi, sizeof(tbi), &len) >= 0)
+                add_stack_of_teb(out, tbi.TebBaseAddress);
+            else
+                ++miss;
+            CloseHandle(th);
+        } while (Thread32Next(snap, &te));
+    }
+    CloseHandle(snap);
+    if (missed) *missed = miss;
+}
+
+void Sweep::reset() {
+    cursor = kScanLow;
+    slices = 0;
+    elapsedUs = 0;
+    bytes = 0;
+    matches = 0;
+    accepted = 0;
+    first = nullptr;
+    recorded = 0;
+    snapshot_excludes(excludes, &excludeMissed);
+    excludeSpans = excludes.count;
+}
+
+Outcome sweep(Sweep& s, const void* wantVtable, uint32_t needBytes, Accept accept, void* user,
+              uint32_t budgetUs) {
+    if (!accept || !wantVtable || needBytes < sizeof(void*)) {
+        s.reset();
+        ++s.passes;
+        return Outcome::Complete;
+    }
+
+    // A fresh pass re-snapshots the exclusions (inside reset): threads come and
+    // go, and a stale snapshot is exactly how a stack gets swept.
+    if (s.cursor < kScanLow) s.reset();
+
+    // Masked here and compared masked in the inner loop, so the raw vtable
+    // address is never a live value inside the sweep.
+    const uintptr_t xorNeedle = reinterpret_cast<uintptr_t>(wantVtable) ^ kNeedleMask;
+
+    const int64_t start = qpc_now();
+    const int64_t deadline = start + (static_cast<int64_t>(budgetUs) * qpc_freq()) / 1000000LL;
+    ++s.slices;
+
+    MEMORY_BASIC_INFORMATION mbi{};
+    while (s.cursor < kScanHigh) {
+        if (VirtualQuery(reinterpret_cast<void*>(s.cursor), &mbi, sizeof(mbi)) != sizeof(mbi))
+            break;
+        const uintptr_t base = reinterpret_cast<uintptr_t>(mbi.BaseAddress);
+        const uintptr_t end = base + mbi.RegionSize;
+        if (end <= base) break; // wrapped: nothing sane left above
+
+        const bool skip = !region_scannable(mbi) || s.excludes.overlaps(base, end) ||
+                          preceded_by_guard_page(base);
+        if (!skip) {
+            const uintptr_t from = s.cursor > base ? s.cursor : base;
+            const uintptr_t stopped =
+                sweep_region(from, end, xorNeedle, needBytes, accept, user, &s, deadline);
+            s.bytes += stopped - from;
+            if (stopped < end) {
+                s.cursor = stopped;
+                s.elapsedUs += qpc_to_us(qpc_now() - start);
+                return Outcome::Working;
+            }
+        }
+        s.cursor = end;
+        if (qpc_now() >= deadline && s.cursor < kScanHigh) {
+            s.elapsedUs += qpc_to_us(qpc_now() - start);
+            return Outcome::Working;
+        }
+    }
+
+    s.elapsedUs += qpc_to_us(qpc_now() - start);
+    s.cursor = 0; // next call starts a new pass
+    ++s.passes;
+    return Outcome::Complete;
+}
+
+bool heap_blocks(Sweep& s, const void* wantVtable, uint32_t needBytes, Accept accept, void* user) {
+    s.reset();
+    s.cursor = 0; // this path does not slice; a following sweep() starts clean
+    if (!accept || !wantVtable || needBytes < sizeof(void*)) return false;
+
+    const int64_t start = qpc_now();
+    const uintptr_t xorNeedle = reinterpret_cast<uintptr_t>(wantVtable) ^ kNeedleMask;
+
+    HANDLE heaps[96];
+    DWORD n = GetProcessHeaps(static_cast<DWORD>(std::size(heaps)), heaps);
+    if (n > std::size(heaps)) n = static_cast<DWORD>(std::size(heaps));
+    for (DWORD i = 0; i < n; ++i) {
+        if (!heaps[i]) continue;
+        ++s.heaps;
+        walk_one_heap(heaps[i], xorNeedle, needBytes, accept, user, &s);
+    }
+
+    s.elapsedUs = qpc_to_us(qpc_now() - start);
+    ++s.passes;
+    return s.first != nullptr;
+}
+
+} // namespace bvr::heap_scan

--- a/src/core/hooks/heap_scan.cpp
+++ b/src/core/hooks/heap_scan.cpp
@@ -179,10 +179,17 @@ uintptr_t sweep_region(uintptr_t begin, uintptr_t end, uintptr_t xorNeedle, uint
 }
 
 // A pooled allocator can put a fixed header in front of the object, so the
-// object need not sit exactly at the block start. Probing a few aligned offsets
-// costs a handful of compares per block and covers that; every hit still has to
-// survive the accept filter, so a wider probe cannot loosen identity.
-constexpr uint32_t kBlockProbeSpan = 64;
+// object need not sit exactly at the block start. Probing aligned offsets across
+// a prefix costs a bounded number of compares per block and covers that; every
+// hit still has to survive the accept filter, so a wider probe cannot loosen
+// identity.
+//
+// Measured on BioShock 1: UShockUserSettings IS found inside this prefix (62 ms
+// for the whole walk), but APlayerWeapon is not - those matches only turned up
+// in the region sweep, so engine actors either sit deeper in their block or come
+// from a pool HeapWalk does not describe. 256 rather than 64 to give the deeper
+// case a chance before falling back; still 64 compares per block.
+constexpr uint32_t kBlockProbeSpan = 256;
 
 // Guarded per-heap walk. The __except swallows and falls through to HeapUnlock,
 // so the unlock runs on both paths: a fault that escaped with the lock held
@@ -291,6 +298,8 @@ void Sweep::reset() {
     accepted = 0;
     first = nullptr;
     recorded = 0;
+    blocks = 0;
+    heaps = 0;
     snapshot_excludes(excludes, &excludeMissed);
     excludeSpans = excludes.count;
 }

--- a/src/core/hooks/heap_scan.h
+++ b/src/core/hooks/heap_scan.h
@@ -1,0 +1,139 @@
+#pragma once
+// Safe, bounded search of the process's private committed memory for a live
+// engine object identified by its class vtable. Game-agnostic: no game names,
+// no addresses. Per-game accept filters live in game/<title>/patterns.cpp.
+//
+// WHY THIS MODULE EXISTS (session 27 crash post-mortem). The per-game scanner
+// it replaces walked the whole 4 GB address space at a 4-byte stride in one
+// blocking call on the game thread, accepting any MEM_PRIVATE + PAGE_READWRITE
+// region. Three consequences, all observed in the field:
+//
+//   1. Thread stacks, TEBs and PEBs ARE MEM_PRIVATE + PAGE_READWRITE, so they
+//      were swept - the filter excluded MEM_IMAGE/MEM_MAPPED, not stacks. A
+//      stack slot that passed the accept filter would then be written to every
+//      frame by the consumer.
+//   2. The needle was an ordinary function argument, so it was spilled onto the
+//      scanning thread's own stack and the sweep matched its own argument. That
+//      is the two "vtable match" lines 0x40 apart just below esp in the
+//      reporter's log.
+//   3. One pass cost 1-4 s of blocked game thread, felt as "the game freezes
+//      every couple of seconds".
+//
+// All three are addressed here: stacks and TEBs are excluded exactly (plus a
+// guard-page heuristic as a second line), the needle only ever exists XOR-
+// masked inside the inner loop, and a pass is sliced across frames under a
+// wall-clock budget so no single call can stall a frame.
+//
+// THREADING: one Sweep belongs to one caller on one thread. Nothing here is
+// internally synchronized.
+
+#include <cstdint>
+
+namespace bvr::heap_scan {
+
+// Regions the sweep must never read: every thread's stack allocation and TEB.
+// Refreshed at the start of each pass, since threads come and go.
+constexpr int kMaxExcludes = 128;
+
+struct ExcludeSet {
+    struct Span {
+        uintptr_t lo;
+        uintptr_t hi; // exclusive
+    };
+    Span spans[kMaxExcludes];
+    int count = 0;
+    bool truncated = false; // more threads than kMaxExcludes: fail loud, not silent
+
+    bool overlaps(uintptr_t lo, uintptr_t hi) const;
+};
+
+// Every thread stack allocation and TEB page in this process. Best-effort: a
+// thread we cannot open is reported via `missed` so the caller can log it
+// rather than silently sweeping that stack.
+void snapshot_excludes(ExcludeSet& out, int* missed = nullptr);
+
+// Candidates recorded for the caller to log AFTER the guarded region. Logging
+// from inside an SEH __try is a deadlock hazard: MSVC under /EHsc does not run
+// C++ destructors during SEH unwinding, so a fault taken while the log mutex
+// is held leaves it held for the life of the process.
+constexpr int kMaxRecorded = 12;
+
+// Diagnostic integers an accept filter may hand back per candidate. Integers
+// rather than a formatted string on purpose: formatting inside the guarded
+// region is the thing this mechanism exists to avoid. Each callsite knows what
+// its own slots mean and formats them after the search returns.
+constexpr int kProbeSlots = 4;
+
+enum class Outcome {
+    Working,  // budget spent, cursor advanced, call again
+    Complete, // a full pass finished; read `accepted` / `first`
+};
+
+// Per-callsite sweep state. Zero-initialize once and keep it; the sweep owns
+// every field. `reset()` starts a fresh pass.
+//
+// The exclusion snapshot is taken once per PASS and cached here, not per slice:
+// enumerating threads costs more than a slice's worth of comparing, and a pass
+// is short enough that a thread created mid-pass cannot move an existing stack.
+struct Sweep {
+    ExcludeSet excludes;    // refreshed at pass start
+    uintptr_t cursor = 0;   // next address to examine (0 = start a new pass)
+    uint32_t passes = 0;    // completed passes
+    uint32_t slices = 0;    // budget slices spent on the current pass
+    uint64_t elapsedUs = 0; // wall clock spent on the current pass
+    uint64_t bytes = 0;     // bytes examined this pass
+
+    int matches = 0;  // vtable hits this pass
+    int accepted = 0; // accept() said yes this pass (>1 means ambiguous)
+    void* first = nullptr;
+
+    int recorded = 0;
+    void* addr[kMaxRecorded] = {};
+    int32_t probe[kMaxRecorded][kProbeSlots] = {};
+    bool ok[kMaxRecorded] = {};
+
+    int excludeSpans = 0;  // spans in force this pass, for the log line
+    int excludeMissed = 0; // threads we could not query (-1 = none at all)
+
+    uint32_t blocks = 0; // busy heap blocks examined (heap_blocks only)
+    uint32_t heaps = 0;  // heaps walked (heap_blocks only)
+
+    void reset();
+};
+
+// Called for every object whose first dword is the wanted vtable. Decides
+// whether this instance is the one wanted - every UClass also has a default
+// object carrying the same vtable, so a plausibility test on the object's own
+// fields is mandatory. Runs INSIDE the sweep's SEH guard: it may read up to
+// `needBytes` from `obj`, must not throw, and must not log or allocate.
+// `probe` receives kProbeSlots diagnostic integers recorded for the caller.
+using Accept = bool (*)(void* obj, void* user, int32_t probe[kProbeSlots]);
+
+// Advance `s` by at most `budgetUs` microseconds of wall clock. Returns
+// Working while the pass is unfinished. `wantVtable` is the absolute address of
+// the class vtable; `needBytes` is how much of the object the accept filter
+// reads.
+Outcome sweep(Sweep& s, const void* wantVtable, uint32_t needBytes, Accept accept, void* user,
+              uint32_t budgetUs);
+
+// FAST PATH, and the one to prefer. Enumerates the BUSY blocks of every heap in
+// the process and tests each block large enough to hold the object, instead of
+// every 4-byte-aligned address in every private region. Two wins over sweep():
+//
+//   - Cost. A sweep reads 1-2 GB per pass and measured 1-4 s of blocked game
+//     thread; this touches a handful of dwords per allocation and completes in
+//     tens of milliseconds, so it needs no slicing at all.
+//   - Liveness. HeapWalk only reports allocated blocks, so a freed-but-not-yet-
+//     reused block cannot be returned. That matters because the consumer WRITES
+//     to what it gets back, and writing an int into a freed block smashes the
+//     allocator's bookkeeping - the leading explanation for the field
+//     0xC0000374 reports.
+//
+// Returns false if the object was not found, in which case the caller should
+// fall back to sweep(): an engine that allocates objects out of its own
+// VirtualAlloc'd pools rather than a Win32 heap is invisible here. `s` is
+// filled the same way sweep() fills it, plus `blocks`/`heaps` for the log line.
+// Never logs or allocates while a heap lock is held.
+bool heap_blocks(Sweep& s, const void* wantVtable, uint32_t needBytes, Accept accept, void* user);
+
+} // namespace bvr::heap_scan

--- a/src/core/hooks/heap_scan.h
+++ b/src/core/hooks/heap_scan.h
@@ -33,7 +33,12 @@ namespace bvr::heap_scan {
 
 // Regions the sweep must never read: every thread's stack allocation and TEB.
 // Refreshed at the start of each pass, since threads come and go.
-constexpr int kMaxExcludes = 128;
+//
+// Two spans per thread, so this is a thread-count ceiling of half its value.
+// Measured on a 12-core machine running BioShock 1: 64 threads, which filled a
+// 128-span table exactly and silently started dropping stacks. Sized for a
+// machine with several times that many.
+constexpr int kMaxExcludes = 512;
 
 struct ExcludeSet {
     struct Span {

--- a/src/core/util/module_id.cpp
+++ b/src/core/util/module_id.cpp
@@ -1,0 +1,50 @@
+#include "core/util/module_id.h"
+
+#include <windows.h>
+
+namespace bvr::module_id {
+namespace {
+
+const IMAGE_NT_HEADERS* nt_headers(HMODULE mod) {
+    if (!mod) return nullptr;
+    auto* dos = reinterpret_cast<const IMAGE_DOS_HEADER*>(mod);
+    if (dos->e_magic != IMAGE_DOS_SIGNATURE) return nullptr;
+    auto* nt = reinterpret_cast<const IMAGE_NT_HEADERS*>(reinterpret_cast<const BYTE*>(mod) +
+                                                         dos->e_lfanew);
+    return nt->Signature == IMAGE_NT_SIGNATURE ? nt : nullptr;
+}
+
+} // namespace
+
+Fingerprint host_exe() {
+    Fingerprint f{};
+    HMODULE host = GetModuleHandleW(nullptr);
+    const IMAGE_NT_HEADERS* nt = nt_headers(host);
+    if (!nt) return f;
+
+    f.timeDateStamp = nt->FileHeader.TimeDateStamp;
+    f.sizeOfImage = nt->OptionalHeader.SizeOfImage;
+    f.checkSum = nt->OptionalHeader.CheckSum;
+
+    wchar_t path[MAX_PATH]{};
+    if (GetModuleFileNameW(nullptr, path, MAX_PATH)) {
+        WIN32_FILE_ATTRIBUTE_DATA fad{};
+        if (GetFileAttributesExW(path, GetFileExInfoStandard, &fad))
+            f.fileBytes = (static_cast<uint64_t>(fad.nFileSizeHigh) << 32) | fad.nFileSizeLow;
+    }
+    f.valid = true;
+    return f;
+}
+
+bool matches(const Fingerprint& f, uint32_t timeDateStamp, uint32_t sizeOfImage,
+             uint64_t fileBytes) {
+    if (!f.valid) return false;
+    if (f.timeDateStamp != timeDateStamp) return false;
+    if (f.sizeOfImage != sizeOfImage) return false;
+    // A zero expected size means "not recorded"; the two PE fields already pin
+    // the link, and the on-disk size is the extra signal that catches a repack.
+    if (fileBytes && f.fileBytes && f.fileBytes != fileBytes) return false;
+    return true;
+}
+
+} // namespace bvr::module_id

--- a/src/core/util/module_id.h
+++ b/src/core/util/module_id.h
@@ -1,0 +1,35 @@
+#pragma once
+// Identity of a loaded module, for deciding whether hardcoded addresses derived
+// from one build may be trusted against the binary actually running.
+// Game-agnostic: the expected values live in each game's patterns header.
+//
+// WHY (session 27). Adapters are selected by exe BASENAME, and every storefront
+// ships BioShock Remastered as the same `BioshockHD.exe`. So an Epic, GOG or
+// repatched build is not rejected - it is DETECTED as supported, and then
+// roughly a hundred absolute RVAs from the 2022-04-13 Steam build are applied to
+// a different binary. Hooking paths mostly survive that because they are
+// prologue- or vtable-gated and refuse, but the object-scan KEYS degrade to
+// "search memory for an arbitrary constant and then write to whatever passes a
+// plausibility test", which is the worst available failure mode.
+
+#include <cstdint>
+
+namespace bvr::module_id {
+
+struct Fingerprint {
+    uint32_t timeDateStamp = 0; // PE FileHeader; the authoritative build id
+    uint32_t sizeOfImage = 0;   // PE OptionalHeader
+    uint32_t checkSum = 0;      // PE OptionalHeader; 0 in many linker configs
+    uint64_t fileBytes = 0;     // on-disk size, catches a repack at the same link
+    bool valid = false;         // false if the PE headers were unreadable
+};
+
+// Fingerprint of the process's main module.
+Fingerprint host_exe();
+
+// True when `f` matches the expected build. checkSum is compared only when both
+// sides have a non-zero value, because the shipped BioShock 1 exe carries 0.
+bool matches(const Fingerprint& f, uint32_t timeDateStamp, uint32_t sizeOfImage,
+             uint64_t fileBytes);
+
+} // namespace bvr::module_id

--- a/src/core/vr/openxr_runtime.cpp
+++ b/src/core/vr/openxr_runtime.cpp
@@ -854,7 +854,24 @@ void init_instance() {
     ici.enabledExtensionNames = enabled;
     r = xrCreateInstance(&ici, &g_instance);
     if (XR_FAILED(r)) {
-        BVR_LOG("xr: xrCreateInstance failed: %s - VR disabled", res_str(r));
+        BVR_LOG("xr: xrCreateInstance failed: %s - VR disabled, game runs flat", res_str(r));
+        // XR_ERROR_RUNTIME_UNAVAILABLE from a 32-bit process is very rarely a
+        // broken install: SteamVR has never shipped a 32-bit OpenXR runtime, and
+        // BioShock is a 32-bit game. Anyone on Lighthouse hardware (Index, Vive)
+        // or running Steam Link, i.e. with SteamVR as the active runtime, lands
+        // here every single time. Saying so turns "the mod does nothing" into an
+        // actionable report - and it is a whole class of them.
+        if (r == XR_ERROR_RUNTIME_UNAVAILABLE) {
+            BVR_LOG("xr: -----------------------------------------------------------");
+            BVR_LOG("xr: The active OpenXR runtime has no 32-bit support. This game is");
+            BVR_LOG("xr: 32-bit, so VR cannot start. SteamVR is the usual cause: it has");
+            BVR_LOG("xr: never shipped a 32-bit OpenXR runtime, which also covers Index,");
+            BVR_LOG("xr: Vive and Steam Link setups.");
+            BVR_LOG("xr: Workaround today: set a runtime that does ship 32-bit - Virtual");
+            BVR_LOG("xr: Desktop (VDXR) or the Oculus/Meta runtime - as the active OpenXR");
+            BVR_LOG("xr: runtime, then relaunch.");
+            BVR_LOG("xr: -----------------------------------------------------------");
+        }
         g_instance = XR_NULL_HANDLE;
         return;
     }

--- a/src/core/vr/openxr_runtime.cpp
+++ b/src/core/vr/openxr_runtime.cpp
@@ -1050,19 +1050,11 @@ void on_present_begin(IDXGISwapChain* swapchain) {
             maxHalfV = fmaxf(maxHalfV, fmaxf(-v.fov.angleDown, v.fov.angleUp));
         }
         float aspect = static_cast<float>(g_swapW) / static_cast<float>(g_swapH);
-        // Which OPTION value makes the render cover both headset half-angles,
-        // under the measured law (tanV = tan(option/2)*9/16, tanH = tanV*aspect):
-        //   tanV        >= tan(maxHalfV) -> tan(option/2) >= tan(maxHalfV)*16/9
-        //   tanV*aspect >= tan(maxHalfH) -> tan(option/2) >= tan(maxHalfH)*16/(9*aspect)
-        // The old form solved the inverted law: right at 16:9, and badly
-        // under-asking elsewhere. At aspect 1.0 with a 54/55 deg eye it suggested
-        // 110, which this engine renders as roughly 73 deg.
-        float needTan = fmaxf(tanf(maxHalfV), tanf(maxHalfH) / aspect);
-        float deg = 2.0f * atanf(needTan * (16.0f / 9.0f)) * 57.29578f;
-        if (deg > 160.0f) deg = 160.0f;
+        float halfH = fmaxf(maxHalfH, atanf(tanf(maxHalfV) * aspect));
+        float deg = fminf(halfH * 2.0f * 57.29578f, 160.0f);
         g_hfovDeg.store(deg, std::memory_order_relaxed);
-        BVR_LOG("xr: headset fov half-angles h=%.1f v=%.1f deg -> game fov option %.1f "
-                "(aspect %.3f; the option is 16:9-referenced and sets the VERTICAL)",
+        BVR_LOG("xr: headset fov half-angles h=%.1f v=%.1f deg -> game hfov %.1f deg "
+                "(aspect %.3f)",
                 maxHalfH * 57.29578f, maxHalfV * 57.29578f, deg, aspect);
     }
 
@@ -1568,34 +1560,11 @@ void on_present_end(IDXGISwapChain* swapchain) {
                                  {static_cast<int32_t>(g_swapW), static_cast<int32_t>(g_swapH)}};
 
                 if (projectionMode) {
-                    // fov = the symmetric fov the game ACTUALLY rendered with.
-                    //
-                    // MEASURED, three readings, one of them exact:
-                    //   16:9,   option 130 -> rendered tanH 2.1445 = tan(65)
-                    //   1:1,    option 130 -> rendered tanH 1.2063 = tan(65)*9/16
-                    //   1:1,    option 100 -> rendered tanH 0.6704 = tan(50)*9/16
-                    //                                    (predicted 0.67036)
-                    // So the option is a 16:9-REFERENCED value whose real effect
-                    // is on the VERTICAL, and the horizontal follows the render
-                    // aspect (Hor+):
-                    //     tanV = tan(option/2) * 9/16
-                    //     tanH = tanV * (render aspect)
-                    // This code assumed the inverse. The two agree EXACTLY at
-                    // 16:9, which is why the assumption survived - every earlier
-                    // measurement was taken at 16:9.
-                    //
-                    // Confirmed by submitting and rendering side by side in one
-                    // live session at 2048x2048: submitted tanH 1.2063 against
-                    // rendered 0.6704, a ratio of 1.80 == 16/9. That mismatch is
-                    // the compositor reprojecting horizontal content by the wrong
-                    // factor: yaw warps, pitch stays clean - reported in-headset,
-                    // and independent of the FOV slider, which is the property
-                    // that discriminates this law from the alternative (both
-                    // scale with tan(option/2), so the aspect factor is a CONSTANT
-                    // stretch at any option value).
-                    float halfV = atanf(tanf(hfovDeg * 0.5f / 57.29578f) * (9.0f / 16.0f));
-                    float halfH = atanf(tanf(halfV) * static_cast<float>(g_swapW) /
-                                        static_cast<float>(g_swapH));
+                    // fov = the symmetric fov the game rendered with (hfov
+                    // written by the adapter, vfov via aspect).
+                    float halfH = hfovDeg * 0.5f / 57.29578f;
+                    float halfV = atanf(tanf(halfH) * static_cast<float>(g_swapH) /
+                                        static_cast<float>(g_swapW));
                     // FOV audit (session 21): the tangents this layer is
                     // TAGGED with, logged on change. The flat gate compares
                     // them against tangents recovered from dumpframe cb0.

--- a/src/core/vr/openxr_runtime.cpp
+++ b/src/core/vr/openxr_runtime.cpp
@@ -53,6 +53,10 @@ XrSwapchain g_swapchains[2] = {XR_NULL_HANDLE, XR_NULL_HANDLE};
 std::vector<XrSwapchainImageD3D11KHR> g_images[2];
 uint32_t g_swapW = 0, g_swapH = 0;
 uint32_t g_backbufferFmt = 0; // DXGI format the live swapchains were built for
+// Set by on_resize (which runs inside the game's ResizeBuffersDetour, at an
+// arbitrary point in the frame) and consumed by the frame loop at a point where
+// no XR frame is open. See the long note in on_resize.
+std::atomic<bool> g_resizePending{false};
 
 ID3D11Device* g_device = nullptr;          // game device, AddRef'd
 ID3D11DeviceContext* g_context = nullptr;  // immediate context, AddRef'd
@@ -434,6 +438,8 @@ void destroy_swapchains() {
     destroy_hud_swapchain();
     g_swapW = g_swapH = 0;
     g_backbufferFmt = 0;
+    // Whatever a queued rebuild was for, it has just happened.
+    g_resizePending.store(false, std::memory_order_relaxed);
     reset_aer(); // the held eye images died with the swapchains
 }
 
@@ -902,6 +908,17 @@ void on_present_begin(IDXGISwapChain* swapchain) {
     // the blocking pacing so the flat window keeps running. Events were
     // already pumped above, so recovery needs no paced frame to be seen.
     if (pace_should_skip(g_state, g_everFocused, GetTickCount64())) return;
+
+    // Deferred swapchain teardown for a real size change (see on_resize). This
+    // is the safe point: past the pair-hold early return, before any wait, so no
+    // XR frame is open and the compositor is not holding an image we are about
+    // to free. Both flags are checked anyway - the cost is two atomic loads and
+    // the failure mode it prevents is a use-after-free inside the runtime.
+    if (g_resizePending.load(std::memory_order_acquire) && !g_frameOpen && !g_srPairOpen) {
+        g_resizePending.store(false, std::memory_order_relaxed);
+        BVR_LOG("xr: performing the queued XR swapchain rebuild (no frame open)");
+        destroy_swapchains();
+    }
 
     // A mid-session ResizeBuffers destroys the swapchains; recreate them at
     // the new backbuffer size (and recompute the fov, which depends on aspect).
@@ -1749,8 +1766,22 @@ void on_resize(unsigned width, unsigned height, unsigned format) {
                 width, height, format);
         return;
     }
-    // Recreated at the new backbuffer size on the next frame.
-    destroy_swapchains();
+
+    // A REAL size change used to destroy the swapchains right here. This
+    // function runs inside the game's ResizeBuffersDetour, which can land
+    // anywhere - including between xrBeginFrame and xrEndFrame, with the
+    // compositor still holding images from the frame in flight. That is the
+    // documented-open half of the session-23 crash (the same-size case above got
+    // its guard then; the real-size case did not), and the captured dump for it
+    // is 22 frames of VDXR calling into d3d11 through 0xDEDEDEDE pointers.
+    //
+    // So only QUEUE it. The frame loop performs the destroy at a point where it
+    // can prove no XR frame is open, and the existing null-swapchain branch in
+    // on_present_begin then rebuilds at the new size.
+    g_resizePending.store(true, std::memory_order_release);
+    BVR_LOG("xr: real ResizeBuffers (%ux%u fmt %u) - XR swapchain rebuild QUEUED for a safe "
+            "point in the frame loop",
+            width, height, format);
 }
 
 void draw_debug_ui() {

--- a/src/core/vr/openxr_runtime.cpp
+++ b/src/core/vr/openxr_runtime.cpp
@@ -1050,11 +1050,19 @@ void on_present_begin(IDXGISwapChain* swapchain) {
             maxHalfV = fmaxf(maxHalfV, fmaxf(-v.fov.angleDown, v.fov.angleUp));
         }
         float aspect = static_cast<float>(g_swapW) / static_cast<float>(g_swapH);
-        float halfH = fmaxf(maxHalfH, atanf(tanf(maxHalfV) * aspect));
-        float deg = fminf(halfH * 2.0f * 57.29578f, 160.0f);
+        // Which OPTION value makes the render cover both headset half-angles,
+        // under the measured law (tanV = tan(option/2)*9/16, tanH = tanV*aspect):
+        //   tanV        >= tan(maxHalfV) -> tan(option/2) >= tan(maxHalfV)*16/9
+        //   tanV*aspect >= tan(maxHalfH) -> tan(option/2) >= tan(maxHalfH)*16/(9*aspect)
+        // The old form solved the inverted law: right at 16:9, and badly
+        // under-asking elsewhere. At aspect 1.0 with a 54/55 deg eye it suggested
+        // 110, which this engine renders as roughly 73 deg.
+        float needTan = fmaxf(tanf(maxHalfV), tanf(maxHalfH) / aspect);
+        float deg = 2.0f * atanf(needTan * (16.0f / 9.0f)) * 57.29578f;
+        if (deg > 160.0f) deg = 160.0f;
         g_hfovDeg.store(deg, std::memory_order_relaxed);
-        BVR_LOG("xr: headset fov half-angles h=%.1f v=%.1f deg -> game hfov %.1f deg "
-                "(aspect %.3f)",
+        BVR_LOG("xr: headset fov half-angles h=%.1f v=%.1f deg -> game fov option %.1f "
+                "(aspect %.3f; the option is 16:9-referenced and sets the VERTICAL)",
                 maxHalfH * 57.29578f, maxHalfV * 57.29578f, deg, aspect);
     }
 
@@ -1560,11 +1568,34 @@ void on_present_end(IDXGISwapChain* swapchain) {
                                  {static_cast<int32_t>(g_swapW), static_cast<int32_t>(g_swapH)}};
 
                 if (projectionMode) {
-                    // fov = the symmetric fov the game rendered with (hfov
-                    // written by the adapter, vfov via aspect).
-                    float halfH = hfovDeg * 0.5f / 57.29578f;
-                    float halfV = atanf(tanf(halfH) * static_cast<float>(g_swapH) /
-                                        static_cast<float>(g_swapW));
+                    // fov = the symmetric fov the game ACTUALLY rendered with.
+                    //
+                    // MEASURED, three readings, one of them exact:
+                    //   16:9,   option 130 -> rendered tanH 2.1445 = tan(65)
+                    //   1:1,    option 130 -> rendered tanH 1.2063 = tan(65)*9/16
+                    //   1:1,    option 100 -> rendered tanH 0.6704 = tan(50)*9/16
+                    //                                    (predicted 0.67036)
+                    // So the option is a 16:9-REFERENCED value whose real effect
+                    // is on the VERTICAL, and the horizontal follows the render
+                    // aspect (Hor+):
+                    //     tanV = tan(option/2) * 9/16
+                    //     tanH = tanV * (render aspect)
+                    // This code assumed the inverse. The two agree EXACTLY at
+                    // 16:9, which is why the assumption survived - every earlier
+                    // measurement was taken at 16:9.
+                    //
+                    // Confirmed by submitting and rendering side by side in one
+                    // live session at 2048x2048: submitted tanH 1.2063 against
+                    // rendered 0.6704, a ratio of 1.80 == 16/9. That mismatch is
+                    // the compositor reprojecting horizontal content by the wrong
+                    // factor: yaw warps, pitch stays clean - reported in-headset,
+                    // and independent of the FOV slider, which is the property
+                    // that discriminates this law from the alternative (both
+                    // scale with tan(option/2), so the aspect factor is a CONSTANT
+                    // stretch at any option value).
+                    float halfV = atanf(tanf(hfovDeg * 0.5f / 57.29578f) * (9.0f / 16.0f));
+                    float halfH = atanf(tanf(halfV) * static_cast<float>(g_swapW) /
+                                        static_cast<float>(g_swapH));
                     // FOV audit (session 21): the tangents this layer is
                     // TAGGED with, logged on change. The flat gate compares
                     // them against tangents recovered from dumpframe cb0.

--- a/src/core/vr/openxr_runtime.cpp
+++ b/src/core/vr/openxr_runtime.cpp
@@ -201,6 +201,9 @@ std::atomic<int8_t> g_srRing[kSrRingSize] = {};
 std::atomic<uint32_t> g_srPushed{0}, g_srPopped{0}, g_srDropped{0},
     g_srCleared{0};
 std::atomic<bool> g_loggedFirstSr{false};
+// Session 28: a live-lens claim substitution must announce itself once. An
+// unexplained src=live is what let the yaw warp hide for a session.
+std::atomic<bool> g_loggedLiveClaim{false};
 
 // M4 rung 2 polish (session 7, after the first in-headset stereo test):
 // xr-frame-per-pair pacing. Per-present xrWaitFrame gave the two presents of
@@ -215,6 +218,14 @@ std::atomic<bool> g_loggedFirstSr{false};
 // blocking wait per game tick. Kill switch in the overlay for live A/B.
 std::atomic<bool> g_srPairPacing{true};
 bool g_srPairOpen = false; // present thread only
+uint64_t g_srPairOpenMs = 0; // when the hold was armed (present thread only)
+uint64_t g_lastIdleLogMs = 0; // rate limit for the SUBMISSION IDLE heartbeat
+// Session 28: the hold is a bounded promise, not a latch. The right eye follows
+// its sibling within the time the game takes to BUILD one frame - ~1-4 ms
+// measured, and the whole pair fits inside one compositor period. 500 ms is
+// three orders of magnitude of slack and still bounds the alt-tab case, where
+// presents stop mid-pair and no sibling is ever coming.
+constexpr uint32_t kPairHoldMaxMs = 500;
 std::atomic<uint32_t> g_srPairs{0}, g_srPairAborts{0};
 std::atomic<bool> g_loggedFirstPair{false};
 
@@ -790,14 +801,20 @@ void pump_events() {
                     break;
                 }
                 case XR_SESSION_STATE_FOCUSED:
-                    if (g_everFocused && g_unfocusedSinceMs != 0)
+                    // Session 28: log the resume whenever there WAS an unfocused
+                    // episode, without also requiring g_everFocused - STOPPING
+                    // clears that latch, so the old condition silently swallowed
+                    // the first resume after every stop.
+                    if (g_unfocusedSinceMs != 0)
                         BVR_LOG("xr: FOCUSED again after %llu ms unfocused - full "
-                                "pacing resumes (guard skipped %u presents)",
+                                "pacing resumes (guard skipped %u presents this "
+                                "episode)",
                                 static_cast<unsigned long long>(GetTickCount64() -
                                                                 g_unfocusedSinceMs),
                                 g_paceSkips.load(std::memory_order_relaxed));
                     g_everFocused = true;
                     g_unfocusedSinceMs = 0;
+                    g_paceSkips.store(0, std::memory_order_relaxed);
                     break;
                 case XR_SESSION_STATE_STOPPING:
                     if (g_sessionBegun) {
@@ -806,6 +823,17 @@ void pump_events() {
                         // The next bring-up must pace freely again (bring-up
                         // needs frames), so the focus latch resets with it.
                         g_everFocused = false;
+                        // Session 28: clear the unfocused stamp too. It used to
+                        // survive STOPPING, and both of the lines that would
+                        // tell a stuck user what happened are gated on it: the
+                        // "pacing SKIPPED" line only prints when the stamp is 0,
+                        // and the "FOCUSED again" line needs the stamp non-zero
+                        // AND g_everFocused, which STOPPING just cleared. So
+                        // after one STOPPING episode the log went silent in both
+                        // directions and the alt-tab freeze looked like nothing
+                        // happening at all.
+                        g_unfocusedSinceMs = 0;
+                        g_paceSkips.store(0, std::memory_order_relaxed);
                         BVR_LOG("xr: session stopped (headset idle?) - waiting for READY again");
                     }
                     break;
@@ -907,24 +935,60 @@ void on_present_begin(IDXGISwapChain* swapchain) {
         return;
     }
 
-    // Pair pacing: the previous (LEFT-tagged) present left the XR frame open;
-    // this present completes the pair at its tail. No second waitFrame, no
-    // re-locate - the pair shares one prediction and one pose set.
-    if (g_srPairOpen) return;
-
     if (g_session == XR_NULL_HANDLE) {
         if (GetTickCount64() < g_nextRetryMs) return;
         try_bring_up(swapchain);
         if (g_session == XR_NULL_HANDLE) return;
     }
 
+    // SESSION 28 - pump_events() now runs ABOVE the pair-hold return, and the
+    // hold is aged. This is OPEN BUG 1 (VR freezes permanently after alt-tab).
+    // The pair-hold used to return before the pump, so while it was set no XR
+    // events were polled at all: g_state could never update, the pace guard
+    // could never see FOCUSED again, and nothing below could re-arm. Alt-tab
+    // stops the game presenting mid-pair, so a LEFT-tagged hold survived the
+    // whole unfocused window with no sibling coming, and the only path in this
+    // function that cleared anything was the `!g_enabled` teardown just above -
+    // which is exactly why the VR off/on toggle was the sole recovery.
+    // Pumping first costs one extra xrPollEvent on the completing present and
+    // preserves the hold's invariant, which is about waitFrame and locateViews,
+    // not events: neither runs on this path.
     pump_events();
-    if (g_session == XR_NULL_HANDLE || !g_sessionBegun) return;
+    if (g_session == XR_NULL_HANDLE || !g_sessionBegun) {
+        g_srPairOpen = false; // never strand a hold across a stopped session
+        return;
+    }
+
+    // Pair pacing: the previous (LEFT-tagged) present left the XR frame open;
+    // this present completes the pair at its tail. No second waitFrame, no
+    // re-locate - the pair shares one prediction and one pose set.
+    if (g_srPairOpen) {
+        if (GetTickCount64() - g_srPairOpenMs <= kPairHoldMaxMs) return;
+        // The sibling never came. Drop the hold and fall through so the
+        // leaked-frame close below reclaims the open frame.
+        BVR_LOG("xr: pair hold outlived %u ms with no right-eye present - "
+                "aborting it (presents stopped mid-pair? alt-tab/level load)",
+                kPairHoldMaxMs);
+        g_srPairOpen = false;
+        g_srPairAborts.fetch_add(1, std::memory_order_relaxed);
+    }
 
     // M8 (a): headset idle (session left FOCUSED after having held it) - skip
     // the blocking pacing so the flat window keeps running. Events were
     // already pumped above, so recovery needs no paced frame to be seen.
-    if (pace_should_skip(g_state, g_everFocused, GetTickCount64())) return;
+    // Session 28: close any leaked frame BEFORE the guard can return, so a
+    // frame cannot sit open for the whole unfocused episode either.
+    if (pace_should_skip(g_state, g_everFocused, GetTickCount64())) {
+        if (g_frameOpen) {
+            XrFrameEndInfo idle{XR_TYPE_FRAME_END_INFO};
+            idle.displayTime = g_frameState.predictedDisplayTime;
+            idle.environmentBlendMode = XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
+            xrEndFrame(g_session, &idle);
+            g_frameOpen = false;
+            g_srPairOpen = false;
+        }
+        return;
+    }
 
     // Deferred swapchain teardown for a real size change (see on_resize). This
     // is the safe point: past the pair-hold early return, before any wait, so no
@@ -1367,8 +1431,32 @@ void on_present_end(IDXGISwapChain* swapchain) {
         // keep draining the tag ring and keep the window pinned to one eye.
         mirror_present(swapchain, sr_pop_eye());
         composite_hud(swapchain); // the window keeps its HUD even with no session
+        // SESSION 28: name the guard, on a heartbeat, while submission is idle.
+        // "Present keeps running but the headset is frozen" was diagnosable only
+        // by reading the source and guessing which early return had fired, and
+        // two of the lines that would have said so were suppressed. Now one line
+        // every 5 s names the actual reason for as long as it lasts.
+        uint64_t now = GetTickCount64();
+        if (g_session != XR_NULL_HANDLE && now - g_lastIdleLogMs >= 5000) {
+            g_lastIdleLogMs = now;
+            const char* why = !g_enabled.load(std::memory_order_relaxed)
+                                  ? "VR disabled in overlay"
+                              : !g_sessionBegun ? "session not begun (waiting "
+                                                  "for READY after a STOPPING)"
+                              : g_state != XR_SESSION_STATE_FOCUSED
+                                  ? "pace guard: session not FOCUSED"
+                              : g_swapchains[0] == XR_NULL_HANDLE
+                                  ? "no XR swapchains (rebuild pending?)"
+                                  : "frame not begun (waitFrame/beginFrame path)";
+            BVR_LOG("xr: SUBMISSION IDLE (reason=%s | state=%s everFocused=%d "
+                    "pairOpen=%d skips=%u frames=%u) - flat rendering continues",
+                    why, state_str(g_state), g_everFocused ? 1 : 0,
+                    g_srPairOpen ? 1 : 0,
+                    g_paceSkips.load(std::memory_order_relaxed), g_framesSubmitted);
+        }
         return;
     }
+    g_lastIdleLogMs = 0; // submitting again - re-arm the idle heartbeat
     bool pairSecond = g_srPairOpen; // this present completes an open pair
     g_srPairOpen = false;
     g_frameOpen = false; // the pair-hold path below re-arms both
@@ -1444,11 +1532,33 @@ void on_present_end(IDXGISwapChain* swapchain) {
         } else if (fovMm && stereoCine) {
             // Claim-fix stereo cinematics: tag the layer with the fov the
             // game ACTUALLY renders (live watch), not the ignored option.
+            //
+            // SESSION 28 - this branch caused the yaw warp, and the reason is
+            // worth stating where it happened. `fov_watch` used to return the
+            // FOREGROUND lens off 16:9, which also latched fovMm permanently ON
+            // during normal gameplay, so normal gameplay came through here and
+            // the projection layer was tagged with the viewmodel frustum -
+            // tanH 0.6468 over a world rendered at tanH 1.1918 at 2750x2850, a
+            // 1.84x under-claim. `src=live` on the audit line was TRUE and the
+            // inference drawn from it ("live means it tracks the render") was
+            // false, because it was tracking the wrong lens.
+            // The watch now votes for the world lens, so fovMm no longer latches
+            // off 16:9 and this branch is back to being what it was designed
+            // for: a genuine scripted-camera fov change (the bathysphere
+            // descent renders 104 while the option reads 130). It is logged on
+            // entry from now on - a substitution must never again be invisible.
             float t = 0.0f;
             unsigned long long age = 0;
-            if (bvr::hud::fov_watch(&t, nullptr, &age) && age < 500 && t > 0.05f) {
+            if (bvr::hud::fov_watch(&t, nullptr, &age, 500) && t > 0.05f) {
                 hfovDeg = 2.0f * atanf(t) * 57.29578f;
                 hfovSrc = 3; // "live"
+                if (!g_loggedLiveClaim.exchange(true))
+                    BVR_LOG("xr: claim substituted from the live WORLD lens "
+                            "(hfov %.2f deg, age %llums) - the fov-mismatch "
+                            "verdict is latched, which off 16:9 used to mean the "
+                            "watch had picked the viewmodel lens; verify with "
+                            "`fovaudit` that lenses/votes look right",
+                            hfovDeg, age);
             }
         }
     } else {
@@ -1545,6 +1655,7 @@ void on_present_end(IDXGISwapChain* swapchain) {
                     // from this frame's single locate (g_views is untouched
                     // until the next waitFrame).
                     g_srPairOpen = true;
+                    g_srPairOpenMs = GetTickCount64(); // aged; see kPairHoldMaxMs
                     g_frameOpen = true;
                     if (!g_loggedFirstPair.exchange(true))
                         BVR_LOG("xr: pair pacing live (one waitFrame per eye "
@@ -2092,9 +2203,9 @@ void handle_cine_command(const char* args) {
         uint64_t ageMs = pv ? GetTickCount64() - (pv >> 1) : 0;
         float t = 0.0f, tv = 0.0f;
         unsigned long long fovAge = 0;
-        bool haveFov = bvr::hud::fov_watch(&t, &tv, &fovAge);
+        bool haveFov = bvr::hud::fov_watch(&t, &tv, &fovAge, 0); // print stale too
         BVR_LOG("xr: cine %s mode=%s active=%d | enters %u exits %u presents %u | "
-                "published strict=%d age=%llums | rendered tanH=%.4f age=%llums "
+                "published strict=%d age=%llums | WORLD tanH=%.4f age=%llums "
                 "mismatch=%d screenOnly=%d (vrcine on|off|mode quad|mode stereo|status)",
                 g_cineEnabled.load(std::memory_order_relaxed) ? "ON" : "off",
                 g_cineStereo.load(std::memory_order_relaxed) ? "stereo" : "quad",

--- a/src/core/vr/openxr_runtime.cpp
+++ b/src/core/vr/openxr_runtime.cpp
@@ -264,6 +264,51 @@ std::atomic<uint32_t> g_paceSkips{0};
 std::atomic<uint32_t> g_lastWaitMs{0}; // last xrWaitFrame block, telemetry
 std::atomic<bool> g_simIdle{false};    // flat stand-in (`vrpace simidle on`)
 
+// ---- Session 28: xrWaitFrame OFF the present thread ------------------------
+// The alt-tab freeze, measured. Alt-tab drops the session FOCUSED -> VISIBLE and
+// VDXR never re-grants FOCUSED, because the M8 guard makes us submit NOTHING
+// while unfocused and a runtime will not promote an app that submits nothing.
+// That is a circular wait, and the log named it outright: `SUBMISSION IDLE
+// (reason=pace guard: session not FOCUSED | state=VISIBLE ... pairOpen=0)`
+// repeating with no FOCUSED line until the VR toggle tore the session down. It
+// also refutes the session-26 claim that "recovery is event-driven, not
+// something an app earns by submitting frames" - on VDXR it IS earned.
+//
+// We cannot simply keep waiting while unfocused: xrWaitFrame takes no timeout,
+// with the headset idle it never returns, and on the present thread that wedged
+// the process in the field twice. The only design that satisfies both is to move
+// the unbounded call OFF the present thread, so the present thread can give up
+// on a wait without being stuck by it. Corroboration from the same log: ZERO
+// `xrWaitFrame blocked` lines all session, so 5772 presents were skipped without
+// a single slow wait to justify it - the guard keys on session STATE when the
+// thing it must actually avoid is a slow WAIT.
+//
+// Protocol - strictly ONE wait per begin, so the frame sequence stays matched:
+//   present thread  no request outstanding -> post one; then wait on `done` with
+//                   a deadline. Signalled -> consume the frame state and go on to
+//                   xrBeginFrame. Timed out -> return, leaving the request
+//                   outstanding to be consumed by a later present.
+//   pace thread     park on `req`, call xrWaitFrame, publish, signal `done`.
+// The deadline is generous while FOCUSED (the headset still paces the game) and
+// short otherwise (an unresponsive runtime must not drag the flat window down).
+// `vrpace thread off` restores the exact pre-session-28 inline behaviour.
+std::atomic<bool> g_paceOffThread{true};
+HANDLE g_paceThread = nullptr;
+HANDLE g_paceReq = nullptr;  // auto-reset, present -> pace
+HANDLE g_paceDone = nullptr; // auto-reset, pace -> present
+std::atomic<bool> g_paceRun{false};
+bool g_paceOutstanding = false; // present thread only
+XrFrameState g_paceFrameState{XR_TYPE_FRAME_STATE}; // handed over via g_paceDone
+std::atomic<int> g_paceResult{0};
+std::atomic<uint32_t> g_paceTimeouts{0}, g_paceHandoffs{0};
+// Teardown deferral: destroying a session while the pace thread is parked inside
+// xrWaitFrame on it is a use-after-free inside the runtime. If a wait will not
+// come back, we keep the session alive (which is exactly today's behaviour) and
+// retry from the present loop rather than crash.
+const char* g_teardownPending = nullptr;
+constexpr uint32_t kPaceDeadlineFocusedMs = 200;
+constexpr uint32_t kPaceDeadlineIdleMs = 20;
+
 // M8 release blocker (b): the desktop mirror. Under SequentialReentry every
 // Present alternates the backbuffer between the two eyes, so the flat window
 // cannot be streamed, recorded, or shown. Fix: LEFT-eye presents snapshot the
@@ -331,10 +376,67 @@ const char* state_str(XrSessionState s) {
 // The stall-guard decision for one present, shared verbatim by the real pace
 // path and the flat simulation (which forces state/everFocused). True = this
 // present must NOT run the blocking pacing. Present thread only.
+// The pace thread body: park, wait a frame, publish, signal. The ONLY place
+// xrWaitFrame is called once g_paceOffThread is on. It may block forever without
+// consequence - nothing else runs on this thread.
+DWORD WINAPI pace_thread_proc(void*) {
+    while (g_paceRun.load(std::memory_order_relaxed)) {
+        if (WaitForSingleObject(g_paceReq, INFINITE) != WAIT_OBJECT_0) break;
+        if (!g_paceRun.load(std::memory_order_relaxed)) break;
+        XrSession s = g_session; // a request is only posted with a live session
+        XrFrameState fs{XR_TYPE_FRAME_STATE};
+        XrResult r = XR_ERROR_SESSION_LOST;
+        uint64_t t0 = GetTickCount64();
+        if (s != XR_NULL_HANDLE) {
+            XrFrameWaitInfo fwi{XR_TYPE_FRAME_WAIT_INFO};
+            r = xrWaitFrame(s, &fwi, &fs);
+        }
+        uint32_t ms = static_cast<uint32_t>(GetTickCount64() - t0);
+        g_lastWaitMs.store(ms, std::memory_order_relaxed);
+        if (ms > 1000) {
+            static uint64_t lastStallLogMs = 0;
+            if (t0 - lastStallLogMs > 5000) {
+                lastStallLogMs = t0;
+                BVR_LOG("xr: xrWaitFrame blocked %u ms on the pace thread (state "
+                        "%s) - the present thread was NOT held by it",
+                        ms, state_str(g_state));
+            }
+        }
+        g_paceFrameState = fs; // handed over by the SetEvent below
+        g_paceResult.store(static_cast<int>(r), std::memory_order_relaxed);
+        SetEvent(g_paceDone);
+    }
+    return 0;
+}
+
+bool pace_thread_start() {
+    if (g_paceThread) return true;
+    if (!g_paceReq) g_paceReq = CreateEventW(nullptr, FALSE, FALSE, nullptr);
+    if (!g_paceDone) g_paceDone = CreateEventW(nullptr, FALSE, FALSE, nullptr);
+    if (!g_paceReq || !g_paceDone) return false;
+    g_paceRun.store(true, std::memory_order_relaxed);
+    g_paceThread = CreateThread(nullptr, 0, &pace_thread_proc, nullptr, 0, nullptr);
+    if (!g_paceThread) {
+        g_paceRun.store(false, std::memory_order_relaxed);
+        return false;
+    }
+    BVR_LOG("xr: pace thread started - xrWaitFrame no longer runs on the present "
+            "thread, so an unbounded block cannot wedge the game (session 28)");
+    return true;
+}
+
 bool pace_should_skip(XrSessionState state, bool everFocused, uint64_t now) {
     if (!g_paceGuard.load(std::memory_order_relaxed)) return false;
     if (state == XR_SESSION_STATE_FOCUSED) return false;
     if (!everFocused) return false; // bring-up: frames are how we REACH focused
+    // SESSION 28: with the wait off the present thread there is no reason to stop
+    // submitting, and a strong reason not to - VDXR will not re-grant FOCUSED to
+    // an app that submits nothing, so skipping here is what made the alt-tab
+    // freeze permanent (measured: state stuck VISIBLE, FOCUSED never returning,
+    // and zero slow waits all session to justify the skip). The unbounded wait
+    // that this guard existed to dodge can no longer reach the present thread,
+    // so the deadline in on_present_begin replaces the skip entirely.
+    if (g_paceOffThread.load(std::memory_order_relaxed)) return false;
     // Unfocused after having held FOCUSED: skip the blocking wait ALWAYS (see
     // the keepalive post-mortem above). One line per unfocused episode.
     if (g_unfocusedSinceMs == 0) {
@@ -529,6 +631,26 @@ void composite_hud(IDXGISwapChain* swapchain) {
 }
 
 void teardown_session(const char* why) {
+    // SESSION 28: never call xrDestroySession while the pace thread is parked
+    // inside xrWaitFrame on that session - that is a use-after-free inside the
+    // runtime. Give an outstanding wait a bounded chance to come back; if it
+    // will not, keep the session alive and retry from the present loop. Worst
+    // case is "the session stays up but idle", which is exactly the pre-session-28
+    // behaviour, and strictly better than a crash.
+    if (g_paceOutstanding) {
+        if (WaitForSingleObject(g_paceDone, 200) == WAIT_OBJECT_0) {
+            g_paceOutstanding = false;
+        } else {
+            if (g_teardownPending != why)
+                BVR_LOG("xr: teardown (%s) DEFERRED - a wait is still in flight on "
+                        "the pace thread; retrying each present rather than "
+                        "destroying a session the runtime is still inside",
+                        why);
+            g_teardownPending = why;
+            return;
+        }
+    }
+    g_teardownPending = nullptr;
     BVR_LOG("xr: session teardown (%s)", why);
     input_on_session_teardown(); // action spaces are session children
     destroy_swapchains();
@@ -930,6 +1052,13 @@ void on_present_begin(IDXGISwapChain* swapchain) {
 
     if (g_instance == XR_NULL_HANDLE) return;
 
+    // A teardown that had to be deferred (pace thread still inside xrWaitFrame)
+    // retries here, first thing, every present.
+    if (g_teardownPending && g_session != XR_NULL_HANDLE) {
+        teardown_session(g_teardownPending);
+        if (g_session != XR_NULL_HANDLE) return; // still deferred
+    }
+
     if (!g_enabled.load(std::memory_order_relaxed)) {
         if (g_session != XR_NULL_HANDLE) teardown_session("disabled in overlay");
         return;
@@ -1026,21 +1155,45 @@ void on_present_begin(IDXGISwapChain* swapchain) {
         BVR_LOG("xr: closed a leaked open frame before waiting (pair aborted?)");
     }
 
-    XrFrameWaitInfo fwi{XR_TYPE_FRAME_WAIT_INFO};
-    g_frameState = {XR_TYPE_FRAME_STATE};
-    uint64_t waitStart = GetTickCount64();
-    XrResult r = xrWaitFrame(g_session, &fwi, &g_frameState);
-    uint32_t waitMs = static_cast<uint32_t>(GetTickCount64() - waitStart);
-    g_lastWaitMs.store(waitMs, std::memory_order_relaxed);
-    // Telemetry for the disconnect stall: a healthy wait is one display
-    // period. Long blocks with their session state tell us how THIS runtime
-    // behaves when the headset idles (rate-limited: keepalives are expected
-    // to block while unfocused).
-    if (waitMs > 1000) {
-        static uint64_t lastStallLogMs = 0;
-        if (waitStart - lastStallLogMs > 5000) {
-            lastStallLogMs = waitStart;
-            BVR_LOG("xr: xrWaitFrame blocked %u ms (state %s)", waitMs, state_str(g_state));
+    XrResult r;
+    if (g_paceOffThread.load(std::memory_order_relaxed) && pace_thread_start()) {
+        // One request outstanding at a time keeps wait:begin at 1:1.
+        if (!g_paceOutstanding) {
+            g_paceOutstanding = true;
+            SetEvent(g_paceReq);
+        }
+        uint32_t deadline = g_state == XR_SESSION_STATE_FOCUSED
+                                ? kPaceDeadlineFocusedMs
+                                : kPaceDeadlineIdleMs;
+        if (WaitForSingleObject(g_paceDone, deadline) != WAIT_OBJECT_0) {
+            // The runtime has not come back yet. Give up on THIS present only -
+            // the request stays outstanding and a later present consumes it. The
+            // game keeps running either way, which is the whole point.
+            g_paceTimeouts.fetch_add(1, std::memory_order_relaxed);
+            return;
+        }
+        g_paceOutstanding = false;
+        g_paceHandoffs.fetch_add(1, std::memory_order_relaxed);
+        g_frameState = g_paceFrameState;
+        r = static_cast<XrResult>(g_paceResult.load(std::memory_order_relaxed));
+    } else {
+        XrFrameWaitInfo fwi{XR_TYPE_FRAME_WAIT_INFO};
+        g_frameState = {XR_TYPE_FRAME_STATE};
+        uint64_t waitStart = GetTickCount64();
+        r = xrWaitFrame(g_session, &fwi, &g_frameState);
+        uint32_t waitMs = static_cast<uint32_t>(GetTickCount64() - waitStart);
+        g_lastWaitMs.store(waitMs, std::memory_order_relaxed);
+        // Telemetry for the disconnect stall: a healthy wait is one display
+        // period. Long blocks with their session state tell us how THIS runtime
+        // behaves when the headset idles.
+        if (waitMs > 1000) {
+            static uint64_t lastStallLogMs = 0;
+            if (waitStart - lastStallLogMs > 5000) {
+                lastStallLogMs = waitStart;
+                BVR_LOG("xr: xrWaitFrame blocked %u ms INLINE on the present "
+                        "thread (state %s) - `vrpace thread on` moves it off",
+                        waitMs, state_str(g_state));
+            }
         }
     }
     if (XR_FAILED(r)) {
@@ -2114,6 +2267,15 @@ void handle_pace_command(const char* args) {
         g_paceGuard.store(false, std::memory_order_relaxed);
         BVR_LOG("xr: pace guard OFF (pre-M8 behavior: every present waits, the "
                 "flat window stalls when the headset idles)");
+    } else if (strcmp(verb, "thread") == 0) {
+        bool on = strncmp(rest, "off", 3) != 0;
+        g_paceOffThread.store(on, std::memory_order_relaxed);
+        BVR_LOG("xr: xrWaitFrame %s (session 28: off-thread is what lets us keep "
+                "submitting while VISIBLE, which is how FOCUSED gets re-granted "
+                "after an alt-tab; inline is the pre-session-28 behaviour and "
+                "reinstates the skip guard)",
+                on ? "OFF the present thread (deadline 200 ms focused / 20 ms idle)"
+                   : "INLINE on the present thread");
     } else if (strcmp(verb, "simidle") == 0) {
         bool on = strncmp(rest, "on", 2) == 0;
         g_simIdle.store(on, std::memory_order_relaxed);
@@ -2122,14 +2284,16 @@ void handle_pace_command(const char* args) {
                      "with the guard off, commands crawl at ~1/s until it lands)"
                    : "");
     } else {
-        BVR_LOG("xr: pace guard %s | session %s everFocused=%d | skips %u "
-                "lastWait %u ms | simidle %s (keepalive retired session 26 - it "
-                "was an unbounded xrWaitFrame block) "
-                "(vrpace on|off|simidle on|off|status)",
+        BVR_LOG("xr: pace guard %s | wait %s | session %s everFocused=%d | skips %u "
+                "lastWait %u ms | handoffs %u timeouts %u | simidle %s "
+                "(vrpace on|off|thread on|off|simidle on|off|status)",
                 g_paceGuard.load(std::memory_order_relaxed) ? "ON" : "off",
+                g_paceOffThread.load(std::memory_order_relaxed) ? "off-thread" : "inline",
                 state_str(g_state), g_everFocused.load(std::memory_order_relaxed) ? 1 : 0,
                 g_paceSkips.load(std::memory_order_relaxed),
                 g_lastWaitMs.load(std::memory_order_relaxed),
+                g_paceHandoffs.load(std::memory_order_relaxed),
+                g_paceTimeouts.load(std::memory_order_relaxed),
                 g_simIdle.load(std::memory_order_relaxed) ? "ON" : "off");
     }
 }

--- a/src/game/bioshock1r/aim.cpp
+++ b/src/game/bioshock1r/aim.cpp
@@ -913,7 +913,12 @@ void update_weapon_profile(const FrameContext& ctx) {
         // they did not.
         if (!w && !g_weaponScanDormant && body::is_gameplay_view(ctx.viewActor)) {
             w = hands::resolve_weapon_actor(ctx);
-            if (!w && ++g_weaponScanMisses >= patterns::kScanMissesBeforeDormant) {
+            // A null return can mean "searched, not there" OR "the sliced sweep
+            // has not finished yet". Only the first is a miss; counting the
+            // second latched the scanner dormant before it had ever completed a
+            // pass (caught in the first smoke test of the sliced scanner).
+            if (!w && !hands::weapon_scan_in_progress() &&
+                ++g_weaponScanMisses >= patterns::kScanMissesBeforeDormant) {
                 g_weaponScanDormant = true;
                 BVR_LOG("[aim] weapon scan fallback DORMANT after %d miss(es) - the cheap rig "
                         "and learned-actor reads keep running; a view-state change re-arms it",

--- a/src/game/bioshock1r/aim.cpp
+++ b/src/game/bioshock1r/aim.cpp
@@ -16,6 +16,7 @@
 #include "core/input/xinput_bridge.h"
 #include "core/util/log.h"
 #include "core/vr/openxr_runtime.h"
+#include "game/bioshock1r/body.h"
 #include "game/bioshock1r/bones.h"
 #include "game/bioshock1r/hands.h"
 #include "game/shared/ue_math.h"
@@ -859,6 +860,12 @@ void apply_weapon_key(const std::string& key, const char* why) {
     }
 }
 
+// Scan-fallback dormancy (session 27). A structural latch, deliberately NOT a
+// counter that the next momentary success zeroes - see the long note at the use
+// site for why that distinction is the whole fix.
+int g_weaponScanMisses = 0;
+bool g_weaponScanDormant = false;
+
 // Per-frame (throttled) weapon-change watch. The weapon actor accessor is
 // cached + vtable-revalidated in hands.cpp; the class name resolves only on
 // a pointer change, so steady-state cost is one pointer compare.
@@ -871,13 +878,11 @@ void update_weapon_profile(const FrameContext& ctx) {
     // preset's value load and seeded the first profile from zeros.
     if (!g_presetBaselineValid && g_weaponProfiles.empty()) return;
     static uint32_t throttle = 0;
-    static uint32_t nullResolves = 0;
-    // Failure backoff for the SCAN fallback only (the rig read is a pointer
-    // dereference and free): a world state with no acceptable weapon must
-    // not full-heap-scan on a cadence (the session-18 hands-scan ~1 fps
-    // lesson; the game intro has no weapon for minutes).
-    uint32_t mask = nullResolves >= 3 ? 2047 : 15;
-    if ((++throttle & mask) != 0) return;
+    // Cheap-read cadence. The scan fallback has its own dormancy latch below,
+    // so this no longer needs to widen (it used to stretch to 2047 frames on
+    // repeated misses, which merely spread the multi-second heap walks out
+    // rather than stopping them).
+    if ((++throttle & 15) != 0) return;
     // Primary: Hands.CurrentHoldable raw off the rig, CLASS-AGNOSTIC
     // (session 21 part 3: MachineGun/GrenadeLauncher carry a different
     // native vtable, so the vtable-gated path rejected them and the stale
@@ -889,16 +894,34 @@ void update_weapon_profile(const FrameContext& ctx) {
     bool haveRig = hands::current_holdable(&w);
     if (!haveRig) {
         w = hands::weapon_actor();
-        // Session 22: the SCAN fallback goes fully DORMANT after 3 straight
-        // failures - the reduced cadence still meant a multi-second heap
-        // walk every ~2000 frames FOREVER on saves with no resolvable
-        // weapon (the early game; user-felt as "the game freezes every
-        // couple of seconds" at the Gatherer's Garden). The cheap rig and
-        // learned-actor reads above keep running at the throttled cadence
-        // and re-arm the scanner the moment they see anything.
-        if (!w && nullResolves < 3) w = hands::resolve_weapon_actor(ctx);
+        // The SCAN fallback goes fully DORMANT after repeated misses. Session
+        // 22 established the need (a reduced cadence still meant a
+        // multi-second heap walk every ~2000 frames FOREVER on saves with no
+        // resolvable weapon - user-felt as "the game freezes every couple of
+        // seconds" at the Gatherer's Garden), but shipped it as a caller-local
+        // counter that ANY momentary success zeroed. weapon_valid() is two
+        // chained vtable compares on memory we do not own, so a stack slot or
+        // a churning heap block satisfies it transiently, the counter resets,
+        // and the walks come back - which is exactly what the session-27
+        // external crash log shows. The latch below is structural: a success
+        // clears the miss COUNT, only an explicit re-arm clears dormancy.
+        //
+        // Also gated on the STRICT gameplay predicate, not aim's own
+        // g_gameplayView: that one deliberately counts the menu attract scene
+        // as gameplay (see the hatch in on_calcview), which is how full heap
+        // walks came to run at the main menu despite the comment above saying
+        // they did not.
+        if (!w && !g_weaponScanDormant && body::is_gameplay_view(ctx.viewActor)) {
+            w = hands::resolve_weapon_actor(ctx);
+            if (!w && ++g_weaponScanMisses >= patterns::kScanMissesBeforeDormant) {
+                g_weaponScanDormant = true;
+                BVR_LOG("[aim] weapon scan fallback DORMANT after %d miss(es) - the cheap rig "
+                        "and learned-actor reads keep running; a view-state change re-arms it",
+                        g_weaponScanMisses);
+            }
+        }
     }
-    nullResolves = (haveRig || w) ? 0 : nullResolves + 1;
+    if (haveRig || w) g_weaponScanMisses = 0;
     if (w == g_weaponKeyActor) return;
     g_weaponKeyActor = w;
     const wchar_t* name = w ? patterns::object_class_name(w) : nullptr;
@@ -1517,6 +1540,14 @@ float trim_yaw_deg(int hand) {
 }
 
 bool laser_enabled() { return g_laser.load(std::memory_order_relaxed); }
+
+void weapon_scan_rearm(const char* why) {
+    g_weaponScanMisses = 0;
+    if (g_weaponScanDormant) {
+        g_weaponScanDormant = false;
+        BVR_LOG("[aim] weapon scan fallback re-armed (%s)", why);
+    }
+}
 
 float pos_fwd_cm(int hand) {
     return g_posFwdCm[hand == 0 ? 0 : 1].load(std::memory_order_relaxed);

--- a/src/game/bioshock1r/aim.h
+++ b/src/game/bioshock1r/aim.h
@@ -118,4 +118,10 @@ void reapply_weapon_profile();
 // thread.
 void note_preset_baseline();
 
+// Wake the weapon-actor scan fallback, which latches dormant after repeated
+// misses so it can never resume walking memory on a cadence. Call on an event
+// that plausibly created a weapon: entering the gameplay view, a pawn change, a
+// level load. `why` is logged. Game thread.
+void weapon_scan_rearm(const char* why);
+
 } // namespace bvr::b1r::aim

--- a/src/game/bioshock1r/bones.cpp
+++ b/src/game/bioshock1r/bones.cpp
@@ -18,6 +18,7 @@
 #include "game/bioshock1r/bones.h"
 
 #include "core/gfx/frame_inspector.h"
+#include "core/gfx/hud_capture.h" // backbuffer_dims: the lens laws are aspect-parameterised
 #include "core/util/log.h"
 #include "game/bioshock1r/camera.h"
 #include "game/bioshock1r/hands.h"
@@ -376,6 +377,17 @@ bool solve_fg(const float M[12], float ndcX, float ndcY, float w, float outP[3])
 // NDC of the world target through a pinhole at the camera position with the
 // given rotation and the world option FOV. outDf = the target's forward
 // distance from the camera - the "true distance" the depth constraint uses.
+// Session 28: h/w of the live backbuffer, defaulting to 16:9. The world lens is
+// tanV = tanH*(h/w) (dump-measured, ENGINE_NOTES "Session 28"), so every model
+// of it here has to read the real aspect. It was hardcoded 9/16, which is right
+// only at 16:9 - and the resolutions people actually run in VR are square-ish.
+float live_inv_aspect() {
+    unsigned w = 0, h = 0;
+    if (bvr::hud::backbuffer_dims(&w, &h) && w && h)
+        return static_cast<float>(h) / static_cast<float>(w);
+    return 9.0f / 16.0f;
+}
+
 bool world_ndc(const FrameContext& ctx, const GamePose& gp, const FRotator& rot, float tanH,
                float* outX, float* outY, float* outDf) {
     float fwd[3], right[3], up[3];
@@ -385,7 +397,7 @@ bool world_ndc(const FrameContext& ctx, const GamePose& gp, const FRotator& rot,
     if (df < 4.0f) return false; // target at/behind the eye: no stable pixel
     float dr = d[0] * right[0] + d[1] * right[1] + d[2] * right[2];
     float du = d[0] * up[0] + d[1] * up[1] + d[2] * up[2];
-    float tanV = tanH * (9.0f / 16.0f); // 16:9 window (matches the option's meaning)
+    float tanV = tanH * live_inv_aspect(); // world lens: vertical follows the window
     *outX = dr / (df * tanH);
     *outY = du / (df * tanV);
     *outDf = df;
@@ -436,9 +448,19 @@ bool render_lock_delta(const FrameContext& ctx, const GamePose& gp, const float 
     // live world tanH and the lens ratio k collapses to 1, so the depth
     // constraint w* = k*df becomes simply the true distance. Without the
     // match, the legacy 60-deg constants apply (kept for A/B).
+    // Session 28: the vertical model reads the LIVE aspect. This comment's claim
+    // that "the rig renders through the WORLD lens, so k collapses to 1" was
+    // TRUE only at 16:9 - the shipped match constant (0.75) left the fg lens
+    // 1.7778/aspect narrower than the world everywhere else, so at a square
+    // backbuffer k was really 1.7778 while this code assumed 1. That mis-scaled
+    // the depth constraint AND the head-split lateral cancel, which is what
+    // "the hand and gun move when the headset moves" looks like. With the
+    // aspect-correct fg write in camera.cpp the lenses genuinely match and k
+    // genuinely collapses to 1 - the assumption is now earned, not asserted.
     bool matched = camera::fg_fov_match_active();
     float invTanHFg = matched ? 1.0f / tanH : patterns::kFgInvTanH;
-    float invTanVFg = matched ? 1.0f / (tanH * (9.0f / 16.0f)) : patterns::kFgInvTanV;
+    float invTanVFg =
+        matched ? 1.0f / (tanH * live_inv_aspect()) : patterns::kFgInvTanV;
     float k = tanH * invTanHFg;
     float wStar = k * df;
     if (wStar < 4.0f) return false; // hand at/behind the face: no stable solve

--- a/src/game/bioshock1r/bones.cpp
+++ b/src/game/bioshock1r/bones.cpp
@@ -223,6 +223,14 @@ bool resolve_skel(void* actor, Skel& out) {
     if (!read_n(static_cast<uint8_t*>(si) + patterns::kSkelInstBonesOffset, &a, sizeof a) ||
         !a.bones || a.count < 1 || a.count > kMaxBones)
         return false;
+    // The count bound alone is not enough (session 27): the drive memcpys up to
+    // count * sizeof(Qts) bytes THROUGH a.bones, so a plausible count paired
+    // with an array pointer that does not actually have that many readable
+    // bytes behind it is a multi-kilobyte write into whatever follows. The SEH
+    // guard on write_n turns that into a survivable fault, not a correct one -
+    // so require the whole span to be committed before trusting the pair.
+    if (!bvr::pattern_scan::is_memory_valid(a.bones, static_cast<size_t>(a.count) * sizeof(Qts)))
+        return false;
     out.inst = si;
     out.bones = a.bones;
     out.count = a.count;

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -336,6 +336,8 @@ void apply_command(const char* cmd, const char* args) {
             g_gameFovWrite.store(true, std::memory_order_relaxed);
             BVR_LOG("[b1r] command: gfov %.1f", v);
         }
+    } else if (strcmp(cmd, "buildgate") == 0) {
+        patterns::handle_buildgate_command(args);
     } else if (strcmp(cmd, "recenter") == 0) {
         g_recenterRequested.store(true, std::memory_order_relaxed);
         BVR_LOG("[b1r] command: recenter");

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -148,6 +148,13 @@ std::atomic<void*>    g_lastViewActor{nullptr}; // *view_actor out-param (the pa
 std::atomic<bool>  g_fgFovMatch{true};
 std::atomic<float> g_fgFovSaved{0.0f};   // engine value to restore on disable
 std::atomic<float> g_fgFovWritten{0.0f}; // telemetry: what we wrote last
+// Session 28: `vrfgfov legacy on` restores the pre-session-28 hardcoded 0.75
+// match constant, which is (4/3)*(9/16) - correct at 16:9 and 1.7778/aspect too
+// narrow everywhere else. Kept as an instant in-headset A/B for the viewmodel,
+// because the aspect correction is the change that made the hands and the world
+// geometrically correct AT THE SAME TIME and that pairing needs confirming.
+std::atomic<bool>  g_fgFovLegacy{false};
+std::atomic<float> g_fgFovK{0.75f};      // telemetry: the match constant used
 
 using CalcViewFn = void(__fastcall*)(void* self, void* edx, void** viewActor,
                                      FVector* loc, FRotator* rot);
@@ -419,10 +426,25 @@ void apply_command(const char* cmd, const char* args) {
                 "callstacks",
                 shots);
     } else if (strcmp(cmd, "vrfgfov") == 0) {
+        // Session 28: `legacy on|off` flips the match constant between the
+        // aspect-correct (4/3)*(h/w) and the pre-session-28 hardcoded 0.75, for
+        // an instant in-headset viewmodel A/B. Identical at 16:9.
+        if (strncmp(args, "legacy", 6) == 0) {
+            bool leg = strstr(args + 6, "off") == nullptr;
+            g_fgFovLegacy.store(leg, std::memory_order_relaxed);
+            BVR_LOG("[b1r] fg lens match constant: %s (last k=%.6f, last written "
+                    "%.1f deg) - legacy 0.75 is (4/3)*(9/16), correct at 16:9 only",
+                    leg ? "LEGACY 0.75" : "aspect-correct (4/3)*(h/w)",
+                    g_fgFovK.load(std::memory_order_relaxed),
+                    g_fgFovWritten.load(std::memory_order_relaxed));
+            return;
+        }
         bool on = strncmp(args, "off", 3) != 0;
         g_fgFovMatch.store(on, std::memory_order_relaxed);
-        BVR_LOG("[b1r] fg lens match %s (last written %.1f)", on ? "ON" : "off",
-                g_fgFovWritten.load(std::memory_order_relaxed));
+        BVR_LOG("[b1r] fg lens match %s (last written %.1f deg, k=%.6f)",
+                on ? "ON" : "off",
+                g_fgFovWritten.load(std::memory_order_relaxed),
+                g_fgFovK.load(std::memory_order_relaxed));
     } else if (strcmp(cmd, "fginfo") == 0) {
         BVR_LOG("[b1r] fginfo: pc=%p viewActor=%p hands=%p weapon=%p (fsweep/hexdump "
                 "targets)",
@@ -788,7 +810,20 @@ void apply_vr_preset() {
     bvr::vr::set_camera_mode(true);    // 6DOF head drive
     bvr::vr::set_sr_pair_pacing(true); // one waitFrame per eye pair
     input::handle_command("on");       // motion controllers as gamepad
-    g_gameFovWrite.store(true, std::memory_order_relaxed);
+    // SESSION 28: the preset no longer forces the game-FOV write ON.
+    //
+    // It used to push option 130, and 130 came from the "129.5 circumscribing"
+    // arithmetic, which solved `tan(option/2)*9/16*aspect = tan(H/2)` - i.e. it
+    // was derived from the WRONG world-lens law. The measured law is
+    // `tanH = tan(option/2)` with no aspect term, so at a square backbuffer
+    // option 100 already renders exactly 100x100 deg - close to ideal for a
+    // Quest-class eye - and 130 over-widens the render by 30 deg, wasting pixels
+    // and shrinking the world inside the eye's actual FOV. It also drags the
+    // foreground lens out with it (~141 deg at option 130 square).
+    // The user confirmed in-headset that the write had to be turned OFF, which
+    // is what the corrected law predicts. `gfov <deg>` still arms it manually,
+    // and the global default was already false - this line was the only thing
+    // turning it on.
     aim::handle_command("on");         // controller aim (R weapon / L plasmid)
     aim::handle_command("pose aim");   // the runtime AIM pose
     aim::handle_command("origin on");  // ray starts at the hand
@@ -1338,9 +1373,49 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
                 if (g_fgFovSaved.load(std::memory_order_relaxed) == 0.0f)
                     g_fgFovSaved.store(*fgFov, std::memory_order_relaxed);
                 float tanW = tanf(static_cast<float>(*opt) * 0.5f / kRadToDeg);
-                float fg = 2.0f * atanf(tanW * 0.75f) * kRadToDeg;
+                // SESSION 28: the match constant is (4/3)*(h/w), NOT 0.75.
+                //
+                // The two passes anchor OPPOSITE axes (ENGINE_NOTES "Session
+                // 28", dump-measured): the world pass fixes the horizontal
+                // (tanH = tan(option/2), tanV = tanH*h/w) and the foreground
+                // pass fixes the vertical (tanV = tan(fgFov/2)*3/4, tanH =
+                // tanV*w/h). Equating the two verticals:
+                //     tan(fgHalf)*3/4 = tan(option/2)*(h/w)
+                //  => tan(fgHalf)    = tan(option/2)*(4/3)*(h/w)
+                // 0.75 IS (4/3)*(9/16), i.e. that expression at 16:9 and
+                // nowhere else. Off 16:9 the shipped constant left the fg lens
+                // 1.7778/aspect narrower than the world - 1.78x at the square
+                // backbuffer the README recommends.
+                //
+                // Why this is load-bearing rather than cosmetic: ONE projection
+                // layer claim serves the whole eye image, so while the two
+                // lenses differ only one of {world, viewmodel} can be
+                // geometrically correct. Before the session-28 watch fix the
+                // claim accidentally carried the FG lens - hands right, world
+                // warping. Fixing the world moved the error onto the hands
+                // ("the gun moves when the headset moves"). Matching the lenses
+                // is what makes both correct at once, and it also makes
+                // bones.cpp's render-lock assumption ("k collapses to 1") TRUE
+                // off 16:9, which it silently was not.
+                //
+                // Independent corroboration: BioVRDev use exactly
+                // 2*atan(tan(fov/2)*(4/3)/aspect) - recorded in
+                // docs/RESEARCH.md since session 20 and never acted on.
+                //
+                // At 16:9 this is bit-identical to the shipped 0.75, so the
+                // session-16 in-headset calibration is preserved by
+                // construction. `vrfgfov legacy on` restores the old constant
+                // for an instant A/B.
+                float k = 0.75f;
+                unsigned bbW = 0, bbH = 0;
+                if (!g_fgFovLegacy.load(std::memory_order_relaxed) &&
+                    bvr::hud::backbuffer_dims(&bbW, &bbH) && bbW && bbH)
+                    k = (4.0f / 3.0f) * (static_cast<float>(bbH) /
+                                         static_cast<float>(bbW));
+                float fg = 2.0f * atanf(tanW * k) * kRadToDeg;
                 *fgFov = fg;
                 g_fgFovWritten.store(fg, std::memory_order_relaxed);
+                g_fgFovK.store(k, std::memory_order_relaxed);
             }
         } else {
             float saved = g_fgFovSaved.load(std::memory_order_relaxed);

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -33,6 +33,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <iterator>
 #include <share.h>
 
 namespace bvr::b1r::camera {
@@ -76,6 +77,11 @@ std::atomic<float> g_headOffFwdUu{0.0f};
 // run on the game thread next frame.
 std::atomic<bool> g_vrPresetPending{false};
 std::atomic<bool> g_vrPresetSavePending{false};
+// Render-resolution request from the overlay. The overlay runs on the RENDER
+// thread and this does file I/O plus a read-back, so it goes through the
+// established pending-atomic seam and is performed on the game thread, next to
+// the preset consumers. Packed as one 64-bit value so the pair cannot tear.
+std::atomic<uint64_t> g_resWritePending{0};
 
 // M8 session 18 part 2: the flat-screen crosshair, DEFAULT HIDDEN (user ask).
 // The lever is `ShockPlayer.bReticleDisabled` - the game's own RenderReticle
@@ -926,6 +932,10 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
     // the render thread and only sets the pending flags).
     if (g_vrPresetPending.exchange(false, std::memory_order_relaxed)) apply_vr_preset();
     if (g_vrPresetSavePending.exchange(false, std::memory_order_relaxed)) save_vr_preset();
+    if (uint64_t req = g_resWritePending.exchange(0, std::memory_order_relaxed)) {
+        game_ini::write_viewport(static_cast<uint32_t>(req >> 32),
+                                 static_cast<uint32_t>(req & 0xFFFFFFFFu));
+    }
     // M5: pump the engine's own pad pipeline against the synthetic gamepad
     // (self-throttles to once per present; no-op while vrinput is off).
     input_drive::on_frame(now);
@@ -1585,6 +1595,101 @@ void draw_debug_ui() {
         bool lockoff = g_lockOnDisabled.load(std::memory_order_relaxed);
         if (ImGui::Checkbox("Lock-on disabled (pad aim magnetism off)", &lockoff))
             g_lockOnDisabled.store(lockoff, std::memory_order_relaxed);
+        // ---- render resolution ------------------------------------------
+        // This is the sharpness control, and it is the game's own resolution
+        // because the eye render IS the backbuffer. It cannot be applied live:
+        // the engine's SETRES faults (ENGINE_NOTES session 27), so the only
+        // working lever is the config the engine reads at startup. Say so
+        // plainly rather than letting a slider imply an instant effect.
+        if (ImGui::CollapsingHeader("Render resolution (applies on next launch)")) {
+            static bool s_read = false;
+            static int s_w = 0, s_h = 0;
+            unsigned liveW = 0, liveH = 0;
+            bvr::vr::fov_audit(nullptr, nullptr, nullptr, &liveW, &liveH);
+            game_ini::Viewport v = game_ini::read_viewport();
+            if (!s_read && v.valid) {
+                s_read = true;
+                s_w = static_cast<int>(v.windowedW);
+                s_h = static_cast<int>(v.windowedH);
+            }
+            if (!v.valid) {
+                ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f),
+                                   "Bioshock.ini not found - cannot set the resolution");
+            } else {
+                ImGui::Text("ini: %ux%u   live backbuffer: %ux%u", v.windowedW, v.windowedH,
+                            liveW, liveH);
+                if (liveW && liveH) {
+                    // A headset eye is near square. A 16:9 buffer spends most of
+                    // its width outside the lenses, which is the whole reason
+                    // this control exists - quantify it instead of asserting it.
+                    float aspect = static_cast<float>(liveW) / static_cast<float>(liveH);
+                    ImGui::Text("aspect %.3f (1.000 is ideal; a headset eye is near square)",
+                                aspect);
+                    if (aspect > 1.25f || aspect < 0.8f)
+                        ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.3f, 1.0f),
+                                           "far from square: much of this render falls "
+                                           "outside the lenses");
+                }
+                // A dropdown of named modes with a Custom escape hatch - the
+                // shape every game's video options uses, so it needs no
+                // explaining. The list is square-first because a headset eye is
+                // near square, with one 16:9 entry for playing flat. The top end
+                // is deliberately generous: a user on a Dream Air runs 7680x4320
+                // happily, so clamping low would be the bug, not the safety.
+                struct Mode {
+                    const char* name;
+                    int w, h;
+                };
+                static const Mode kModes[] = {
+                    {"1920 x 1080  (16:9, for flat play)", 1920, 1080},
+                    {"2048 x 2048  (4.2 MPx, balanced)", 2048, 2048},
+                    {"2560 x 2560  (6.6 MPx, sharper)", 2560, 2560},
+                    {"3072 x 3072  (9.4 MPx, high-end GPU)", 3072, 3072},
+                    {"4096 x 4096  (16.8 MPx, very demanding)", 4096, 4096},
+                    {"Custom...", 0, 0},
+                };
+                const int kCustom = static_cast<int>(std::size(kModes)) - 1;
+
+                // Preselect whatever the ini already says, so the dropdown opens
+                // showing the truth rather than a default.
+                static int s_sel = -1;
+                if (s_sel < 0) {
+                    s_sel = kCustom;
+                    for (int i = 0; i < kCustom; ++i)
+                        if (kModes[i].w == s_w && kModes[i].h == s_h) s_sel = i;
+                }
+                const char* preview = kModes[s_sel].name;
+                if (ImGui::BeginCombo("Resolution", preview)) {
+                    for (int i = 0; i < static_cast<int>(std::size(kModes)); ++i) {
+                        if (ImGui::Selectable(kModes[i].name, s_sel == i)) {
+                            s_sel = i;
+                            if (i != kCustom) {
+                                s_w = kModes[i].w;
+                                s_h = kModes[i].h;
+                            }
+                        }
+                    }
+                    ImGui::EndCombo();
+                }
+                if (s_sel == kCustom) {
+                    ImGui::InputInt("width", &s_w, 64, 256);
+                    ImGui::InputInt("height", &s_h, 64, 256);
+                    if (s_w < 1024) s_w = 1024;
+                    if (s_h < 1024) s_h = 1024;
+                    if (s_w > 8192) s_w = 8192;
+                    if (s_h > 8192) s_h = 8192;
+                }
+                ImGui::Text("selected: %d x %d, %.1f MPx per eye", s_w, s_h,
+                            static_cast<double>(s_w) * s_h / 1.0e6);
+                if (ImGui::Button("Write to Bioshock.ini")) {
+                    g_resWritePending.store((static_cast<uint64_t>(s_w) << 32) |
+                                                static_cast<uint32_t>(s_h),
+                                            std::memory_order_relaxed);
+                }
+                ImGui::SameLine();
+                ImGui::TextDisabled("restart the game for it to take effect");
+            }
+        }
         atomic_slider("World scale (UU per m)", g_worldScale, 10.0f, 200.0f);
         atomic_slider("IPD (mm)", g_ipdMm, 55.0f, 75.0f);
         atomic_slider("Head offset up (UU)", g_headOffUpUu, -150.0f, 150.0f);

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -459,14 +459,23 @@ void apply_command(const char* cmd, const char* args) {
             int src = -1;
             unsigned sw = 0, sh = 0;
             bvr::vr::fov_audit(&tanH, &tanV, &src, &sw, &sh);
-            // Option-derived expectation. Flat there is no session (swap dims
-            // 0x0) - assume the 16:9 render aspect the dumps confirm per draw.
+            // Option-derived expectation, from the WORLD lens law measured in
+            // session 28: tanH = tan(option/2) (aspect-independent), tanV =
+            // tanH * (h/w). Flat there is no XR session, so fall back to the
+            // real BACKBUFFER dims - never to a hardcoded 9/16, which is right
+            // only at 16:9 and is how a 1.84x error stayed invisible.
+            unsigned bbW = 0, bbH = 0;
+            bool haveBb = bvr::hud::backbuffer_dims(&bbW, &bbH);
+            unsigned aw = (sw && sh) ? sw : bbW;
+            unsigned ah = (sw && sh) ? sh : bbH;
             float optTanH = 0.0f, optTanV = 0.0f;
             if (opt) {
                 optTanH = tanf(static_cast<float>(*opt) * 0.5f / kRadToDeg);
-                optTanV = optTanH * ((sw && sh) ? (static_cast<float>(sh) / static_cast<float>(sw))
-                                                : (9.0f / 16.0f));
+                optTanV = optTanH * ((aw && ah) ? (static_cast<float>(ah) /
+                                                   static_cast<float>(aw))
+                                                : 1.0f);
             }
+            (void)haveBb;
             BVR_LOG("[b1r] fovaudit: option=%d gfovWrite=%s(%.1f) | submitted tanH=%.6f "
                     "tanV=%.6f src=%s swap=%ux%u | option-derived tanH=%.6f tanV=%.6f",
                     opt ? *opt : -1,
@@ -478,18 +487,44 @@ void apply_command(const char* cmd, const char* args) {
                     : src == 3 ? "live"
                                : "none",
                     sw, sh, optTanH, optTanV);
-            // Session 22 live fov watch: what the game is ACTUALLY rendering
-            // right now (decoded per present from the first scene draw's cb0).
+            // Session 22 live fov watch, session 28: BOTH lenses, each labelled
+            // FRESH or STALE in words. maxAge 0 so a stale value still prints -
+            // several session-27 conclusions were taken from samples that
+            // printed age>9000ms, stale by the rule the same line printed, so
+            // the word is now on the line and nothing has to be inferred.
             float liveTanH = 0.0f, liveTanV = 0.0f;
             unsigned long long liveAge = 0;
-            if (bvr::hud::fov_watch(&liveTanH, &liveTanV, &liveAge))
-                BVR_LOG("[b1r] fovaudit live: rendered tanH=%.4f tanV=%.4f (%.1f deg) "
-                        "age=%llums | mismatch=%d cineActive=%d",
+            if (bvr::hud::fov_watch(&liveTanH, &liveTanV, &liveAge, 0)) {
+                float fgH = 0.0f, fgV = 0.0f;
+                unsigned long long fgAge = 0;
+                bool haveFg = bvr::hud::fov_watch_fg(&fgH, &fgV, &fgAge, 0);
+                BVR_LOG("[b1r] fovaudit live: WORLD tanH=%.6f tanV=%.6f (%.2f deg) "
+                        "age=%llums %s | FG tanH=%.6f tanV=%.6f age=%llums %s | "
+                        "lenses=%d mismatch=%d cineActive=%d",
                         liveTanH, liveTanV, 2.0f * atanf(liveTanH) * kRadToDeg,
-                        liveAge, bvr::hud::fov_mismatch() ? 1 : 0,
+                        liveAge, liveAge <= 500 ? "FRESH" : "STALE - DO NOT CONCLUDE",
+                        haveFg ? fgH : 0.0f, haveFg ? fgV : 0.0f, fgAge,
+                        !haveFg ? "n/a (single lens - 16:9)"
+                                : (fgAge <= 500 ? "FRESH" : "STALE"),
+                        bvr::hud::fov_lens_count(),
+                        bvr::hud::fov_mismatch() ? 1 : 0,
                         bvr::vr::cinematic_active() ? 1 : 0);
-            else
+                // The two laws, spelled out against this backbuffer so the
+                // reader never has to redo the arithmetic (session 28 measured:
+                // world is horizontal-anchored, fg is vertical-anchored).
+                if (opt && aw && ah) {
+                    float a = static_cast<float>(aw) / static_cast<float>(ah);
+                    BVR_LOG("[b1r] fovaudit laws (aspect %.5f from %ux%u): world "
+                            "expects tanH=tan(opt/2)=%.6f tanV=tanH*h/w=%.6f | fg "
+                            "matches the world when the 0.75 becomes "
+                            "(4/3)*h/w=%.6f (shipped 0.75 is that only at 16:9; "
+                            "here it under-lenses the viewmodel by %.4fx)",
+                            a, aw, ah, optTanH, optTanV,
+                            (4.0f / 3.0f) / a, (4.0f / 3.0f) / a / 0.75f);
+                }
+            } else {
                 BVR_LOG("[b1r] fovaudit live: no decoded scene tangents yet");
+            }
         }
     } else if (strcmp(cmd, "fsweep") == 0) {
         float lo = 0.0f, hi = 0.0f;

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -775,7 +775,7 @@ void assert_crosshair(uint64_t now) {
 void assert_lockon(uint64_t now) {
     int want = g_lockOnDisabled.load(std::memory_order_relaxed) ? 1 : 0;
     bool due = want != g_lockOnApplied ||
-               (want == 1 && now - g_lockOnAssertMs >= 15000);
+               (want == 1 && now - g_lockOnAssertMs >= kExecReassertMs);
     if (!due) return;
     bool first = g_lockOnApplied != want;
     g_lockOnApplied = want;

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -14,6 +14,7 @@
 #include "game/bioshock1r/body.h"
 #include "game/bioshock1r/bones.h"
 #include "game/bioshock1r/console_exec.h"
+#include "game/bioshock1r/game_ini.h"
 #include "core/vr/openxr_runtime.h"
 #include "game/bioshock1r/hands.h"
 #include "game/bioshock1r/input_drive.h"
@@ -338,6 +339,21 @@ void apply_command(const char* cmd, const char* args) {
         }
     } else if (strcmp(cmd, "buildgate") == 0) {
         patterns::handle_buildgate_command(args);
+    } else if (strcmp(cmd, "vrres") == 0) {
+        // The eye render IS the game's backbuffer, so the game's resolution is
+        // the VR resolution. `SETRES` faults (ENGINE_NOTES session 27), so the
+        // game's own ini is the only working lever and a change lands on the
+        // next launch. Deliberately explicit rather than automatic.
+        unsigned rw = 0, rh = 0;
+        if (sscanf_s(args, "%ux%u", &rw, &rh) == 2 && rw && rh) {
+            game_ini::write_viewport(rw, rh);
+        } else if (sscanf_s(args, "%u %u", &rw, &rh) == 2 && rw && rh) {
+            game_ini::write_viewport(rw, rh);
+        } else {
+            unsigned bw = 0, bh = 0;
+            bvr::vr::fov_audit(nullptr, nullptr, nullptr, &bw, &bh);
+            game_ini::log_status(bw, bh);
+        }
     } else if (strcmp(cmd, "recenter") == 0) {
         g_recenterRequested.store(true, std::memory_order_relaxed);
         BVR_LOG("[b1r] command: recenter");

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -745,13 +745,23 @@ void apply_vr_preset() {
     BVR_LOG("[b1r] VR PRESET 1 armed (unwind: vrstereo off + overlay checkboxes)");
 }
 
+// Re-assert interval for the engine-exec upkeep below. Was 15 s, which meant a
+// shipping session made two calls into the engine's SET handler through a
+// hand-built FOutputDevice stub every 15 seconds forever - five times in the 85 s
+// of the session-27 crash report. The stub is now measured and self-disabling
+// (console_exec.cpp), but the exposure was still 20x more than the job needs:
+// the state is re-asserted on the events that can actually undo it (entering
+// gameplay, a pawn or level change - see note_world_event) and this timer is only
+// a slow safety net for a script-side caller we have not identified.
+constexpr uint64_t kExecReassertMs = 300000; // 5 minutes
+
 // Crosshair upkeep (see the globals): push the wanted state through the
-// engine's SET handler on change, and re-assert every 15 s while hidden in
-// case script-side EnableReticle callers exist somewhere. Game thread.
+// engine's SET handler on change, on a world event, and on the slow safety
+// net. Game thread.
 void assert_crosshair(uint64_t now) {
     int want = g_crosshairVisible.load(std::memory_order_relaxed) ? 1 : 0;
     bool due = want != g_crosshairApplied ||
-               (want == 0 && now - g_crosshairAssertMs >= 15000);
+               (want == 0 && now - g_crosshairAssertMs >= kExecReassertMs);
     if (!due) return;
     g_crosshairApplied = want;
     g_crosshairAssertMs = now;
@@ -775,6 +785,15 @@ void assert_lockon(uint64_t now) {
     else if (first)
         BVR_LOG("[b1r] pad lock-on re-enabled: the game's own radius returns "
                 "on the next game restart");
+}
+
+// One engine-state re-assert, driven by an event rather than a timer. Called on
+// the gameplay-view transition, which is the point a new pawn or a fresh level
+// can have reset the properties we set.
+void note_world_event(const char* why) {
+    g_crosshairApplied = -1; // sentinel: forces one assert on the next tick
+    g_lockOnApplied = -1;
+    BVR_LOG("[b1r] engine-state re-assert queued (%s)", why);
 }
 
 void poll_command_file(uint64_t now) {
@@ -1176,6 +1195,9 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
             if (strictGameplay) {
                 patterns::hfov_scan_rearm("entered gameplay view");
                 aim::weapon_scan_rearm("entered gameplay view");
+                // Same event drives the engine-property re-assert, which used to
+                // run off a 15 s timer forever (session 27).
+                note_world_event("entered gameplay view");
             }
         }
 

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -154,6 +154,27 @@ bool g_wasOverridingFov = false;
 float g_savedFov = 0.0f;
 bool g_wasWritingGameFov = false;
 int32_t g_savedGameFov = 0;
+// WHICH object g_savedGameFov was captured from (session 27). Without this the
+// restore could write object A's saved value into object B after a re-scan
+// picked a different instance, and a value restored into the wrong object is
+// indistinguishable from corruption. Also gates the write itself: the pointer
+// must still be the one we bound to.
+const int32_t* g_savedGameFovOwner = nullptr;
+
+// SEH-guarded write of the settings FOV int. The pointer comes from an object
+// search, and while the search is now stack-safe and liveness-checked
+// (heap_scan.h), "the address passed two identity predicates" is still not the
+// same as "the engine owns this and it is safe to poke". A fault here must
+// never take the game down; it disarms the writer instead. Logging happens at
+// the call site, never inside the guard.
+bool write_option_fov(int32_t* dst, int32_t value) {
+    __try {
+        if (*dst != value) *dst = value;
+        return true;
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        return false;
+    }
+}
 uint64_t g_lastHeartbeatMs = 0;
 uint32_t g_heartbeatBaseCount = 0;
 bool g_haveRecenter = false;
@@ -1047,16 +1068,41 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
         if (wantVr || wantManual) {
             if (!g_wasWritingGameFov) {
                 g_savedGameFov = *optionFov;
+                g_savedGameFovOwner = optionFov;
                 g_wasWritingGameFov = true;
-                BVR_LOG("[b1r] game fov write ON (saved option %d)", g_savedGameFov);
+                BVR_LOG("[b1r] game fov write ON (saved option %d from %p)", g_savedGameFov,
+                        optionFov);
+            } else if (optionFov != g_savedGameFovOwner) {
+                // The scan re-bound to a different instance while we were
+                // writing. The old object's saved value means nothing here, so
+                // re-seed rather than carrying it across.
+                BVR_LOG("[b1r] game fov owner changed %p -> %p - re-seeding the saved option "
+                        "(was %d, now %d)",
+                        static_cast<const void*>(g_savedGameFovOwner), optionFov, g_savedGameFov,
+                        *optionFov);
+                g_savedGameFov = *optionFov;
+                g_savedGameFovOwner = optionFov;
             }
             float want = wantVr ? vrFov : g_gameFovDeg.load(std::memory_order_relaxed);
             int32_t wantInt = static_cast<int32_t>(want + 0.5f);
-            if (*optionFov != wantInt) *optionFov = wantInt;
+            if (!write_option_fov(optionFov, wantInt)) {
+                BVR_LOG("[b1r] game fov write FAULTED at %p - disarming the FOV writer", optionFov);
+                g_wasWritingGameFov = false;
+                g_savedGameFovOwner = nullptr;
+                g_gameFovWrite.store(false, std::memory_order_relaxed);
+                g_forceHeadsetFov.store(false, std::memory_order_relaxed);
+            }
         } else if (g_wasWritingGameFov) {
-            *optionFov = g_savedGameFov;
+            // Only restore into the object the value came from.
+            if (optionFov == g_savedGameFovOwner && write_option_fov(optionFov, g_savedGameFov))
+                BVR_LOG("[b1r] game fov write OFF (restored option %d)", g_savedGameFov);
+            else
+                BVR_LOG("[b1r] game fov write OFF (saved %d NOT restored - object is %p, the "
+                        "value came from %p)",
+                        g_savedGameFov, optionFov,
+                        static_cast<const void*>(g_savedGameFovOwner));
             g_wasWritingGameFov = false;
-            BVR_LOG("[b1r] game fov write OFF (restored option %d)", g_savedGameFov);
+            g_savedGameFovOwner = nullptr;
         }
     }
     g_vrDriving.store(vrDrove, std::memory_order_relaxed);
@@ -1123,6 +1169,14 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
             s_lastViewState = viewState;
             BVR_LOG("[b1r] view state: %s",
                     strictGameplay ? "GAMEPLAY (ShockPlayer view)" : "menu/cutscene");
+            // The object scanners latch dormant after repeated misses rather
+            // than rescanning forever (session 27); entering gameplay is the
+            // event that plausibly created what they were looking for, so it is
+            // the one place allowed to wake them.
+            if (strictGameplay) {
+                patterns::hfov_scan_rearm("entered gameplay view");
+                aim::weapon_scan_rearm("entered gameplay view");
+            }
         }
 
         // Radial-wheel pitch guard (session 19 part 2): the stick-pitch kill
@@ -1371,10 +1425,20 @@ void restore_game_fov_if_stale(uint64_t staleMs) {
     if (!g_wasWritingGameFov || !calcview_silent(staleMs)) return;
     int32_t* optionFov = patterns::hfov_option_ptr();
     if (!optionFov) return;
-    *optionFov = g_savedGameFov;
+    // Same ownership rule as the CalcView path: never write a value back into an
+    // object it did not come from (session 27).
+    if (optionFov != g_savedGameFovOwner) {
+        BVR_LOG("[b1r] game fov stale-restore SKIPPED - object is %p, the saved %d came from %p",
+                optionFov, g_savedGameFov, static_cast<const void*>(g_savedGameFovOwner));
+        g_wasWritingGameFov = false;
+        g_savedGameFovOwner = nullptr;
+        return;
+    }
+    bool ok = write_option_fov(optionFov, g_savedGameFov);
     g_wasWritingGameFov = false;
-    BVR_LOG("[b1r] game fov write OFF (restored option %d - calcview silent %llu ms)",
-            g_savedGameFov,
+    g_savedGameFovOwner = nullptr;
+    BVR_LOG("[b1r] game fov write OFF (%s option %d - calcview silent %llu ms)",
+            ok ? "restored" : "FAULTED restoring", g_savedGameFov,
             static_cast<unsigned long long>(GetTickCount64() - g_lastCalcViewMs));
 }
 

--- a/src/game/bioshock1r/console_exec.cpp
+++ b/src/game/bioshock1r/console_exec.cpp
@@ -8,6 +8,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <utility>
 
 namespace bvr::b1r::console_exec {
 namespace {
@@ -21,17 +22,44 @@ using ExecFn = int(__fastcall*)(void* self, void* edx, const wchar_t* cmd,
 // as a 2-arg log filter FIRST and skips formatting + Serialize entirely when
 // it returns 0 - so every slot here is a callee-pop-8 no-op RETURNING 0,
 // which both suppresses output and keeps direct Serialize(text, event)
-// (vtbl+0x4, 2 args) balanced. A slot invoked with a different arg count
-// would still unbalance the stack - accepted, SEH-guarded dev tool.
-int __stdcall StubNoop2(const void*, int) { return 0; }
-void* g_stubVtbl[24];
+// (vtbl+0x4, 2 args) balanced.
+//
+// A slot invoked with a DIFFERENT arg count still unbalances the stack, and no
+// stub can pop a count it does not know. That used to be written off as
+// "accepted, SEH-guarded dev tool" - but SEH cannot catch a silent stack
+// imbalance, and this stopped being a dev tool the moment the shipping build
+// started re-asserting the reticle through it every 15 s forever (session 27).
+// So instead of assuming, this now MEASURES:
+//   - each slot is its own thunk that records the fact it was entered, so the
+//     log says whether anything beyond the expected filter slot is ever
+//     reached on a real build;
+//   - esp is compared across the call and REPAIRED if it moved, and the seam
+//     latches off for the session on any imbalance or fault.
+uint32_t g_slotsHit = 0;
+uint32_t g_slotsReported = 0;
+bool g_seamDisabled = false;
+const char* g_seamDisabledWhy = nullptr;
+
+template <int Slot>
+int __stdcall StubSlot(const void*, int) {
+    g_slotsHit |= (1u << Slot);
+    return 0;
+}
+
+constexpr int kStubSlots = 24;
+void* g_stubVtbl[kStubSlots];
 struct Stub {
     void** vptr = nullptr;
 } g_stub;
 
+template <int... I>
+void fill_slots(std::integer_sequence<int, I...>) {
+    ((g_stubVtbl[I] = reinterpret_cast<void*>(&StubSlot<I>)), ...);
+}
+
 void ensure_stub() {
     if (g_stub.vptr) return;
-    for (auto& s : g_stubVtbl) s = reinterpret_cast<void*>(&StubNoop2);
+    fill_slots(std::make_integer_sequence<int, kStubSlots>{});
     g_stub.vptr = g_stubVtbl;
 }
 
@@ -46,17 +74,62 @@ int filter_capture(EXCEPTION_POINTERS* ep) {
     return EXCEPTION_EXECUTE_HANDLER;
 }
 
+// Kept separate from the SEH frame so the esp reads sit either side of a plain
+// call with its own frame: any imbalance inside the callee shows up here as the
+// caller's esp having moved, whatever the compiler did with the argument pushes.
+// Repairing esp is what turns "the process is now quietly corrupt" into "one
+// command did nothing and said so".
+__declspec(noinline) int call_exec(ExecFn fn, void* obj, const wchar_t* wcmd, bool* balanced) {
+    int r = 0;
+#ifdef _M_IX86
+    uintptr_t before = 0, after = 0;
+    __asm mov before, esp
+    r = fn(obj, nullptr, wcmd, &g_stub);
+    __asm mov after, esp
+    *balanced = (before == after);
+    if (before != after) {
+        __asm mov esp, before
+    }
+#else
+    r = fn(obj, nullptr, wcmd, &g_stub);
+    *balanced = true;
+#endif
+    return r;
+}
+
 int seh_exec(ExecFn fn, void* obj, const wchar_t* wcmd) {
+    bool balanced = true;
+    int r = 0;
     __try {
-        return fn(obj, nullptr, wcmd, &g_stub);
+        r = call_exec(fn, obj, wcmd, &balanced);
     } __except (filter_capture(GetExceptionInformation())) {
         auto* base = reinterpret_cast<uint8_t*>(GetModuleHandleW(nullptr));
         BVR_LOG("[b1r] exec fault: eip=%p (exe+0x%X) fault-addr=%p",
                 reinterpret_cast<void*>(g_faultIp),
                 g_faultIp - reinterpret_cast<uintptr_t>(base),
                 reinterpret_cast<void*>(g_faultAddr));
+        g_seamDisabled = true;
+        g_seamDisabledWhy = "a previous command faulted";
         return -1;
     }
+    if (!balanced) {
+        BVR_LOG("[b1r] exec STACK IMBALANCE on '%ls' - esp repaired and the engine-exec seam "
+                "is disabled for this session (a vtable slot took an argument count the "
+                "FOutputDevice stub cannot pop)",
+                wcmd);
+        g_seamDisabled = true;
+        g_seamDisabledWhy = "a previous command unbalanced the stack";
+        return -2;
+    }
+    // One line the first time a new set of stub slots is reached. Expected in
+    // practice is the single filter slot at vtbl+0x10 (bit 4); anything else
+    // means a code path we have not accounted for is calling into the stub.
+    if (g_slotsHit != g_slotsReported) {
+        g_slotsReported = g_slotsHit;
+        BVR_LOG("[b1r] exec: FOutputDevice stub slots reached = 0x%06X%s", g_slotsHit,
+                (g_slotsHit & ~(1u << 4)) ? " - UNEXPECTED slot(s) beyond the filter" : "");
+    }
+    return r;
 }
 
 // SEH-safe fetch of the UGameEngine object (vtable-identity checked).
@@ -79,6 +152,16 @@ enum class Entry { Viewport, Client, Engine };
 void run(const char* args, uint32_t rva, const char* label, Entry entry) {
     if (!args || !args[0]) {
         BVR_LOG("[b1r] exec: missing command text");
+        return;
+    }
+    if (g_seamDisabled) {
+        static bool once = false;
+        if (!once) {
+            once = true;
+            BVR_LOG("[b1r] exec: seam DISABLED for this session (%s) - '%s' and later commands "
+                    "are ignored; relaunch to re-enable",
+                    g_seamDisabledWhy, args);
+        }
         return;
     }
     ensure_stub();
@@ -114,10 +197,13 @@ void run(const char* args, uint32_t rva, const char* label, Entry entry) {
     auto* base = reinterpret_cast<uint8_t*>(GetModuleHandleW(nullptr));
     auto fn = reinterpret_cast<ExecFn>(base + rva);
     int r = seh_exec(fn, target, wcmd);
-    if (r < 0)
+    if (r == -1)
         BVR_LOG("[b1r] %s exec FAULTED on '%ls' (SEH caught - engine state "
                 "unknown, prefer a relaunch before trusting further commands)",
                 label, wcmd);
+    else if (r == -2)
+        BVR_LOG("[b1r] %s exec on '%ls' left the stack unbalanced - see the line above", label,
+                wcmd);
     else
         BVR_LOG("[b1r] %s exec '%ls' -> %s", label, wcmd,
                 r ? "HANDLED" : "unhandled (fell off this chain link)");

--- a/src/game/bioshock1r/game_ini.cpp
+++ b/src/game/bioshock1r/game_ini.cpp
@@ -1,0 +1,299 @@
+#include "game/bioshock1r/game_ini.h"
+
+#include "core/util/log.h"
+
+#include <windows.h>
+#include <shlobj.h>
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+namespace bvr::b1r::game_ini {
+namespace {
+
+// The PC driver section. The other three that carry identical key names are
+// [XeDrv.XenonClient], [DurangoDrv.DurangoClient] and [OrbisDrv.OrbisClient] -
+// console drivers, verified present in the shipped file at lines 467/499/531.
+// Never touch those.
+constexpr char kPcSection[] = "[WinDrv.WindowsClient]";
+
+wchar_t g_path[MAX_PATH] = {};
+bool g_searched = false;
+
+bool file_exists(const wchar_t* p) {
+    DWORD a = GetFileAttributesW(p);
+    return a != INVALID_FILE_ATTRIBUTES && !(a & FILE_ATTRIBUTE_DIRECTORY);
+}
+
+bool read_all(const wchar_t* p, std::string& out) {
+    HANDLE h = CreateFileW(p, GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING,
+                           FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (h == INVALID_HANDLE_VALUE) return false;
+    LARGE_INTEGER size{};
+    if (!GetFileSizeEx(h, &size) || size.QuadPart <= 0 || size.QuadPart > (8 << 20)) {
+        CloseHandle(h);
+        return false;
+    }
+    out.resize(static_cast<size_t>(size.QuadPart));
+    DWORD got = 0;
+    bool ok = ReadFile(h, out.data(), static_cast<DWORD>(out.size()), &got, nullptr) &&
+              got == out.size();
+    CloseHandle(h);
+    if (!ok) out.clear();
+    return ok;
+}
+
+bool write_all(const wchar_t* p, const std::string& data) {
+    HANDLE h = CreateFileW(p, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL,
+                           nullptr);
+    if (h == INVALID_HANDLE_VALUE) return false;
+    DWORD wrote = 0;
+    bool ok = WriteFile(h, data.data(), static_cast<DWORD>(data.size()), &wrote, nullptr) &&
+              wrote == data.size();
+    // Flush before the rename: a crash between the two would otherwise leave a
+    // zero-length temp file to be promoted over the real config.
+    if (ok) FlushFileBuffers(h);
+    CloseHandle(h);
+    return ok;
+}
+
+// [start, end) byte span of the PC driver section's BODY, or false.
+bool pc_section_span(const std::string& text, size_t& start, size_t& end) {
+    size_t at = text.find(kPcSection);
+    if (at == std::string::npos) return false;
+    size_t bodyStart = text.find('\n', at);
+    if (bodyStart == std::string::npos) return false;
+    ++bodyStart;
+    // The section ends at the next line that begins a new section.
+    size_t p = bodyStart;
+    while (p < text.size()) {
+        if (text[p] == '[') break;
+        size_t nl = text.find('\n', p);
+        if (nl == std::string::npos) {
+            p = text.size();
+            break;
+        }
+        p = nl + 1;
+    }
+    start = bodyStart;
+    end = p;
+    return true;
+}
+
+// Value of `key` inside [start, end), or -1. Key must match at a line start.
+long section_value(const std::string& text, size_t start, size_t end, const char* key) {
+    const size_t keyLen = strlen(key);
+    size_t p = start;
+    while (p < end) {
+        size_t nl = text.find('\n', p);
+        size_t lineEnd = (nl == std::string::npos || nl > end) ? end : nl;
+        if (lineEnd - p > keyLen && text.compare(p, keyLen, key) == 0 && text[p + keyLen] == '=') {
+            return strtol(text.c_str() + p + keyLen + 1, nullptr, 10);
+        }
+        if (nl == std::string::npos) break;
+        p = nl + 1;
+    }
+    return -1;
+}
+
+// Replace `key`'s value inside [start, end) in place. Returns false if the key is
+// not present in that section (this code never ADDS keys - the shipped file has
+// all of them, and inventing one is how a config stops loading).
+bool set_section_value(std::string& text, size_t start, size_t& end, const char* key,
+                       uint32_t value) {
+    const size_t keyLen = strlen(key);
+    size_t p = start;
+    while (p < end) {
+        size_t nl = text.find('\n', p);
+        size_t lineEnd = (nl == std::string::npos || nl > end) ? end : nl;
+        if (lineEnd - p > keyLen && text.compare(p, keyLen, key) == 0 && text[p + keyLen] == '=') {
+            // Keep the line's terminator (CR and/or LF) exactly as it was.
+            size_t valStart = p + keyLen + 1;
+            size_t valEnd = valStart;
+            while (valEnd < lineEnd && text[valEnd] != '\r' && text[valEnd] != '\n') ++valEnd;
+            char buf[16];
+            int n = _snprintf_s(buf, sizeof buf, _TRUNCATE, "%u", value);
+            if (n <= 0) return false;
+            const size_t oldLen = valEnd - valStart;
+            text.replace(valStart, oldLen, buf, static_cast<size_t>(n));
+            end += static_cast<size_t>(n) - oldLen; // span shifts with the edit
+            return true;
+        }
+        if (nl == std::string::npos) break;
+        p = nl + 1;
+    }
+    return false;
+}
+
+bool section_bool(const std::string& text, size_t start, size_t end, const char* key) {
+    const size_t keyLen = strlen(key);
+    size_t p = start;
+    while (p < end) {
+        size_t nl = text.find('\n', p);
+        size_t lineEnd = (nl == std::string::npos || nl > end) ? end : nl;
+        if (lineEnd - p > keyLen && text.compare(p, keyLen, key) == 0 && text[p + keyLen] == '=')
+            return _strnicmp(text.c_str() + p + keyLen + 1, "True", 4) == 0;
+        if (nl == std::string::npos) break;
+        p = nl + 1;
+    }
+    return false;
+}
+
+// A candidate only wins if it EXISTS and actually contains the PC driver
+// section: the same file name appears in layouts that belong to other titles.
+bool candidate_ok(const wchar_t* p) {
+    if (!file_exists(p)) return false;
+    std::string text;
+    if (!read_all(p, text)) return false;
+    return text.find(kPcSection) != std::string::npos;
+}
+
+void search() {
+    g_searched = true;
+    wchar_t roaming[MAX_PATH]{}, docs[MAX_PATH]{};
+    SHGetFolderPathW(nullptr, CSIDL_APPDATA, nullptr, 0, roaming);
+    SHGetFolderPathW(nullptr, CSIDL_PERSONAL, nullptr, 0, docs);
+
+    // Verified on the live Steam install: %APPDATA%\BioshockHD\Bioshock\.
+    // The Documents variants cover layouts seen on other installs. The game
+    // directory is deliberately NOT searched: under Program Files a write there
+    // is silently redirected to VirtualStore, which reads back as success and
+    // changes nothing.
+    const wchar_t* tries[][2] = {
+        {roaming, L"\\BioshockHD\\Bioshock\\Bioshock.ini"},
+        {roaming, L"\\Bioshock\\Bioshock.ini"},
+        {docs, L"\\BioshockHD\\Bioshock\\Bioshock.ini"},
+        {docs, L"\\BioShock Remastered\\Bioshock.ini"},
+    };
+    for (const auto& t : tries) {
+        if (!t[0][0]) continue;
+        wchar_t p[MAX_PATH];
+        if (_snwprintf_s(p, MAX_PATH, _TRUNCATE, L"%s%s", t[0], t[1]) < 0) continue;
+        if (candidate_ok(p)) {
+            wcscpy_s(g_path, p);
+            BVR_LOG("[b1r] game ini: %ls", g_path);
+            return;
+        }
+        BVR_LOG("[b1r] game ini: not here - %ls", p);
+    }
+    BVR_LOG("[b1r] game ini: NOT FOUND - resolution cannot be set from the mod");
+}
+
+} // namespace
+
+const wchar_t* path() {
+    if (!g_searched) search();
+    return g_path;
+}
+
+Viewport read_viewport() {
+    Viewport v{};
+    if (!path()[0]) return v;
+    std::string text;
+    if (!read_all(g_path, text)) return v;
+    size_t start = 0, end = 0;
+    if (!pc_section_span(text, start, end)) return v;
+
+    long wx = section_value(text, start, end, "WindowedViewportX");
+    long wy = section_value(text, start, end, "WindowedViewportY");
+    long fx = section_value(text, start, end, "FullscreenViewportX");
+    long fy = section_value(text, start, end, "FullscreenViewportY");
+    if (wx <= 0 || wy <= 0) return v;
+    v.windowedW = static_cast<uint32_t>(wx);
+    v.windowedH = static_cast<uint32_t>(wy);
+    v.fullscreenW = fx > 0 ? static_cast<uint32_t>(fx) : 0;
+    v.fullscreenH = fy > 0 ? static_cast<uint32_t>(fy) : 0;
+    v.startupFullscreen = section_bool(text, start, end, "StartupFullscreen");
+    v.valid = true;
+    return v;
+}
+
+bool write_viewport(uint32_t w, uint32_t h) {
+    if (w < 640 || h < 480 || w > 16384 || h > 16384) {
+        BVR_LOG("[b1r] game ini: refusing %ux%u (outside 640x480..16384x16384)", w, h);
+        return false;
+    }
+    if (!path()[0]) {
+        BVR_LOG("[b1r] game ini: cannot write - no Bioshock.ini located");
+        return false;
+    }
+
+    std::string text;
+    if (!read_all(g_path, text)) {
+        BVR_LOG("[b1r] game ini: read failed (err %lu)", GetLastError());
+        return false;
+    }
+    size_t start = 0, end = 0;
+    if (!pc_section_span(text, start, end)) {
+        BVR_LOG("[b1r] game ini: %s not found - refusing to guess", kPcSection);
+        return false;
+    }
+
+    // Both pairs, deliberately: UE2 reads whichever mode it starts in.
+    bool ok = set_section_value(text, start, end, "WindowedViewportX", w) &&
+              set_section_value(text, start, end, "WindowedViewportY", h) &&
+              set_section_value(text, start, end, "FullscreenViewportX", w) &&
+              set_section_value(text, start, end, "FullscreenViewportY", h);
+    if (!ok) {
+        BVR_LOG("[b1r] game ini: a viewport key is missing from %s - nothing written",
+                kPcSection);
+        return false;
+    }
+
+    // One-time backup, matching the existing .bvr-bak-* convention. Never
+    // overwritten, so the first backup is always the user's original.
+    wchar_t bak[MAX_PATH];
+    if (_snwprintf_s(bak, MAX_PATH, _TRUNCATE, L"%s.bvr-bak-res", g_path) > 0 &&
+        !file_exists(bak)) {
+        if (CopyFileW(g_path, bak, TRUE))
+            BVR_LOG("[b1r] game ini: original backed up to %ls", bak);
+        else
+            BVR_LOG("[b1r] game ini: backup FAILED (err %lu) - writing anyway", GetLastError());
+    }
+
+    // Temp file then ReplaceFileW, so an interrupted write cannot truncate the
+    // user's config.
+    wchar_t tmp[MAX_PATH];
+    if (_snwprintf_s(tmp, MAX_PATH, _TRUNCATE, L"%s.bvr-tmp", g_path) < 0) return false;
+    if (!write_all(tmp, text)) {
+        BVR_LOG("[b1r] game ini: temp write failed (err %lu)", GetLastError());
+        return false;
+    }
+    if (!ReplaceFileW(g_path, tmp, nullptr, REPLACEFILE_IGNORE_MERGE_ERRORS, nullptr, nullptr)) {
+        DWORD err = GetLastError();
+        DeleteFileW(tmp);
+        BVR_LOG("[b1r] game ini: replace failed (err %lu) - config untouched", err);
+        return false;
+    }
+
+    // READ BACK. A write that reports success and changes nothing is the failure
+    // mode worth catching by hand - it is what UAC redirection looks like.
+    Viewport after = read_viewport();
+    if (!after.valid || after.windowedW != w || after.windowedH != h) {
+        BVR_LOG("[b1r] game ini: WROTE %ux%u but it reads back %ux%u - the write did not stick",
+                w, h, after.windowedW, after.windowedH);
+        return false;
+    }
+    BVR_LOG("[b1r] game ini: viewport set to %ux%u (windowed AND fullscreen pairs, verified) "
+            "- takes effect on the NEXT launch",
+            w, h);
+    return true;
+}
+
+void log_status(uint32_t liveW, uint32_t liveH) {
+    Viewport v = read_viewport();
+    if (!v.valid) {
+        BVR_LOG("[b1r] game ini: unreadable or missing the PC driver section");
+        return;
+    }
+    const bool agrees = liveW == 0 || (v.windowedW == liveW && v.windowedH == liveH);
+    BVR_LOG("[b1r] game ini: windowed %ux%u fullscreen %ux%u startupFullscreen=%s | live "
+            "backbuffer %ux%u%s",
+            v.windowedW, v.windowedH, v.fullscreenW, v.fullscreenH,
+            v.startupFullscreen ? "True" : "False", liveW, liveH,
+            agrees ? "" : " - INI NOT HONOURED (the game rewrites this file at exit from its "
+                          "own settings; change it with the game closed)");
+}
+
+} // namespace bvr::b1r::game_ini

--- a/src/game/bioshock1r/game_ini.h
+++ b/src/game/bioshock1r/game_ini.h
@@ -1,0 +1,60 @@
+#pragma once
+// Read and write the GAME's own Bioshock.ini, specifically the render
+// resolution. Per-game on purpose: the file name, its location and its section
+// layout are all BioShock-1 facts.
+//
+// WHY THIS EXISTS RATHER THAN A LIVE RESOLUTION CHANGE. The engine's own
+// `SETRES` console command, reachable through the viewport Exec seam this mod
+// already uses successfully for `set ...`, FAULTS: a near-null dereference at
+// exe+0x4C2353 with no ResizeBuffers following (measured, session 27 - see
+// ENGINE_NOTES). So the only working control over the render resolution is the
+// config the engine reads at startup, which means a change takes effect on the
+// NEXT launch. The reference mod (BioVRDev) reached the same conclusion and
+// ships a setup script for it.
+//
+// WHY IT MATTERS. The eye render is the game's backbuffer, so the game's
+// resolution IS the VR resolution - and a headset panel is near square while
+// 16:9 throws away roughly half the width at the FOV this mod asks for. A user
+// on a Dream Air independently found this: their runtime's own resolution slider
+// did nothing (it cannot - nothing reads it), and editing this file to 7680x4320
+// made the image "super crisp" at about 53% pixel efficiency.
+//
+// SAFETY. Four separate sections of this file carry the same viewport key names
+// - the PC driver plus the Xbox 360, Xbox One and PS4 ones. A naive key
+// replacement writes a console driver section and appears to succeed, so every
+// write here is scoped to `[WinDrv.WindowsClient]`. The file is ANSI with CRLF
+// endings and the mod edits it in place, preserving every other byte including
+// the trailing semicolons the shipped file has on some values.
+
+#include <cstdint>
+
+namespace bvr::b1r::game_ini {
+
+// Full path to the located Bioshock.ini, or an empty string. Cached after the
+// first call; the search is logged once.
+const wchar_t* path();
+
+struct Viewport {
+    uint32_t windowedW = 0, windowedH = 0;
+    uint32_t fullscreenW = 0, fullscreenH = 0;
+    bool startupFullscreen = false;
+    bool valid = false;
+};
+
+// Current [WinDrv.WindowsClient] geometry.
+Viewport read_viewport();
+
+// Write BOTH the windowed and fullscreen pairs to w x h. Both, because UE2 keeps
+// two and reads whichever mode it starts in - writing only one is how "setting
+// the resolution" silently stops working the moment the user toggles fullscreen.
+// Backs the file up once to Bioshock.ini.bvr-bak-res (house convention), then
+// re-reads and verifies. Returns false and logs on any failure; never leaves a
+// partially written file. Game thread, on explicit request only.
+bool write_viewport(uint32_t w, uint32_t h);
+
+// One log line: located path, current geometry, and whether it agrees with the
+// live backbuffer. A disagreement means the ini was not honoured - most likely
+// the game rewrote it at exit from its own in-memory values.
+void log_status(uint32_t liveBackbufferW, uint32_t liveBackbufferH);
+
+} // namespace bvr::b1r::game_ini

--- a/src/game/bioshock1r/hands.cpp
+++ b/src/game/bioshock1r/hands.cpp
@@ -149,28 +149,32 @@ bool has_vtable(void* obj, uint32_t wantRva) {
 
 struct ScanCtx {
     float camX, camY, camZ;
-    bool logEvery;  // probe: describe every instance
     bool chooseAny; // probe: choose nothing, so the whole list gets logged
 };
 
-// Both accept callbacks run inside the scan's SEH guard (patterns.cpp).
+// Both accept callbacks run inside the scan's SEH guard (heap_scan.cpp), so
+// neither may LOG or ALLOCATE: MSVC does not run C++ destructors during SEH
+// unwinding, and a fault taken while the log mutex is held would wedge logging
+// for the life of the process (session 27). Diagnostics go out through `probe`
+// and are formatted by the caller afterwards.
+//
 // A UClass default object carries the same vtable as a live actor but sits at
 // the origin with zeroed fields; proximity to the camera separates the live
 // viewmodel from it (and from `0xCCCCCCCC` stack debris).
-bool accept_hands(void* obj, void* user) {
+//
+// Probe slots: [0..2] location truncated to UU, [3] distance to the camera.
+bool accept_hands(void* obj, void* user, int32_t probe[bvr::heap_scan::kProbeSlots]) {
     ScanCtx* c = static_cast<ScanCtx*>(user);
     const uint8_t* p = static_cast<const uint8_t*>(obj);
     float loc[3];
-    int32_t rot[3];
     memcpy(loc, p + patterns::kActorLocOffset, sizeof loc);
-    memcpy(rot, p + patterns::kActorViewDirOffset, sizeof rot);
 
     float dx = loc[0] - c->camX, dy = loc[1] - c->camY, dz = loc[2] - c->camZ;
     float dist = sqrtf(dx * dx + dy * dy + dz * dz);
-    if (c->logEvery)
-        BVR_LOG("[hands] AHands match @ %p loc=(%.1f %.1f %.1f) rot=(%d %d %d) "
-                "distToCam=%.1f UU",
-                obj, loc[0], loc[1], loc[2], rot[0], rot[1], rot[2], dist);
+    probe[0] = static_cast<int32_t>(loc[0]);
+    probe[1] = static_cast<int32_t>(loc[1]);
+    probe[2] = static_cast<int32_t>(loc[2]);
+    probe[3] = static_cast<int32_t>(dist);
     if (!c->chooseAny) return false;
     return dist < 2000.0f && (loc[0] != 0.0f || loc[1] != 0.0f || loc[2] != 0.0f);
 }
@@ -188,10 +192,11 @@ struct WeaponScanCtx {
     void* handsActor; // structural accept: Base(+0x450) == the AHands rig
     void* best;
     float bestDist;
-    bool logEvery;
 };
 
-bool accept_weapon(void* obj, void* user) {
+// Probe slots: [0..2] location truncated to UU, [3] distance to the expected
+// gun spot, or -1 when the structural (attachment) accept fired instead.
+bool accept_weapon(void* obj, void* user, int32_t probe[bvr::heap_scan::kProbeSlots]) {
     WeaponScanCtx* c = static_cast<WeaponScanCtx*>(user);
     const uint8_t* p = static_cast<const uint8_t*>(obj);
 
@@ -208,20 +213,23 @@ bool accept_weapon(void* obj, void* user) {
     // states (live: 2 owner-matched candidates, both >120 UU); attachment
     // does not.
     void* base = *reinterpret_cast<void* const*>(p + patterns::kActorBaseOffset);
-    if (c->handsActor && base == c->handsActor) {
-        c->best = obj;
-        c->bestDist = 0.0f;
-        return false;
-    }
 
     float loc[3];
     memcpy(loc, p + patterns::kActorLocOffset, sizeof loc);
+    probe[0] = static_cast<int32_t>(loc[0]);
+    probe[1] = static_cast<int32_t>(loc[1]);
+    probe[2] = static_cast<int32_t>(loc[2]);
+
+    if (c->handsActor && base == c->handsActor) {
+        c->best = obj;
+        c->bestDist = 0.0f;
+        probe[3] = -1; // structural accept: attached to the rig
+        return false;
+    }
+
     float dx = loc[0] - c->camX, dy = loc[1] - c->camY, dz = loc[2] - c->camZ;
     float dist = sqrtf(dx * dx + dy * dy + dz * dz);
-    if (c->logEvery)
-        BVR_LOG("[hands] player weapon match @ %p loc=(%.1f %.1f %.1f) distToGunSpot=%.1f UU "
-                "base=%p",
-                obj, loc[0], loc[1], loc[2], dist, base);
+    probe[3] = static_cast<int32_t>(dist);
     if (dist < 120.0f && dist < c->bestDist) {
         c->best = obj;
         c->bestDist = dist;
@@ -253,22 +261,19 @@ void* find_hands_actor(const FrameContext& ctx, bool probeOnly) {
         if (now - g_lastHandsScanMs < (2000ull << shift)) return nullptr;
         g_lastHandsScanMs = now;
     }
-    ScanCtx sc{ctx.camX, ctx.camY, ctx.camZ, probeOnly, !probeOnly};
-    int matches = 0;
-    uint64_t scanStart = GetTickCount64();
-    void* found = patterns::scan_for_vtable_object(
-        patterns::kHandsVtableRva, patterns::kActorViewDirOffset + 12, &accept_hands, &sc,
-        "AHands", &matches);
-    g_lastMatches.store(matches, std::memory_order_relaxed);
+    ScanCtx sc{ctx.camX, ctx.camY, ctx.camZ, !probeOnly};
+    static patterns::ObjectScan scan;
+    patterns::ScanResult r{};
+    if (!patterns::run_object_scan(scan, patterns::kHandsVtableRva,
+                                   patterns::kActorViewDirOffset + 12, &accept_hands, &sc, r))
+        return nullptr; // sliced sweep still running - no stall, retry next frame
+    patterns::log_scan_result("AHands", scan, r, probeOnly || g_handsScanFails == 0);
+    g_lastMatches.store(r.matches, std::memory_order_relaxed);
     if (probeOnly) return nullptr;
-    g_handsActor = found;
-    if (found) {
+    g_handsActor = r.object;
+    if (r.object) {
         g_handsScanFails = 0;
     } else {
-        if (g_handsScanFails == 0)
-            BVR_LOG("[hands] no live AHands in this world yet (scan %u ms) - "
-                    "retrying with backoff",
-                    static_cast<uint32_t>(GetTickCount64() - scanStart));
         ++g_handsScanFails;
     }
     return g_handsActor;
@@ -299,13 +304,25 @@ void* find_weapon_actor(const FrameContext& ctx, bool probeOnly) {
                      has_vtable(g_handsActor, patterns::kHandsVtableRva) ? g_handsActor
                                                                          : nullptr,
                      nullptr,
-                     1e9f,
-                     probeOnly};
-    int matches = 0;
-    patterns::scan_for_vtable_object(patterns::kPlayerWeaponVtableRva,
-                                     patterns::kWeaponOwnerOffset + sizeof(void*),
-                                     &accept_weapon, &wc, "APlayerWeapon", &matches);
-    g_lastMatches.store(matches, std::memory_order_relaxed);
+                     1e9f};
+    static patterns::ObjectScan scan;
+    patterns::ScanResult r{};
+    if (!patterns::run_object_scan(scan, patterns::kPlayerWeaponVtableRva,
+                                   patterns::kWeaponOwnerOffset + sizeof(void*), &accept_weapon,
+                                   &wc, r))
+        return nullptr; // sliced sweep still running - no stall, retry next frame
+
+    // This resolver picks through WeaponScanCtx::best rather than by accepting a
+    // candidate, so ScanResult::object is ALWAYS null here. Reporting that as
+    // "chosen=00000000" is what made the shipped log unreadable: an external
+    // crash log could not tell whether the resolver had succeeded or failed
+    // (session 27). Log the real outcome.
+    patterns::log_scan_result("APlayerWeapon", scan, r, probeOnly);
+    g_lastMatches.store(r.matches, std::memory_order_relaxed);
+    BVR_LOG("[hands] player weapon resolver: %d match(es) -> %s @ %p%s", r.matches,
+            wc.best ? (wc.bestDist == 0.0f ? "ATTACHED to the rig" : "nearest to the gun spot")
+                    : "NONE",
+            wc.best, wc.best && wc.bestDist > 0.0f ? " (distance pick)" : "");
     if (probeOnly) return nullptr;
     g_weaponActor = wc.best;
     return g_weaponActor;

--- a/src/game/bioshock1r/hands.cpp
+++ b/src/game/bioshock1r/hands.cpp
@@ -76,6 +76,14 @@ void* g_handsActor = nullptr;
 void* g_weaponActor = nullptr;
 uint64_t g_lastHandsScanMs = 0;
 uint64_t g_lastWeaponScanMs = 0;
+// Search state at file scope, not function-local, because the retry gates below
+// have to be able to ASK whether a sliced sweep is mid-flight. Getting that
+// wrong starves the sweep: the first smoke test of the sliced scanner had the
+// rate limit refusing to continue an in-progress sweep for up to 32 s, while
+// the caller counted every "still working" return as a miss and latched the
+// scanner dormant before it had ever completed a single pass (session 27).
+patterns::ObjectScan g_handsScan;
+patterns::ObjectScan g_weaponScan;
 uint32_t g_handsScanFails = 0; // consecutive empty scans -> backoff
 void* g_lastPc = nullptr;
 std::atomic<uint32_t> g_writes{0};
@@ -258,16 +266,17 @@ void* find_hands_actor(const FrameContext& ctx, bool probeOnly) {
         // (session 18 part 3, live). Reset on success, world change, and
         // re-enable, so pickup stays prompt when the rig actually appears.
         uint32_t shift = g_handsScanFails > 4 ? 4 : g_handsScanFails;
-        if (now - g_lastHandsScanMs < (2000ull << shift)) return nullptr;
+        // The backoff must never gate a sweep that has already started, or the
+        // slices are spread minutes apart and the pass never finishes.
+        if (!g_handsScan.sweeping && now - g_lastHandsScanMs < (2000ull << shift)) return nullptr;
         g_lastHandsScanMs = now;
     }
     ScanCtx sc{ctx.camX, ctx.camY, ctx.camZ, !probeOnly};
-    static patterns::ObjectScan scan;
     patterns::ScanResult r{};
-    if (!patterns::run_object_scan(scan, patterns::kHandsVtableRva,
+    if (!patterns::run_object_scan(g_handsScan, patterns::kHandsVtableRva,
                                    patterns::kActorViewDirOffset + 12, &accept_hands, &sc, r))
         return nullptr; // sliced sweep still running - no stall, retry next frame
-    patterns::log_scan_result("AHands", scan, r, probeOnly || g_handsScanFails == 0);
+    patterns::log_scan_result("AHands", g_handsScan, r, probeOnly || g_handsScanFails == 0);
     g_lastMatches.store(r.matches, std::memory_order_relaxed);
     if (probeOnly) return nullptr;
     g_handsActor = r.object;
@@ -290,7 +299,9 @@ void* find_weapon_actor(const FrameContext& ctx, bool probeOnly) {
         if (weapon_valid(g_weaponActor)) return g_weaponActor;
         g_weaponActor = nullptr;
         uint64_t now = GetTickCount64();
-        if (now - g_lastWeaponScanMs < 2000) return nullptr;
+        // As above: never gate an in-flight sweep.
+        if (!g_weaponScan.sweeping && now - g_lastWeaponScanMs < patterns::kScanRetryMs)
+            return nullptr;
         g_lastWeaponScanMs = now;
     }
     // Anchor at the expected gun spot: 50 UU along the current view.
@@ -305,9 +316,8 @@ void* find_weapon_actor(const FrameContext& ctx, bool probeOnly) {
                                                                          : nullptr,
                      nullptr,
                      1e9f};
-    static patterns::ObjectScan scan;
     patterns::ScanResult r{};
-    if (!patterns::run_object_scan(scan, patterns::kPlayerWeaponVtableRva,
+    if (!patterns::run_object_scan(g_weaponScan, patterns::kPlayerWeaponVtableRva,
                                    patterns::kWeaponOwnerOffset + sizeof(void*), &accept_weapon,
                                    &wc, r))
         return nullptr; // sliced sweep still running - no stall, retry next frame
@@ -317,7 +327,7 @@ void* find_weapon_actor(const FrameContext& ctx, bool probeOnly) {
     // "chosen=00000000" is what made the shipped log unreadable: an external
     // crash log could not tell whether the resolver had succeeded or failed
     // (session 27). Log the real outcome.
-    patterns::log_scan_result("APlayerWeapon", scan, r, probeOnly);
+    patterns::log_scan_result("APlayerWeapon", g_weaponScan, r, probeOnly);
     g_lastMatches.store(r.matches, std::memory_order_relaxed);
     BVR_LOG("[hands] player weapon resolver: %d match(es) -> %s @ %p%s", r.matches,
             wc.best ? (wc.bestDist == 0.0f ? "ATTACHED to the rig" : "nearest to the gun spot")
@@ -512,6 +522,8 @@ void* weapon_actor() {
 void* resolve_weapon_actor(const FrameContext& ctx) {
     return find_weapon_actor(ctx, false);
 }
+
+bool weapon_scan_in_progress() { return g_weaponScan.sweeping; }
 
 bool current_holdable(void** out) {
     // Raw rig read, CLASS-AGNOSTIC: the MachineGun and GrenadeLauncher carry

--- a/src/game/bioshock1r/hands.h
+++ b/src/game/bioshock1r/hands.h
@@ -96,6 +96,12 @@ void* weapon_actor();
 // too. Game thread; callers gate on gameplay view to avoid cutscene scans.
 void* resolve_weapon_actor(const FrameContext& ctx);
 
+// True while a sliced sweep for the weapon actor is mid-flight, i.e. a null
+// return from resolve_weapon_actor means "not finished" and NOT "not there".
+// Callers with a miss counter must not count the former (session 27). Game
+// thread.
+bool weapon_scan_in_progress();
+
 // Hands.CurrentHoldable read raw off the rig, CLASS-AGNOSTIC (session 21
 // part 3: the MachineGun/GrenadeLauncher native vtable differs from
 // kPlayerWeaponVtableRva, so vtable-gated paths rejected them and pinned

--- a/src/game/bioshock1r/patterns.cpp
+++ b/src/game/bioshock1r/patterns.cpp
@@ -7,6 +7,7 @@
 #include "game/bioshock1r/patterns.h"
 
 #include "core/util/log.h"
+#include "core/util/module_id.h"
 
 #include <windows.h>
 
@@ -18,6 +19,10 @@ namespace {
 // Captured by resolve() so the lazy hfov_option_ptr() can form the vtable
 // address for this session's ASLR base.
 const uint8_t* g_imageBase = nullptr;
+
+// Set once by resolve(): does the running exe match the build every RVA in
+// patterns.h came from? See the header's build-identity block.
+bool g_rvaTrusted = false;
 
 // ---- live-object search (session 27 rewrite) --------------------------------
 // The generic machinery - thread-stack/TEB exclusion, the live-heap fast path,
@@ -75,6 +80,10 @@ bool accept_user_settings(void* obj, void*, int32_t probe[bvr::heap_scan::kProbe
 
 void log_scan_result(const char* what, const ObjectScan& scan, const ScanResult& r,
                      bool candidates) {
+    // A refusal already said so once, in run_object_scan. Repeating a summary for
+    // a search that never ran turns the retry cadence into log spam - which the
+    // wrong-build test produced, one line every 2 s for the whole session.
+    if (r.disabled) return;
     const bvr::heap_scan::Sweep& s = scan.sweep;
     if (candidates) {
         for (int i = 0; i < s.recorded; ++i) {
@@ -102,6 +111,21 @@ bool run_object_scan(ObjectScan& scan, uint32_t vtableRva, uint32_t needBytes,
                      ObjectAccept accept, void* user, ScanResult& out) {
     out = ScanResult{};
     if (!g_imageBase || !accept) return true; // nothing to search: complete and empty
+    // On an unrecognised build the vtable RVA is an arbitrary constant, and the
+    // callers of this function WRITE to what it returns. Searching memory for a
+    // meaningless value and then poking the winner is the one failure mode worth
+    // refusing outright (session 27).
+    if (!g_rvaTrusted) {
+        static bool once = false;
+        if (!once) {
+            once = true;
+            BVR_LOG("[b1r] object scans DISABLED - the host build is not the one these vtable "
+                    "addresses came from (see the build block above)");
+        }
+        out.path = "disabled (unverified build)";
+        out.disabled = true;
+        return true;
+    }
     const void* wantVtable = g_imageBase + vtableRva;
 
     // Fast path first: only live, allocated heap blocks, tens of milliseconds,
@@ -207,11 +231,38 @@ void hfov_scan_rearm(const char* why) {
 
 bool settings_bound() { return g_userSettings != nullptr; }
 
+bool rva_trusted() { return g_rvaTrusted; }
+
 bool resolve(const bvr::pattern_scan::ProcessImage& image, Symbols& out) {
     using namespace bvr::pattern_scan;
 
     g_imageBase = image.base;
     BVR_LOG("[b1r] scanning main module: base %p size 0x%zX", image.base, image.size);
+
+    // Build gate FIRST, so everything logged below is read in the right light.
+    const bvr::module_id::Fingerprint host = bvr::module_id::host_exe();
+    g_rvaTrusted =
+        bvr::module_id::matches(host, kHostTimeDateStamp, kHostSizeOfImage, kHostFileBytes);
+    if (g_rvaTrusted) {
+        BVR_LOG("[b1r] host build VERIFIED (pe-timestamp 0x%08X) - hardcoded addresses trusted",
+                host.timeDateStamp);
+    } else {
+        BVR_LOG("[b1r] ============================================================");
+        BVR_LOG("[b1r] HOST BUILD NOT RECOGNISED - address-dependent features OFF");
+        BVR_LOG("[b1r]   running:  pe-timestamp 0x%08X size-of-image 0x%08X bytes %llu",
+                host.timeDateStamp, host.sizeOfImage,
+                static_cast<unsigned long long>(host.fileBytes));
+        BVR_LOG("[b1r]   expected: pe-timestamp 0x%08X size-of-image 0x%08X bytes %llu",
+                kHostTimeDateStamp, kHostSizeOfImage,
+                static_cast<unsigned long long>(kHostFileBytes));
+        BVR_LOG("[b1r] Every offset this mod hardcodes was derived from the 2022-04-13 Steam");
+        BVR_LOG("[b1r] build. Applying them to a different binary is how a mod corrupts a");
+        BVR_LOG("[b1r] game rather than failing to work, so they stand down and the game");
+        BVR_LOG("[b1r] stays fully playable. Head tracking still uses a pattern scan and is");
+        BVR_LOG("[b1r] unaffected. If you are on Epic, GOG or a newer patch, please send this");
+        BVR_LOG("[b1r] log - the three numbers above are what a per-build offset table needs.");
+        BVR_LOG("[b1r] ============================================================");
+    }
 
     EventScanResult scan{};
     bool ok = find_event_function(image, "PlayerCalcView", scan);

--- a/src/game/bioshock1r/patterns.cpp
+++ b/src/game/bioshock1r/patterns.cpp
@@ -23,6 +23,8 @@ const uint8_t* g_imageBase = nullptr;
 // Set once by resolve(): does the running exe match the build every RVA in
 // patterns.h came from? See the header's build-identity block.
 bool g_rvaTrusted = false;
+// Test override for the stand-down path - see handle_buildgate_command.
+bool g_buildGateForcedOff = false;
 
 // ---- live-object search (session 27 rewrite) --------------------------------
 // The generic machinery - thread-stack/TEB exclusion, the live-heap fast path,
@@ -231,7 +233,26 @@ void hfov_scan_rearm(const char* why) {
 
 bool settings_bound() { return g_userSettings != nullptr; }
 
-bool rva_trusted() { return g_rvaTrusted; }
+bool rva_trusted() { return g_rvaTrusted && !g_buildGateForcedOff; }
+
+void handle_buildgate_command(const char* args) {
+    if (args && strncmp(args, "off", 3) == 0) {
+        g_buildGateForcedOff = true;
+        BVR_LOG("[b1r] buildgate FORCED OFF - address-dependent features now behave exactly as "
+                "they would on an unrecognised build (object scans refuse, so no FOV control "
+                "and no viewmodel drive). 'buildgate on' restores.");
+    } else if (args && strncmp(args, "on", 2) == 0) {
+        g_buildGateForcedOff = false;
+        // The scanners latched dormant while refusing; wake them.
+        hfov_scan_rearm("buildgate restored");
+        BVR_LOG("[b1r] buildgate restored (host build itself is %s)",
+                g_rvaTrusted ? "VERIFIED" : "STILL UNRECOGNISED");
+    } else {
+        BVR_LOG("[b1r] buildgate: host build %s, forced-off %s -> rva_trusted=%s",
+                g_rvaTrusted ? "VERIFIED" : "NOT RECOGNISED",
+                g_buildGateForcedOff ? "yes" : "no", rva_trusted() ? "yes" : "no");
+    }
+}
 
 bool resolve(const bvr::pattern_scan::ProcessImage& image, Symbols& out) {
     using namespace bvr::pattern_scan;

--- a/src/game/bioshock1r/patterns.cpp
+++ b/src/game/bioshock1r/patterns.cpp
@@ -19,90 +19,117 @@ namespace {
 // address for this session's ASLR base.
 const uint8_t* g_imageBase = nullptr;
 
-// Cached UShockUserSettings instance (revalidated by vtable every call). There
-// is no static pointer to it, so we find it by its fixed-RVA vtable and cache
-// the heap address for the session.
+// ---- live-object search (session 27 rewrite) --------------------------------
+// The generic machinery - thread-stack/TEB exclusion, the live-heap fast path,
+// the budgeted sliced fallback - lives in core/hooks/heap_scan.h. This file
+// supplies only the per-class accept filters and the dormancy policy, because
+// those are the parts that know what a BioShock object looks like.
+//
+// What this replaced swept the whole 4 GB address space at a 4-byte stride in
+// one blocking call, accepting any MEM_PRIVATE + PAGE_READWRITE region - which
+// is also the signature of a thread stack. Field consequences: multi-second
+// game-thread stalls, and a candidate that could be a stack slot or a freed
+// block while the FOV writer poked it every frame. Full post-mortem in
+// heap_scan.h and ENGINE_NOTES session 27.
+
+// Cached UShockUserSettings instance (revalidated every call). There is no
+// static pointer to it, so we find it by its fixed-RVA vtable and cache the
+// address for the session.
 void* g_userSettings = nullptr;
-uint64_t g_lastScanMs = 0;
+uint64_t g_lastSettingsAttemptMs = 0;
+int g_settingsMisses = 0;
+bool g_settingsDormant = false;
+ObjectScan g_settingsScan;
 
-bool region_scannable(const MEMORY_BASIC_INFORMATION& mbi) {
-    if (mbi.State != MEM_COMMIT) return false;
-    if (mbi.Protect & (PAGE_GUARD | PAGE_NOACCESS)) return false;
-    if (mbi.Type != MEM_PRIVATE) return false; // the object lives on the heap
-    switch (mbi.Protect & 0xFF) {
-        case PAGE_READWRITE:
-        case PAGE_EXECUTE_READWRITE:
-            return true;
-        default:
-            return false;
-    }
-}
+// Probe slots for the candidate log line: [0] HorizontalFOV, [1] 1 if the
+// UObject class chain resolved, [2] the class name's FName index.
+bool accept_user_settings(void* obj, void*, int32_t probe[bvr::heap_scan::kProbeSlots]) {
+    const uint8_t* p = static_cast<const uint8_t*>(obj);
+    int32_t fov = *reinterpret_cast<const int32_t*>(p + kUserSettingsHfovOffset);
+    probe[0] = fov;
 
-// SEH-guarded scan of one region for the vtable dword. A region can decommit
-// between VirtualQuery and the read (the game heap churns on other threads),
-// so the raw walk must not fault the game. No C++ objects in this frame.
-void scan_region(uintptr_t base, uintptr_t end, uintptr_t wantVtable, uint32_t needBytes,
-                 ObjectAccept accept, void* user, void** outChosen, int* outMatches) {
-    __try {
-        for (uintptr_t a = base; a + needBytes <= end; a += 4) {
-            if (*reinterpret_cast<const uintptr_t*>(a) != wantVtable) continue;
-            ++*outMatches;
-            void* obj = reinterpret_cast<void*>(a);
-            if (!*outChosen && accept(obj, user)) *outChosen = obj;
-        }
-    } __except (EXCEPTION_EXECUTE_HANDLER) {
-    }
-}
+    // CORROBORATION (session 27). The vtable dword is one predicate, and it is
+    // satisfied by any 4 bytes that happen to hold that value: a stack slot
+    // spilling the pointer, or a freed object whose header the allocator has
+    // not reused yet. The consumer WRITES to whatever comes back, so one
+    // predicate is not enough. object_class_name walks obj -> +0x30 UClass* ->
+    // UClass vtable identity -> +0x28 FName index -> GNames with every step
+    // validated, so a non-null result is strong evidence of a live UObject.
+    //
+    // Deliberately NOT compared against an expected name: the live instance
+    // could be a subclass and rejecting it would silently disable FOV control.
+    // The resolved name is logged instead, so tightening this to an exact match
+    // later is a one-line change backed by real data.
+    const wchar_t* cls = object_class_name(obj);
+    probe[1] = cls ? 1 : 0;
+    if (!cls) return false;
+    const uint8_t* clsObj = *reinterpret_cast<const uint8_t* const*>(p + kUObjectClassOffset);
+    probe[2] = *reinterpret_cast<const int32_t*>(clsObj + kUObjectNameIndexOffset);
 
-// Accept the first UShockUserSettings whose HorizontalFOV reads as a plausible
-// degree value, logging every candidate so a wrong pick (e.g. a class default
-// object) is diagnosable.
-bool accept_user_settings(void* obj, void*) {
-    int32_t fov = *reinterpret_cast<const int32_t*>(static_cast<uint8_t*>(obj) +
-                                                    kUserSettingsHfovOffset);
-    BVR_LOG("[b1r] UShockUserSettings vtable match @ %p HorizontalFOV=%d", obj, fov);
-    return fov >= 40 && fov <= 170;
-}
-
-// One-shot per session in practice - the object exists by the time CalcView
-// first fires.
-void* scan_for_user_settings() {
-    int matches = 0;
-    return scan_for_vtable_object(kUserSettingsVtableRva,
-                                  kUserSettingsHfovOffset + sizeof(int32_t),
-                                  &accept_user_settings, nullptr, "UShockUserSettings",
-                                  &matches);
+    // The engine's own options UI clamps to 75..130. The 40..170 window this
+    // used to accept let far more debris through.
+    return fov >= kUserSettingsHfovMin && fov <= kUserSettingsHfovMax;
 }
 
 } // namespace
 
-void* scan_for_vtable_object(uint32_t vtableRva, uint32_t needBytes, ObjectAccept accept,
-                             void* user, const char* what, int* outMatches) {
-    if (!g_imageBase || !accept) return nullptr;
-    const uintptr_t wantVtable = reinterpret_cast<uintptr_t>(g_imageBase) + vtableRva;
-    void* chosen = nullptr;
-    int matches = 0;
-
-    uintptr_t p = 0x10000;
-    MEMORY_BASIC_INFORMATION mbi{};
-    // Walk the FULL 4 GB range: the game is Large-Address-Aware, and after a
-    // long session the engine allocates actors ABOVE 2 GB - a 0x7FFF0000 cap
-    // made the live AHands invisible after a level transition (session 18
-    // part 4, live: "2 matches, chosen=0" forever while the rig rendered on
-    // screen). VirtualQuery just fails past the top on non-LAA processes, so
-    // the loop still terminates there.
-    while (p < 0xFFFE0000u &&
-           VirtualQuery(reinterpret_cast<void*>(p), &mbi, sizeof(mbi)) == sizeof(mbi)) {
-        uintptr_t base = reinterpret_cast<uintptr_t>(mbi.BaseAddress);
-        uintptr_t end = base + mbi.RegionSize;
-        if (end <= base) break;
-        if (region_scannable(mbi))
-            scan_region(base, end, wantVtable, needBytes, accept, user, &chosen, &matches);
-        p = end;
+void log_scan_result(const char* what, const ObjectScan& scan, const ScanResult& r,
+                     bool candidates) {
+    const bvr::heap_scan::Sweep& s = scan.sweep;
+    if (candidates) {
+        for (int i = 0; i < s.recorded; ++i) {
+            const wchar_t* cls = object_class_name(s.addr[i]);
+            BVR_LOG("[b1r] %s candidate @ %p probe=%d,%d,%d,%d class='%ls' -> %s", what, s.addr[i],
+                    s.probe[i][0], s.probe[i][1], s.probe[i][2], s.probe[i][3],
+                    cls ? cls : L"<unresolved>", s.ok[i] ? "ACCEPTED" : "rejected");
+        }
+        if (s.matches > s.recorded)
+            BVR_LOG("[b1r] %s: %d further match(es) not recorded (cap %d)", what,
+                    s.matches - s.recorded, bvr::heap_scan::kMaxRecorded);
     }
-    BVR_LOG("[b1r] %s scan: %d vtable match(es), chosen=%p", what, matches, chosen);
-    if (outMatches) *outMatches = matches;
-    return chosen;
+    BVR_LOG("[b1r] %s scan via %s: %d match(es), %d accepted, chosen=%p "
+            "(%.1f ms, %u slice(s), %u heap(s)/%u block(s), %d exclude span(s)%s)",
+            what, r.path, r.matches, r.accepted, r.object,
+            static_cast<double>(s.elapsedUs) / 1000.0, s.slices, s.heaps, s.blocks,
+            s.excludeSpans,
+            s.excludeMissed > 0   ? " - SOME THREAD STACKS NOT EXCLUDED"
+            : s.excludeMissed < 0 ? " - THREAD ENUMERATION FAILED"
+                                  : "");
+}
+
+bool run_object_scan(ObjectScan& scan, uint32_t vtableRva, uint32_t needBytes,
+                     ObjectAccept accept, void* user, ScanResult& out) {
+    out = ScanResult{};
+    if (!g_imageBase || !accept) return true; // nothing to search: complete and empty
+    const void* wantVtable = g_imageBase + vtableRva;
+
+    // Fast path first: only live, allocated heap blocks, tens of milliseconds,
+    // and it cannot hand back a freed block. When it succeeds the sliced sweep
+    // never runs at all.
+    if (!scan.sweeping) {
+        if (bvr::heap_scan::heap_blocks(scan.sweep, wantVtable, needBytes, accept, user)) {
+            out.object = scan.sweep.first;
+            out.matches = scan.sweep.matches;
+            out.accepted = scan.sweep.accepted;
+            out.path = "heap";
+            return true;
+        }
+        // Not in any Win32 heap block: either the object does not exist yet, or
+        // this engine allocates it from its own pool. Fall back to the region
+        // sweep, sliced so it can never stall a frame.
+        scan.sweeping = true;
+        scan.sweep.cursor = 0;
+    }
+
+    auto outcome = bvr::heap_scan::sweep(scan.sweep, wantVtable, needBytes, accept, user,
+                                         kScanSliceBudgetUs);
+    out.path = "sweep";
+    if (outcome == bvr::heap_scan::Outcome::Working) return false;
+    scan.sweeping = false;
+    out.object = scan.sweep.first;
+    out.matches = scan.sweep.matches;
+    out.accepted = scan.sweep.accepted;
+    return true;
 }
 
 int32_t* hfov_option_ptr() {
@@ -111,26 +138,73 @@ int32_t* hfov_option_ptr() {
 
     const void* wantVtable = g_imageBase + kUserSettingsVtableRva;
 
-    // Revalidate the cache: object freed/moved -> vtable no longer matches.
+    // Revalidate the cache on TWO predicates, not one: the vtable dword AND the
+    // UObject class chain, so a freed-and-not-yet-reused block cannot keep
+    // passing as the settings object while the FOV writer pokes it every frame.
     if (g_userSettings) {
         if (is_memory_valid(g_userSettings, kUserSettingsHfovOffset + sizeof(int32_t)) &&
-            *reinterpret_cast<const void* const*>(g_userSettings) == wantVtable) {
+            *reinterpret_cast<const void* const*>(g_userSettings) == wantVtable &&
+            object_class_name(g_userSettings) != nullptr) {
             return reinterpret_cast<int32_t*>(static_cast<uint8_t*>(g_userSettings) +
                                               kUserSettingsHfovOffset);
         }
-        g_userSettings = nullptr; // stale, fall through to a rescan
+        g_userSettings = nullptr;
+        hfov_scan_rearm("cached settings object went stale");
     }
 
-    // Rate-limit rescans so a not-yet-created object doesn't scan every frame.
-    uint64_t now = GetTickCount64();
-    if (now - g_lastScanMs < 2000) return nullptr;
-    g_lastScanMs = now;
+    // DORMANCY (backported from bioshock2r; the session-22 weapon-resolver
+    // lesson). A rate limit alone means a save where the object never appears
+    // rescans forever, which reads as "the game freezes every couple of
+    // seconds". Only an explicit re-arm clears this.
+    if (g_settingsDormant) return nullptr;
 
-    g_userSettings = scan_for_user_settings();
-    if (!g_userSettings) return nullptr;
+    uint64_t now = GetTickCount64();
+    if (!g_settingsScan.sweeping && now - g_lastSettingsAttemptMs < kScanRetryMs) return nullptr;
+    g_lastSettingsAttemptMs = now;
+
+    ScanResult r{};
+    if (!run_object_scan(g_settingsScan, kUserSettingsVtableRva,
+                         kUserSettingsHfovOffset + sizeof(int32_t), &accept_user_settings, nullptr,
+                         r))
+        return nullptr; // sweep still in progress - no stall, try again next frame
+
+    log_scan_result("UShockUserSettings", g_settingsScan, r, true);
+
+    // FAIL CLOSED on ambiguity: more than one object passed the filter, so we
+    // cannot say which one the renderer reads. Writing to the wrong one is
+    // worse than not writing at all.
+    if (r.accepted > 1) {
+        BVR_LOG("[b1r] UShockUserSettings AMBIGUOUS (%d accepted) - refusing to bind, "
+                "FOV control stays off",
+                r.accepted);
+        g_settingsDormant = true;
+        return nullptr;
+    }
+
+    g_userSettings = r.object;
+    if (!g_userSettings) {
+        if (++g_settingsMisses >= kScanMissesBeforeDormant) {
+            g_settingsDormant = true;
+            BVR_LOG("[b1r] UShockUserSettings scan DORMANT after %d miss(es) - a view-state "
+                    "change re-arms it",
+                    g_settingsMisses);
+        }
+        return nullptr;
+    }
+    g_settingsMisses = 0;
     return reinterpret_cast<int32_t*>(static_cast<uint8_t*>(g_userSettings) +
                                       kUserSettingsHfovOffset);
 }
+
+void hfov_scan_rearm(const char* why) {
+    g_settingsMisses = 0;
+    if (g_settingsDormant) {
+        g_settingsDormant = false;
+        BVR_LOG("[b1r] UShockUserSettings scan re-armed (%s)", why);
+    }
+}
+
+bool settings_bound() { return g_userSettings != nullptr; }
 
 bool resolve(const bvr::pattern_scan::ProcessImage& image, Symbols& out) {
     using namespace bvr::pattern_scan;

--- a/src/game/bioshock1r/patterns.cpp
+++ b/src/game/bioshock1r/patterns.cpp
@@ -92,7 +92,8 @@ void log_scan_result(const char* what, const ObjectScan& scan, const ScanResult&
             what, r.path, r.matches, r.accepted, r.object,
             static_cast<double>(s.elapsedUs) / 1000.0, s.slices, s.heaps, s.blocks,
             s.excludeSpans,
-            s.excludeMissed > 0   ? " - SOME THREAD STACKS NOT EXCLUDED"
+            s.excludes.truncated  ? " - EXCLUSION TABLE FULL, SOME STACKS NOT EXCLUDED"
+            : s.excludeMissed > 0 ? " - SOME THREAD STACKS NOT EXCLUDED"
             : s.excludeMissed < 0 ? " - THREAD ENUMERATION FAILED"
                                   : "");
 }
@@ -123,7 +124,7 @@ bool run_object_scan(ObjectScan& scan, uint32_t vtableRva, uint32_t needBytes,
 
     auto outcome = bvr::heap_scan::sweep(scan.sweep, wantVtable, needBytes, accept, user,
                                          kScanSliceBudgetUs);
-    out.path = "sweep";
+    out.path = "sweep (heap path found nothing)";
     if (outcome == bvr::heap_scan::Outcome::Working) return false;
     scan.sweeping = false;
     out.object = scan.sweep.first;

--- a/src/game/bioshock1r/patterns.h
+++ b/src/game/bioshock1r/patterns.h
@@ -32,6 +32,17 @@ inline constexpr uint64_t kHostFileBytes = 21214720;
 // CalcView seam, the FName chain) is build-independent and keeps working.
 bool rva_trusted();
 
+// Force the gate closed at RUNTIME, for testing the stand-down path.
+//
+// This exists because the alternative bit me: the only way to exercise the
+// unverified-build path used to be editing kHostTimeDateStamp and rebuilding,
+// and a sabotaged DLL then got left installed in the game folder. The symptoms
+// (no FOV control, viewmodel not following the controllers) read exactly like a
+// regression, because every object scan refuses. A runtime switch means the test
+// never produces a binary that can be mistaken for a real one.
+// `buildgate off|on|status` on the command seam. Game thread.
+void handle_buildgate_command(const char* args);
+
 // Live horizontal FOV in degrees (float) inside APlayerController.
 // Derivation: itsloopyo/bioshock-remastered-headtracking (MIT)
 // FOV_LIVE_OFFSET; verified live in DR-4. Telemetry-only: the renderer never

--- a/src/game/bioshock1r/patterns.h
+++ b/src/game/bioshock1r/patterns.h
@@ -4,6 +4,7 @@
 // ARCHITECTURE.md). Every entry is documented in docs/bioshock1/ENGINE_NOTES.md with
 // its derivation method.
 
+#include "core/hooks/heap_scan.h"
 #include "core/hooks/pattern_scan.h"
 
 #include <cstdint>
@@ -28,6 +29,25 @@ inline constexpr uint32_t kFovLiveOffset = 0xE0;
 // it by scanning the heap for its fixed-RVA vtable and caching the instance.
 inline constexpr uint32_t kUserSettingsVtableRva = 0xDA3878;  // .?AVUShockUserSettings@@
 inline constexpr uint32_t kUserSettingsHfovOffset = 0x8C;     // int32, degrees
+
+// Plausibility window for the accept filter. The options UI clamps to 75-130,
+// so anything outside that is debris rather than a settings object. The scanner
+// this replaced accepted 40-170, which let a great deal more through - and the
+// consumer writes to whatever is accepted (session 27).
+inline constexpr int32_t kUserSettingsHfovMin = 75;
+inline constexpr int32_t kUserSettingsHfovMax = 130;
+
+// ---- object-scan policy (session 27) ----------------------------------------
+// Wall clock one sliced sweep slice may spend on the game thread. 4 ms at ~90
+// CalcView/s is a visible frame cost while a sweep is running and nothing at
+// all once the object is bound; the alternative it replaced was a single 1-4 s
+// blocking pass, which is what users reported as the game freezing.
+inline constexpr uint32_t kScanSliceBudgetUs = 4000;
+// Gap between search attempts once one has completed without finding anything.
+inline constexpr uint64_t kScanRetryMs = 2000;
+// Consecutive completed-but-empty searches before the scanner latches dormant.
+// A rate limit alone rescans forever on a save where the object never appears.
+inline constexpr int kScanMissesBeforeDormant = 3;
 
 // Render command-queue functions (DR-5 / SequentialReentry). Derivation
 // (ENGINE_NOTES "Scene-draw architecture"): draw-callstack RVA histogram from
@@ -633,24 +653,60 @@ void resolve_aim_natives(const bvr::pattern_scan::ProcessImage& image, Symbols& 
 
 // The live HorizontalFOV field of the UShockUserSettings singleton, or null.
 // Lazy by design: the object exists only after engine init, so this validates
-// on every call (null global / dead memory / foreign vtable all return null)
-// instead of caching at resolve() time. Game thread only.
+// on every call (null global / dead memory / foreign vtable / dead UObject
+// class chain all return null) instead of caching at resolve() time. Goes
+// dormant after repeated misses; hfov_scan_rearm() is the only way back.
+// Game thread only.
 int32_t* hfov_option_ptr();
 
+// Clear the miss counter and wake a dormant settings scan. Call on any event
+// that plausibly created the object: a view-state change, a pawn change, a
+// level load. `why` is logged.
+void hfov_scan_rearm(const char* why);
+
+// True once the settings object is bound, for status lines.
+bool settings_bound();
+
+// ---- live-object search -----------------------------------------------------
 // Find a live object by its class vtable. There is no static pointer to most
-// engine singletons, so we scan committed private memory for the fixed-RVA
-// vtable dword - the technique that found UShockUserSettings, reused for the
-// M7 AHands viewmodel.
+// engine singletons, so the object is located by its fixed-RVA vtable dword.
+// The generic, stack-safe, budgeted machinery is core/hooks/heap_scan.h; this
+// wraps it with the two-phase policy every callsite here wants.
 //
 // `accept` is called for every object whose first dword is that vtable and
 // decides whether this instance is the one wanted: every UClass also has a
 // default object carrying the same vtable, so a plausibility test on the
-// object's own fields is mandatory. It runs inside the scan's SEH guard, may
-// read up to `needBytes` from the object, and must not throw. The first
-// accepted instance wins; `outMatches` reports how many vtable hits were seen
-// (0 = the class is not instantiated yet, many = the filter is doing real work).
-using ObjectAccept = bool (*)(void* obj, void* user);
-void* scan_for_vtable_object(uint32_t vtableRva, uint32_t needBytes, ObjectAccept accept,
-                             void* user, const char* what, int* outMatches);
+// object's own fields is mandatory. It runs inside an SEH guard, may read up to
+// `needBytes` from the object, must not throw, and MUST NOT LOG OR ALLOCATE -
+// MSVC does not run C++ destructors during SEH unwinding, so a fault taken
+// while the log mutex is held would wedge logging for the life of the process.
+// Hand diagnostics back through `probe` instead and format them afterwards.
+using ObjectAccept = bvr::heap_scan::Accept;
+
+// Caller-owned search state. One static per callsite; zero-initialize and keep.
+struct ObjectScan {
+    bvr::heap_scan::Sweep sweep;
+    bool sweeping = false; // in the sliced fallback rather than the heap path
+};
+
+struct ScanResult {
+    void* object = nullptr; // the accepted instance, or null
+    int matches = 0;        // vtable hits
+    int accepted = 0;       // accept() said yes; >1 means ambiguous, fail closed
+    const char* path = "-"; // "heap" (fast path) or "sweep" (fallback)
+};
+
+// Advance one search. Returns true when a search COMPLETED this call and `out`
+// is meaningful; false means a sliced sweep is still running, so call again
+// next frame. Tries the live-heap-block fast path first and only falls back to
+// the region sweep if the object is not in a Win32 heap block.
+bool run_object_scan(ObjectScan& scan, uint32_t vtableRva, uint32_t needBytes,
+                     ObjectAccept accept, void* user, ScanResult& out);
+
+// Log a one-line summary of a completed search, and with `candidates` every
+// recorded candidate and its probe values. Call after run_object_scan returns
+// true - never from inside an accept filter.
+void log_scan_result(const char* what, const ObjectScan& scan, const ScanResult& r,
+                     bool candidates);
 
 } // namespace bvr::b1r::patterns

--- a/src/game/bioshock1r/patterns.h
+++ b/src/game/bioshock1r/patterns.h
@@ -11,6 +11,27 @@
 
 namespace bvr::b1r::patterns {
 
+// ---- host build identity (session 27) ---------------------------------------
+// Every RVA in this header was derived from ONE build of BioshockHD.exe:
+// 2022-04-13, PE TimeDateStamp 0x6256F776, SizeOfImage 0x01677000, 21214720
+// bytes on disk (measured from the live Steam install; the exe carries no PE
+// checksum, so that field is not part of the test).
+//
+// The adapter is chosen by exe BASENAME, and every storefront ships this same
+// file name - so an Epic, GOG or repatched build is not rejected, it is accepted
+// and then mis-addressed. Hook installs survive that (they are prologue- and
+// vtable-gated and refuse), but the object-scan KEYS degrade to "search memory
+// for an arbitrary constant, then write to whatever passes a plausibility
+// test". Those are gated on rva_trusted() instead.
+inline constexpr uint32_t kHostTimeDateStamp = 0x6256F776;
+inline constexpr uint32_t kHostSizeOfImage = 0x01677000;
+inline constexpr uint64_t kHostFileBytes = 21214720;
+
+// False when the running exe is not the build the addresses came from. Features
+// that depend on a raw RVA must stand down; anything pattern-derived (the
+// CalcView seam, the FName chain) is build-independent and keeps working.
+bool rva_trusted();
+
 // Live horizontal FOV in degrees (float) inside APlayerController.
 // Derivation: itsloopyo/bioshock-remastered-headtracking (MIT)
 // FOV_LIVE_OFFSET; verified live in DR-4. Telemetry-only: the renderer never
@@ -694,6 +715,7 @@ struct ScanResult {
     int matches = 0;        // vtable hits
     int accepted = 0;       // accept() said yes; >1 means ambiguous, fail closed
     const char* path = "-"; // "heap" (fast path) or "sweep" (fallback)
+    bool disabled = false;  // refused before searching (unverified build)
 };
 
 // Advance one search. Returns true when a search COMPLETED this call and `out`

--- a/src/game/bioshock1r/scenedraw.cpp
+++ b/src/game/bioshock1r/scenedraw.cpp
@@ -116,6 +116,9 @@ std::atomic<uint32_t> g_savedNumHwThreads{0};
 // install hooks from the render thread, so it posts a request here and the
 // game thread applies it from note_calcview (outside any hooked call).
 std::atomic<int> g_vrstereoPending{-1}; // -1 none, 0 off, 1 on
+// Session 28: the same request lane for the stereo-ONLY toggle (doubling on/off
+// with 1t and the head drive left alone) - the un-confounded A/B.
+std::atomic<int> g_stereoOnlyPending{-1};
 // Deadlock watchdog (session 6): the doubled render strands the engine's
 // command-queue event protocol - game thread parked mid-build waiting for
 // "render done" while the render thread waits for more work; a lost wakeup
@@ -1286,6 +1289,25 @@ void apply_vrstereo(bool on) {
     }
 }
 
+// Session 28: drop ONLY the scene doubling and leave 1t and the head-driven
+// camera exactly as they are. The one-toggle above cannot serve as a stereo A/B
+// because it also turns the head drive off, and with the head not driving the
+// camera the compositor reprojects an unchanging image as you turn - which looks
+// exactly like the warping being diagnosed. Every "is it stereo?" test through
+// the one-toggle was therefore confounded. This is additive: the one-toggle
+// keeps its behaviour and its label.
+void apply_stereo_only(bool on) {
+    BVR_LOG("[reentry] STEREO-ONLY %s: doubling %s, 1t and camera mode left "
+            "UNTOUCHED (this is the un-confounded A/B - the one-toggle also "
+            "drops the head drive, which mimics warping)",
+            on ? "ON" : "off", on ? "on" : "off");
+    handle_command(on ? "stereo on" : "stereo off");
+    BVR_LOG("[reentry] stereo-only now: 1t=%d stereo=%d cameraMode=%d",
+            g_forceInline.load(std::memory_order_relaxed) ? 1 : 0,
+            g_stereo.load(std::memory_order_relaxed) ? 1 : 0,
+            bvr::vr::vr_camera_mode() ? 1 : 0);
+}
+
 } // namespace
 
 void init(const bvr::pattern_scan::ProcessImage& image) {
@@ -1518,7 +1540,11 @@ void handle_command(const char* args) {
             }
         }
     } else if (strcmp(verb, "vrstereo") == 0) {
-        apply_vrstereo(strncmp(rest, "on", 2) == 0);
+        // `vrstereo stereoonly on|off` = doubling only, head drive untouched.
+        if (strncmp(rest, "stereoonly", 10) == 0)
+            apply_stereo_only(strstr(rest + 10, "off") == nullptr);
+        else
+            apply_vrstereo(strncmp(rest, "on", 2) == 0);
     } else if (strcmp(verb, "wdkick") == 0) {
         bool on = strncmp(rest, "on", 2) == 0;
         g_wdKickEnabled.store(on, std::memory_order_relaxed);
@@ -1618,6 +1644,12 @@ bool stereo_active() {
 void request_vrstereo(bool on) {
     g_vrstereoPending.store(on ? 1 : 0, std::memory_order_relaxed);
 }
+
+void request_stereo_only(bool on) {
+    g_stereoOnlyPending.store(on ? 1 : 0, std::memory_order_relaxed);
+}
+
+bool doubling_on() { return g_stereo.load(std::memory_order_relaxed); }
 
 void handle_fgnode_command(const char* args) {
     if (strncmp(args, "fova", 4) == 0) {
@@ -1757,6 +1789,11 @@ void note_calcview() {
                 g_vrstereoPending.exchange(-1, std::memory_order_relaxed);
             if (pending >= 0) apply_vrstereo(pending == 1);
         }
+        if (g_stereoOnlyPending.load(std::memory_order_relaxed) >= 0) {
+            int pending =
+                g_stereoOnlyPending.exchange(-1, std::memory_order_relaxed);
+            if (pending >= 0) apply_stereo_only(pending == 1);
+        }
     }
     if (g_calcstackPending.load(std::memory_order_relaxed) > 0 &&
         g_calcstackPending.exchange(0, std::memory_order_relaxed) > 0)
@@ -1781,6 +1818,18 @@ void draw_debug_ui() {
     if (ImGui::Checkbox("VR stereo (1t + camera mode + stereo)", &vrToggle) &&
         vrToggle != vrOn)
         request_vrstereo(vrToggle);
+    // Session 28: the A/B that the one-toggle above cannot do. Unticking this
+    // drops ONLY the doubling - the head keeps driving the camera, so if the
+    // image still misbehaves it is not the stereo path. Unticking the toggle
+    // above instead also kills the head drive, and a static image reprojected
+    // as you turn looks exactly like warping, which confounded every previous
+    // attempt at this test.
+    bool dblOn = g_stereo.load(std::memory_order_relaxed);
+    bool dblToggle = dblOn;
+    if (ImGui::Checkbox("...stereo doubling ONLY (A/B - keeps the head drive)",
+                        &dblToggle) &&
+        dblToggle != dblOn)
+        request_stereo_only(dblToggle);
     bool hook1t = g_forceInline.load(std::memory_order_relaxed);
     bool poke1t = g_savedNumHwThreads.load(std::memory_order_relaxed) != 0;
     ImGui::Text("render %s  1t %s  hooks: build %s, submit %s, drain %s, "

--- a/src/game/bioshock1r/scenedraw.h
+++ b/src/game/bioshock1r/scenedraw.h
@@ -51,6 +51,16 @@ bool stereo_active();
 // Safe from any thread (the overlay checkbox draws on the render thread).
 void request_vrstereo(bool on);
 
+// Session 28: stereo-ONLY request - toggles the scene doubling and leaves 1t and
+// the head-driven camera exactly as they are. The one-toggle above cannot be
+// used as a stereo A/B because it also drops the head drive, and a
+// non-head-driven camera makes the compositor reproject a static image as you
+// turn - indistinguishable from the warping it was being used to test for.
+// Safe from any thread. `doubling_on` reports the doubling alone, for the
+// overlay checkbox state.
+void request_stereo_only(bool on);
+bool doubling_on();
+
 // Session 21 discovery instrument: "vrfgnode on|off|dump" - read-only hook on
 // the engine's per-frame FOREGROUND SCENE NODE ctor (patterns.h "FOREGROUND
 // SCENE NODE"); dump logs the parent-view/node snapshots taken at ctor tail

--- a/src/game/bioshock2r/camera.cpp
+++ b/src/game/bioshock2r/camera.cpp
@@ -378,16 +378,27 @@ void apply_command(const char* cmd, const char* args) {
                 : src == 3 ? "live"
                            : "none",
                 sw, sh, optTanH, optTanV);
+        // Session 28 (core change, shared): both lenses, age labelled in words.
+        // BS2's own lens laws are UNMEASURED - per the never-copy rule this line
+        // reports what the watch sees and asserts nothing about BS2's fg pass.
         float liveTanH = 0.0f, liveTanV = 0.0f;
         unsigned long long liveAge = 0;
-        if (bvr::hud::fov_watch(&liveTanH, &liveTanV, &liveAge))
-            BVR_LOG("[b2r] fovaudit live: rendered tanH=%.4f tanV=%.4f (%.1f deg) "
-                    "age=%llums | mismatch=%d cineActive=%d",
+        if (bvr::hud::fov_watch(&liveTanH, &liveTanV, &liveAge, 0)) {
+            float fgH = 0.0f, fgV = 0.0f;
+            unsigned long long fgAge = 0;
+            bool haveFg = bvr::hud::fov_watch_fg(&fgH, &fgV, &fgAge, 0);
+            BVR_LOG("[b2r] fovaudit live: WORLD tanH=%.6f tanV=%.6f (%.2f deg) "
+                    "age=%llums %s | 2nd-lens tanH=%.6f tanV=%.6f age=%llums | "
+                    "lenses=%d mismatch=%d cineActive=%d",
                     liveTanH, liveTanV, 2.0f * atanf(liveTanH) * kRadToDeg, liveAge,
+                    liveAge <= 500 ? "FRESH" : "STALE - DO NOT CONCLUDE",
+                    haveFg ? fgH : 0.0f, haveFg ? fgV : 0.0f, fgAge,
+                    bvr::hud::fov_lens_count(),
                     bvr::hud::fov_mismatch() ? 1 : 0,
                     bvr::vr::cinematic_active() ? 1 : 0);
-        else
+        } else {
             BVR_LOG("[b2r] fovaudit live: no decoded scene tangents yet");
+        }
     } else if (strcmp(cmd, "fsweep") == 0) {
         float flo = 0.0f, fhi = 0.0f;
         if (sscanf_s(args, "%x %u %f %f", &addr, &len, &flo, &fhi) == 4)

--- a/tools/game-cmd.ps1
+++ b/tools/game-cmd.ps1
@@ -5,6 +5,10 @@
 # reads the file.
 # Usage: .\tools\game-cmd.ps1 "memscani 123" "memlist"
 #        .\tools\game-cmd.ps1 -Game bs2 "recenter"
+# PositionalBinding=$false so -Game can never swallow a command: as a positional
+# parameter it did, and every bare `game-cmd.ps1 "vrinput on"` call failed
+# validation, which silently broke boot.ps1's menu-press loop.
+[CmdletBinding(PositionalBinding=$false)]
 param(
     [ValidateSet("bs1", "bs2")][string]$Game = "bs1",
     [Parameter(ValueFromRemainingArguments=$true)][string[]]$Lines


### PR DESCRIPTION
Two sessions of BS1 work. Everything below is in-headset accepted unless stated otherwise. **No release in this PR** - the version stays at 0.4.1 and the tag waits until stage 3 (cinematics) is verified, because this PR changes the projection claim, the foreground lens and the frame pacing, and cinematics are the one place those three interact that has not been exercised.

## Session 27 - stability

`patterns::scan_for_vtable_object` swept the whole 4 GB address space at a 4-byte stride on the game thread, accepting `MEM_PRIVATE | PAGE_READWRITE` - which is also the signature of a thread stack. It found its own argument spill (two "vtable match" lines sitting 0x40 below the crashing thread's esp), poked unguarded writes into candidates that passed only two predicates, and blocked the game thread for over 3 s per pass. That was the freeze and probably the heap-corruption crash.

- New `core/hooks/heap_scan`: stacks/TEBs excluded via TEB bounds, XOR-masked needle compares, a live-heap fast path, and the region walk kept only as a 4 ms sliced fallback. `UShockUserSettings` resolves in ~57 ms with exactly one match (was 3+ s and three matches, two of them our own stack). Engine actors still need the sweep; its ~3.8 s of work spreads over 888 slices with the camera heartbeat holding 1600-2100 calls/s throughout.
- UObject class-chain corroboration on every candidate, a structural dormancy latch only an explicit re-arm clears, and fail-closed on ambiguity.
- Host build fingerprint gate - every storefront ships the same `BioshockHD.exe`, so an Epic/GOG/repatched build was accepted and then mis-addressed. Verified both directions.
- Engine-exec seam hardened (per-slot stub thunks, esp comparison across the call, re-assert moved off its timer). `crash::install()` first, swapchain hooks before the OpenXR instance. Real-size `ResizeBuffers` now queues the XR swapchain rebuild for a point with no XR frame open.
- Game-ini resolution lane plus an overlay dropdown, PC-section-scoped with read-back verification. `SETRES` through the viewport Exec seam FAULTS, so the ini lane is primary.

## Session 28 - one defect wearing three faces

A frame carries **two** perspective lenses with opposite aspect conventions - the world pass anchors its horizontal (`tanH = tan(option/2)`, `tanV = tanH*h/w`), the foreground pass anchors its vertical (`tanV = tan(fgFov/2)*3/4`, `tanH = tanV*w/h`) - and **they coincide exactly at 16:9**, which is why six sessions of measurement at 1920x1080 could not tell the two candidate laws apart.

- **Yaw warping at non-16:9.** The live fov watch sampled the first decodable draw; the fg draws come first, on a tier that clears its size gate, carrying the same block at the same floats, and the decode's two cross-checks were intra-axis so they carried no lens information. Off 16:9 it reported the viewmodel lens as the world lens, which latched `fov_mismatch()` during normal gameplay and substituted the projection claim with the viewmodel frustum - a 1.84x under-claim. The watch now stride-samples up to 8 cb0 heads across the whole pass and votes, with the runner-up published as a named second lens, behind the offline decoder's structural zero-slot checks plus majority and coverage guards. The age gate moved into `fov_watch()` and every line says FRESH or STALE in words.
- **Viewmodel/hands moving with the head.** The same defect from the other side: one layer carries one fov claim, so while the lenses differ only one of {world, viewmodel} can be geometrically correct, and fixing the world moved the 1.78x onto the hands. The fg match constant is now `(4/3)*(h/w)` rather than a hardcoded `0.75` (which is that expression at 16:9), and `bones.cpp`'s world and fg lens models read the live aspect - `render_lock_delta` had asserted that `k` collapses to 1, true at 16:9 only. Accepted with **no re-tune** of the session-16 offsets, which proved those offsets were correct all along.
- **VR freezes permanently after alt-tab.** A circular wait: the M8 pace guard submitted nothing while unfocused, and VDXR will not re-grant FOCUSED to an app that submits nothing, so the guard's own effect kept its own precondition true. Measured: 5772 presents skipped with zero `xrWaitFrame blocked` lines - the guard keyed on session state when the hazard is a slow wait. `xrWaitFrame` now runs on a dedicated pace thread with a deadline on the present thread (200 ms FOCUSED / 20 ms otherwise), which retires the session-26 hang class rather than trading it for this freeze. `teardown_session` defers rather than hand the runtime a freed session handle.
- **FOV policy retired.** The preset no longer forces the game-FOV write; its 130 came from arithmetic derived from the disproved law. The black bars that motivated raising FOV were an aspect problem - set the aspect with the resolution lane and leave FOV alone. Option 100 at 2048x2048 renders exactly 100x100 deg.

## Verification

Flat gates use the same instrument that found the bug. At 2048x2048 the dump goes from two tangent clusters to one, with the 576-byte foreground tier inside the world cluster; `fovaudit` reports `lenses=1 mismatch=0` and no `rendered-fov mismatch ON` line anywhere, where session 27 had one within seconds of gameplay. Lens math verified dynamic at two aspects (`k=1.333333` at 2048x2048, exactly `0.750000` at 1920x1080 - so 16:9 is bit-identical to prior releases by construction). Stage-1 regression gates hold: host build VERIFIED, one heap-path settings scan in tens of ms, a 1.000 s camera heartbeat with no gaps, four `engine exec` lines per boot, no IMBALANCE / exec fault lines. `vrfgfov legacy on|off` and `vrstereo stereoonly on|off` ship as live A/B levers; `vrpace thread off` restores the old inline pacing.

Also banked: `docs/bioshock2/ENGINE_NOTES.md` gains the whole defect class as an ordered checklist for BS2 rather than constants to copy - starting with whether BS2 even has two lenses, which session 25's native-foreground finding suggests it may not.

All builds and testing in these two sessions were **Debug**.