### PR TITLE
BS2: resolution lane, and the lens verdict

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -860,3 +860,49 @@ runtime.
   per-weapon profile key rather than resolving the holdable a second time), never a heuristic
   like "the hand is moving like melee". Everything else about the gesture is a comfort tuning
   knob; that one line is the safety property, and it is the first thing the flat checklist tests.
+- **2026-07-31 Â· session 32 Â· BS1's square-backbuffer policy does NOT apply to BS2, and the
+  resolution lane is per-game in FILE as well as in shape.** BS1's settled policy (set the ASPECT
+  with the resolution lane, leave the FOV option alone, because a square backbuffer fills a
+  roughly-square headset eye) is now explicitly scoped to BS1. Measured on BS2: a 2048x2048
+  backbuffer renders the scene into a 2048x1421 viewport with a black band, collapses the world
+  horizontal from 100 to 67.7 deg, and produces a ray block whose two vertical encodings disagree -
+  i.e. the projection stops being a consistent perspective off 16:9. On BS2 the resolution lane is
+  therefore a SHARPNESS lever at 16:9, not an aspect-matching one, until a bisection finds which
+  aspects (if any) BS2 renders full-height. Also per-game: BS2's viewport lives in `Shared.ini`
+  `[SharedOptions] ViewportX/Y`, and the `[WinDrv.WindowsClient]` keys BS1's whole lane writes are
+  IGNORED by BS2 (they are an output the game rewrites from its live state). `game_ini` is
+  duplicated per adapter rather than shared, following the recorded duplicate-now seam policy - a
+  third consumer should trigger the extraction, and the generic part (section-scoped ini editing
+  with backup + temp + ReplaceFileW + read-back) is what would move.
+- **2026-07-31 Â· session 32 Â· A verified write is not an honoured one; acceptance is the
+  observable effect.** The BS1-shaped BS2 resolution port wrote its keys, re-read them, and logged
+  "verified" while the engine rendered a different resolution entirely. Read-back proves the FILE
+  took the value and nothing more. This is the same failure class as `-> HANDLED` from the Exec
+  seam (session 30) and it now has two instances, so treat it as a standing rule: for any write
+  that leaves our address space, the acceptance criterion must be a measured downstream EFFECT (the
+  backbuffer at first Present, the ammo counter, the visible behaviour), never the write's own
+  confirmation.
+- **2026-07-31 Â· session 32 Â· cb0 layout offsets are PER-GAME constants, published by the adapter,
+  with a self-correcting hunt as backstop.** The screen-ray helper's float index was hardcoded to
+  BS1's 12 in both core (`hud_capture.cpp`) and the offline decoder. BS2's is 16 - same shape, four
+  floats later - so the live watch decoded nothing on BS2 and the offline decoder decoded zero
+  blocks. The offset is now `bvr::hud::set_ray_block_offset()`, published from
+  `bioshock2r/patterns.h` at adapter init, keeping engine constants in the per-game patterns header
+  as the project rule requires. Core also widened its cb0 copy window from 80 to 1344 bytes (a
+  block past float 19 was previously not even COPIED, so no offset could have rescued it) with
+  per-slot length tracking, and gained a hunt that only runs after the configured offset fails
+  repeatedly, adopting and LOGGING what it finds so a wrong constant names its own correction. BS1
+  is unaffected by construction (offset 12 validates on the first sample, so the hunt never runs)
+  and was regression-checked: WORLD tanH=1.191754 at 2048x2048, bit-identical to the banked
+  session-28 value.
+- **2026-07-31 Â· session 32 Â· BS2's two lenses differ in MAGNITUDE at every aspect, unlike BS1's.**
+  BS1's split was two aspect CONVENTIONS that coincide exactly at 16:9, so its symptoms were
+  aspect-gated. BS2 carries a world lens that follows the FOV option and a second lens fixed at
+  tan(30) = 60 deg that ignores it, distinguished by callstack, and they differ at 1920x1080. Since
+  one projection layer carries one fov claim, that is a 2.06x angular-gain error on whichever layer
+  the claim does not match, at 16:9, growing to 3.99x at option 130 - which matches the reported
+  stereo viewmodel symptoms (wrong depth, moves with the head) far better than BS1's mechanism,
+  which could not produce a symptom at 16:9 at all. Whether that 60-deg cluster IS the viewmodel is
+  NOT yet proven and must be settled by making it move (holster/switch the weapon and re-dump),
+  never by draw counts - BS1's rule, which is in the notes because inferring it from counts is what
+  went wrong there.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -725,6 +725,27 @@ kill. Both prerequisites below are now MET.):**
       M4-level stereo within the milestone, in-headset verified). Carried forward, not
       blocking: the stereo viewmodel blemish, a user-driven load-crossing pass, and a
       combat-scene perf profile.)
+- [x] **Session 32 - BS2 resolution lane + lens verdict.** `vrres` ships on BS2 (writes
+      `Shared.ini [SharedOptions]`, NOT the `[WinDrv.WindowsClient]` keys BS1 uses - BS2 ignores
+      those), verified end to end through a relaunch. The frozen engine-pitch bug is fixed
+      (`publish_pitch_error`), and `vrinput` is dispatched on BS2 for the first time. BS2's cb0
+      ray block derived at float 16 and parameterised into both the live watch and the offline
+      decoder; BS1 regression-checked bit-identical.
+      **Two findings that change the plan:** (1) BS1's square-backbuffer policy does NOT transfer -
+      BS2 letterboxes 2048x2048 into a 2048x1421 viewport and its projection degenerates off 16:9;
+      (2) BS2 carries TWO lenses that differ AT 16:9 (world tracks the FOV option, a second is
+      fixed at 60 deg), a 2.06x gain error at option 100 rising to 3.99x at 130 - the leading
+      explanation for the stereo viewmodel report.
+- [ ] **BS2 aspect bisection** - find the squarest aspect BS2 renders full-height with a consistent
+      frustum. That is BS2's best VR configuration AND the clean second aspect needed to settle its
+      world FOV law (the two candidate laws coincide at 16:9).
+- [ ] **Identify BS2's 60-deg lens** by making it MOVE (holster/switch weapon, re-dump), never by
+      draw counts. Decides whether the viewmodel fix is a lens match or something else entirely.
+- [ ] **BS2 pitch-servo sign check in-headset** - the one thing flat cannot answer about the
+      session-32 fix.
+- [ ] **BS2 swing-to-attack** - one `swing::publish_gate` line plus the melee-equipped predicate
+      (the hard part; prefer the ProcessEvent-by-name seam). Unblocked now that `vrinput` reaches
+      core's flat test suite on BS2.
 
 ## Post-v1 backlog (not scheduled)
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,7 +2,119 @@
 
 > Handoff file. Rewrite "Current state" and "Next steps" every session; append to the session log.
 
-## Current state (2026-07-31, session 31 - SWING-TO-ATTACK IS DONE AND ACCEPTED IN-HEADSET - branch s31-b1r-swing-to-attack)
+## Current state (2026-07-31, session 32 - BS2: RESOLUTION LANE SHIPS, AND BS1'S SQUARE-BACKBUFFER POLICY IS DEAD ON BS2 - branch s32-b2r-resolution-and-lens)
+
+All BS2 work. **Three BS1 assumptions died**, each caught by an acceptance test rather than by
+reading code, and the second one changes the plan for BS2's VR configuration.
+
+### 0. Step 0 - the frozen engine pitch is FIXED (sign check still owed in-headset)
+
+Confirmed open by reading the code, not assumed: b2r armed the shared core pitch kill via
+`publish_vr_gameplay` and never published a pitch error, so BS2's engine-side view pitch was frozen
+and the DRILL aimed with it - BS1's session-30 wrench bug, same shared code. `publish_pitch_error`
+now fires immediately before the `rot->pitch` overwrite.
+
+Two corrections to the session brief, both verified in the tree:
+
+- **The brief's confirmation method could not have worked.** It said the `[b2r] camera:` heartbeat
+  prints `rot` before the overwrite; it does not - the heartbeat runs LAST by design and reports
+  the FINAL camera, so its pitch is the head's, never the engine's. The heartbeat now carries
+  `enginePitch=` (sampled pre-overwrite) and `pitchErr=`.
+- **BS2 had no `vrinput` command at all.** `bvr::input::handle_command` is core and BS1 dispatches
+  to it; b2r never did, so the synthetic gamepad, `pitchservo` AND the whole core swing-gesture
+  flat suite were unreachable on BS2. One line fixed it - and it is a CLASS of bug worth auditing
+  (core growing a feature does not give an adapter access to it).
+
+**Still owed:** the servo's SIGN, which needs the headset - flat, with `drive=0`, `pitchErr` is 0
+by construction. Checklist in `docs/bioshock2/TESTING.md`.
+
+### 1. Step 1 - `vrres` ships on BS2, and the file is NOT the one BS1 uses
+
+`vrres <w>x<h>` writes **`%APPDATA%\BioshockHD\Bioshock2\Shared.ini` `[SharedOptions]
+ViewportX/Y`**. BS1's entire lane writes `[WinDrv.WindowsClient]`'s viewport keys - **BS2 has those
+keys and IGNORES them.** Proven by changing one variable at a time across three relaunches; the
+decisive row is SP-ini 1920x1080 + Shared 2048x2048 -> renders 2048x2048.
+
+**The lesson, and it now has two instances so it is a standing rule:** the BS1-shaped port wrote
+its four keys, re-read them, logged `verified`, and the engine rendered 1920x1080 anyway. **A
+verified write is not an honoured one** - same failure class as trusting `-> HANDLED` from the Exec
+seam. Acceptance must be a downstream EFFECT (the backbuffer at first Present), never the write's
+own confirmation.
+
+Verified end to end through the shipped path: write -> relaunch -> `first Present: backbuffer
+2048x2048`; both files backed up once to `.bvr-bak-res`; diff shows ONLY the intended keys, with
+all four decoy sections byte-unchanged. **BS2 has FIVE viewport-carrying sections, not BS1's four**
+(it adds `[PS3Drv.PS3Client]`), so section-scoping matters more here, not less. Also answered, a
+question BS1 left open: **a clean quit (`WM_CLOSE`) does not clobber the write** - byte-identical,
+hash unchanged. Scope: menu-quit path only.
+
+### 2. THE HEADLINE: BS2 does NOT render non-16:9. Do not port the square-backbuffer policy.
+
+BS1's settled policy is that a square backbuffer matches the roughly-square headset eye, which is
+what made its FOV write unnecessary. **On BS2 the premise fails.** At 2048x2048:
+
+- the scene renders into a **2048x1421 viewport** - the bottom ~30% of the backbuffer is BLACK
+  (screenshot-confirmed, HUD drawn over the band);
+- the world horizontal **collapses from 100 to 67.7 deg**;
+- the ray block's two vertical encodings stop agreeing - the frustum is no longer a consistent
+  perspective at all.
+
+At 1920x1080 all three are clean. So on BS2 today the resolution lane is a SHARPNESS lever at 16:9,
+not an aspect-matching one. **Next session's first job** is to bisect which aspects BS2 will render
+full-height; the squarest one that does is the best VR configuration available.
+
+### 3. Step 2 - the lens verdict: TWO lenses, differing AT 16:9
+
+Unlike BS1, whose split was two aspect CONVENTIONS that coincide exactly at 16:9 (so its symptoms
+were aspect-gated), BS2 carries a MAGNITUDE difference that is present at 1920x1080:
+
+| cluster | option 100 | option 130 | blocks | callstack head |
+|---|---|---|---|---|
+| **world** | tanH 1.1918 (100.0 deg) | tanH 2.1445 | 229 | `...AEC7B4...` |
+| **second** | tanH **0.5774** (60.0 deg) | **0.5774 unchanged** | 19 | `...AECACF...` |
+
+`0.5774 = tan(30)` to five decimals and it **ignores the FOV option** while the world lens tracks
+it. One projection layer carries one fov claim, so whichever layer the claim does not match is
+displayed at `k = 2.06x` angular gain at option 100 - rising to **3.99x at option 130**.
+
+**This is the leading explanation for the user's stereo viewmodel report** ("wrong depth",
+"moves/slides with the head", maybe "wrong size") and it fits where BS1's mechanism could not: it
+is NOT aspect-gated, so it is present at 16:9, which is where the user tested. It also predicts
+that raising FOV makes it worse.
+
+**NOT proven: that the 60-deg cluster IS the viewmodel.** Evidence is circumstantial (distinct
+pass, small draw count, FOV-independent). BS1's rule applies - identify it by making it MOVE, never
+by draw counts. The test is one dump: holster/switch the weapon and see whether the 19-block
+cluster changes.
+
+### 4. The world FOV law is only PARTIALLY derived, deliberately
+
+`tanH = tan(option/2)` measured exactly at 1920x1080 (and tracks the option 100 -> 130). But the
+two candidate laws COINCIDE at 16:9 - that is the trap that cost BS1 two sessions - and BS2 gives
+no clean second aspect because every non-16:9 render measured is degenerate. The decoder now prints
+both laws and **both PASS at 16:9**, which is the tool reporting the ambiguity honestly rather than
+manufacturing a verdict. Not settled; the section-2 bisection is what would settle it.
+
+### 5. Tooling: both decoders parameterised, BS2's cb0 offset derived
+
+BS2's ray block is at **cb0 float 16** (BS1's is 12) - same shape, four floats later. The offset is
+now a per-game constant in `bioshock2r/patterns.h`, published to core via
+`bvr::hud::set_ray_block_offset`. Core also widened its cb0 copy from **80 to 1344 bytes** (a block
+past float 19 was previously not even COPIED, so no offset could have rescued it) and gained a hunt
+that runs only after the configured offset fails and LOGS what it adopts - it found float 16 live,
+independently of the offline derivation.
+
+`tools/decode-framedump.ps1` gained `-RayOffset`, `-Aspect` (killing a hardcoded `9/16`),
+`-FgBakeRvas`, `-ScanLayout` and `-Diff`. **`-Diff` is the instrument that cracked it**: comparing
+two dumps at different FOV options assumes nothing about layout, which is what was needed after
+`-ScanLayout` came back empty on the square dump. That empty result was itself a false lead - the
+square-aspect degeneracy, not a different layout shape.
+
+**BS1 no-regression PASSED**: `WORLD tanH=1.191754 tanV=1.191754` at 2048x2048, bit-identical to
+the banked session-28 value, with the offset hunt never firing. The last hardcoded aspect constant
+in b2r (`fovaudit`'s `9/16` flat fallback) is gone.
+
+## Previous state (2026-07-31, session 31 - SWING-TO-ATTACK IS DONE AND ACCEPTED IN-HEADSET - branch s31-b1r-swing-to-attack)
 
 **Release still held. v0.5.0 stays untagged.** Session 30's three items are unchanged (one fixed
 and accepted, one fixed with the cause identified, one untested). This session adds one feature on
@@ -835,7 +947,49 @@ in case long soaks ever disprove this.
 
 ## Next steps
 
-### 0. FIRST ACTIONS NEXT SESSION
+### 0. SESSION 33 OPENER (BS2) - written with the verdicts that shape it
+
+Session 32 answered the lens question and killed the square-backbuffer plan. Steps 3-4 of the
+session-32 brief were NOT reached; they are re-scoped below by what was measured.
+
+**A. Bisect BS2's usable aspects (30-60 min, unblocks everything else).** BS2 renders 2048x2048 as
+a letterboxed 2048x1421 with a degenerate projection, and 1920x1080 cleanly. The question is where
+the boundary is. Each data point is `vrres <w>x<h>` -> relaunch -> load a save -> `dumpframe full`
+-> check the `vp=` field and whether the ray block's vertical pair agrees. Suggested ladder:
+2560x1440 (16:9 control, expect clean), 1920x1440 (4:3), 1920x1200 (16:10), 1920x1600. **The
+squarest aspect that renders full-height with a consistent frustum is BS2's best VR
+configuration**, and it doubles as the clean second aspect that settles the world FOV law (section
+4 above). `[Engine.RenderConfig] HorizontalFOVLock=True` is an unexamined suspect for the
+mechanism.
+
+**B. Prove what the 60-deg lens IS (one dump).** It is the leading explanation for the viewmodel
+report but it is NOT confirmed to be the viewmodel. Identify it by making it MOVE, never by draw
+counts (BS1's rule, learned the hard way): holster or switch weapon, re-dump at 16:9, and see
+whether the 19-block `...AECACF...` cluster disappears or changes. If it IS the viewmodel, BS1's
+conclusion applies - MATCH the lenses, because one claim cannot serve two - and the fix is a BS2
+fg-lens write, which is underived. If it is NOT, the viewmodel cause is still open and the two
+zero-code in-headset A/Bs (sweep IPD ~20 vs ~120 mm, sweep world scale) are the next instrument.
+
+Note this must be reconciled with session 25, which measured BS2's foreground following the world
+FOV natively in mono. Both can be true if the drill rides the world lens and the 60-deg cluster is
+some other pass. The holster test distinguishes them.
+
+**C. In-headset: the pitch servo's sign (30 s, owed).** Checklist in `docs/bioshock2/TESTING.md`.
+`enginePitch=` in the heartbeat must MOVE while looking up and down; `vrinput pitchservo invert` if
+the view fights you. Measure BS2's own stick deadzone rather than assuming BS1's 4-8 deg residual.
+
+**D. Swing-to-attack on BS2 (its own session).** Still exactly one line
+(`swing::publish_gate(...)`) plus the melee-equipped predicate, which is the hard part. Step 0's
+`vrinput` dispatch removed the blocker that would have made the flat suite untestable. Hazards
+unchanged and BS2-specific: native dual wield (a left-hand gesture must not compose the right
+trigger), the drill's sustained fire mode (a 120 ms discrete pulse may read as a stutter), more
+melee-ish states than BS1's single wrench. Re-measure the pulse width and threshold - 3.6 m/s is
+per-PLAYER.
+
+**E. Do not tune any BS2 viewmodel trims yet.** The reason is unchanged and now better evidenced:
+trims tuned before the lens question is closed bake the lens error in and stop being portable.
+
+### 0b. FIRST ACTIONS NEXT SESSION (BS1 - unchanged from session 31)
 
 The game-breaking item is closed and accepted. What is left before the release is verification
 breadth, not new investigation.
@@ -3837,6 +3991,54 @@ and it resumes.
   (install.ps1 backs theirs up automatically).
 
 ## Session log (newest first)
+
+### Session 32 - 2026-07-31 - BS2 resolution lane + the lens verdict; three BS1 assumptions died
+
+Branch `s32-b2r-resolution-and-lens`. All BS2. Steps 0-2 of the brief completed; steps 3-4 not
+reached and re-scoped in "Next steps 0".
+
+**What shipped:** the frozen-pitch fix (`publish_pitch_error`), a `vrinput` dispatch that BS2 never
+had, `vrres` + a BS2-specific `game_ini` module, BS2's cb0 ray-block offset as a per-game constant,
+a widened + parameterised core fov watch, and five new instruments in `decode-framedump.ps1`.
+
+**The three dead assumptions, all caught by acceptance tests rather than by reading code:**
+
+1. **The ini file.** BS1's lane writes `[WinDrv.WindowsClient]` viewport keys. BS2 has them and
+   ignores them; `Shared.ini [SharedOptions] ViewportX/Y` governs. Caught only because the
+   acceptance criterion was the backbuffer at first Present - the write itself had logged
+   `verified`. **A verified write is not an honoured one**, now a standing rule in the decision log
+   alongside the `-> HANDLED` lesson.
+2. **The square-backbuffer policy.** BS1's biggest banked conclusion does not transfer: BS2 renders
+   2048x2048 as a letterboxed 2048x1421 with a black band and a degenerate projection (horizontal
+   collapses 100 -> 67.7 deg, the ray block's vertical encodings disagree). 16:9 is the only aspect
+   proven to render correctly. This inverted the session's own plan mid-flight.
+3. **The cb0 layout.** BS2's ray block is at float 16, not 12 - and core was only COPYING 80 bytes,
+   so no offset could have rescued it. Now a per-game constant with a self-correcting, logging
+   hunt as backstop.
+
+**The lens verdict (the thing that unblocks the viewmodel work):** BS2 has TWO lenses and, unlike
+BS1's aspect-gated split, they differ AT 16:9 - a world lens tracking the FOV option and a second
+fixed at tan(30) = 60 deg that ignores it, separated by callstack. That is a 2.06x angular-gain
+error at option 100 and 3.99x at 130, present at the aspect the user actually tested, which matches
+their "wrong depth / moves with the head" report where BS1's mechanism could not. **Not yet proven
+to BE the viewmodel** - the holster test is queued and must be the identification, not draw counts.
+
+**Method note worth carrying:** the first `-ScanLayout` run came back empty and looked like "BS2's
+layout is a different shape". It was not - it was the square-aspect degeneracy breaking the check.
+`-Diff` (two dumps at different FOV options, assuming nothing about layout) is what cracked it, and
+re-scanning at 16:9 then found the offset cleanly. **Derive layouts at an aspect the game renders
+correctly.**
+
+**Regression gate:** BS1 `WORLD tanH=1.191754 tanV=1.191754` at 2048x2048, bit-identical to the
+banked session-28 value, hunt never fired.
+
+**Incident:** one black-screen hang after a force-kill mid-gameplay plus a resolution change; a
+clean restart fixed it, and the same DLL had rendered fine minutes earlier, so it was not a mod
+regression. Also re-confirmed the stale-`command.txt` trap - an old `vrres 2048x2048` re-applied at
+boot.
+
+**Still owed:** the pitch servo's sign (needs the headset; flat `pitchErr` is 0 by construction
+with `drive=0`).
 
 ### Session 31 - 2026-07-31 - swing the wrench to swing the wrench, ACCEPTED IN-HEADSET
 

--- a/docs/bioshock2/ENGINE_NOTES.md
+++ b/docs/bioshock2/ENGINE_NOTES.md
@@ -570,3 +570,186 @@ is how the detector was verified flat with a pistol in hand. If BS2's gate reads
 give it its own forcing command - flat coverage of the gesture depends on being able to open the
 gate without a human equipping a weapon (weapon switching still cannot be driven flat on either
 game; the radial needs a person).
+
+## Session 32 (2026-07-31): the resolution lane, and BS2 does NOT render non-16:9
+
+Everything below is measured on BS2, this session, with the derivation named. **Three BS1 beliefs
+died here**, all of them the kind the never-copy rule exists to catch: the ini file, the cb0
+layout, and - the expensive one - the square-backbuffer policy.
+
+### 1. The resolution lever is `Shared.ini`, NOT the `[WinDrv.WindowsClient]` viewport keys
+
+BS1's whole lane writes `%APPDATA%\BioshockHD\Bioshock\Bioshock.ini` `[WinDrv.WindowsClient]`'s
+`Windowed/FullscreenViewportX/Y`. **BS2 has those keys, in a file with the same section name, and
+IGNORES them.** The file that governs is `%APPDATA%\BioshockHD\Bioshock2\Shared.ini`, section
+`[SharedOptions]`, keys `ViewportX`/`ViewportY` - a file BS1 does not have at all.
+
+Measured over three relaunches, changing one variable at a time:
+
+| Bioshock2SP.ini WinDrv | Shared.ini SharedOptions | rendered backbuffer |
+|---|---|---|
+| 2048x2048 | 1920x1080 | 1920x1080 |
+| 2048x2048 | 2048x2048 | 2048x2048 |
+| 1920x1080 | 2048x2048 | **2048x2048** (decisive: Shared alone) |
+
+**The trap this sprang, and it is worth internalising:** the BS1-shaped port wrote its four keys,
+re-read them, logged `viewport set to 2048x2048 ... verified`, and the engine rendered 1920x1080
+anyway. **A verified write is not an honoured one.** The read-back proves the FILE took the value
+and nothing more; the only acceptance that means anything is the backbuffer at first Present after
+a relaunch. This is the same shape of mistake as trusting `-> HANDLED` from the Exec seam
+(session 30).
+
+Other BS2 deltas found while deriving this:
+
+- **FIVE sections carry the viewport key names**, not BS1's four: `[WinDrv.WindowsClient]` (470),
+  `[XeDrv.XenonClient]` (509), **`[PS3Drv.PS3Client]` (541)**, `[DurangoDrv.DurangoClient]` (573),
+  `[OrbisDrv.OrbisClient]` (605). BS2 adds the PS3 one. Section-scoping is therefore more
+  load-bearing here, not less; an unscoped replacement hits the Xenon section first (line 510).
+  `PS3Drv` is also the marker that tells the two games' configs apart - BS1 ships `GNMDrv`, never
+  `PS3Drv`.
+- **The game itself rewrites `Bioshock2SP.ini`'s WinDrv keys from its live state.** Observed: the
+  file was hand-set to 1920x1080 with the game closed, and read back 2048x2048 after a run driven
+  by Shared.ini. Those keys are an OUTPUT, not an input. `game_ini.cpp` keeps them in sync anyway -
+  not because the engine reads them, but so a config regeneration cannot silently revert the
+  resolution.
+- **A clean quit does NOT clobber the write.** `WM_CLOSE` (the orderly shutdown path) from the main
+  menu left `Shared.ini` byte-identical, hash unchanged. This closes the question BS1 left open,
+  but only for the menu-quit path - a quit from gameplay, or one made after touching the in-game
+  graphics options, is still untested and is exactly where the game would write its own settings.
+- No live `SETRES` path was attempted, deliberately. BS2 has no engine `Exec` seam at all, so the
+  question cannot be asked without first deriving one, against a BS1 precedent where it faults. If
+  it is ever wanted, the BS2-native route is the ProcessEvent-by-name seam reaching
+  `PlayerController.ConsoleCommand` (FString param block: ptr/count/max).
+
+### 2. THE BIG ONE: BS2 letterboxes non-16:9, and its projection degenerates there
+
+**Do not port BS1's settled square-backbuffer policy to BS2.** On BS1 a 2048x2048 backbuffer
+renders a full square image and is the recommended VR configuration. On BS2 the same setting gives:
+
+- a scene viewport of **2048x1421** inside the 2048x2048 backbuffer - the bottom ~30% is BLACK
+  (confirmed in a screenshot, with the HUD drawn over the black band);
+- a world horizontal that **collapses from 100 deg to 67.7 deg** (tanH 1.1918 -> 0.6704, which is
+  `tan(50)*9/16`);
+- a ray block whose two vertical encodings **stop agreeing** (`-f[21]/2 = 0.9662` vs
+  `f[22] = 0.6704`, a 0.296 disagreement against a 0.001 tolerance) - the frustum is no longer a
+  consistent symmetric perspective at all.
+
+At 1920x1080 all three are clean: viewport 1920x1080 full, tanH = 1.1918 = `tan(50)` exactly,
+tanV = 0.6704 = `tanH * 9/16`, centre (0,0), both encodings agreeing to four decimals.
+
+**Consequence for the VR policy.** BS1's chain was: black bars are an ASPECT problem -> match the
+render aspect to the (roughly square) headset eye -> a sane FOV then fills the eye -> no FOV write
+needed. **On BS2 the first link breaks**: asking for a square aspect produces a letterbox and a
+broken projection rather than a square image. So on BS2 today, 16:9 is the only aspect proven to
+render correctly, and the resolution lane's value is SHARPNESS (a bigger 16:9 buffer), not aspect
+matching.
+
+**Unresolved, and it is the next session's first job:** which aspects BS2 will render full-height.
+2048x1421 is 1.4413:1; where that comes from is underived, and it does NOT depend on the FOV option
+(the viewport was identical at option 100 and 130). Bisect it - the squarest aspect that still
+renders full-height is the best VR configuration available, and finding it is a handful of
+relaunches. `[Engine.RenderConfig] HorizontalFOVLock=True` and `ShockUserSettings`
+`bHorizontalFOVLock=False` / `LockHorizontalFOV=False` are unexamined suspects.
+
+### 3. The world FOV law - PARTIALLY derived, and honestly so
+
+At 1920x1080, option 100, world cluster: **tanH = 1.1918 = tan(50) exactly**, tanV = 0.6704 =
+tanH * (h/w). Sweeping the option to 130 moved it to tanH = 2.1445 = `tan(65)`, so the option is
+consumed as a horizontal half-angle.
+
+**But this does NOT settle the law**, and the reason is the trap that cost BS1 two sessions: the
+"true horizontal" and "16:9-referenced horizontal" laws COINCIDE EXACTLY at 16:9. Distinguishing
+them needs a second, CLEAN aspect - and BS2 does not currently provide one, because every non-16:9
+render measured is letterboxed and internally inconsistent (section 2). The decoder now prints both
+laws side by side and, at 1920x1080, **both PASS** - the tool correctly reporting the ambiguity
+rather than manufacturing a conclusion.
+
+So: `tanH = tan(option/2)` is confirmed AT 16:9 and must not be promoted to a general law until a
+clean second aspect exists. Whatever comes out of the section-2 bisection is that second aspect.
+
+### 4. BS2 HAS TWO LENSES, they differ AT 16:9, and the second one ignores the FOV option
+
+BS1's split was aspect-gated: two conventions that coincide exactly at 16:9, so the symptom could
+only appear off 16:9. **BS2's split is a MAGNITUDE difference and is present at 16:9.**
+
+Measured at 1920x1080 (`decode-framedump.ps1 -ScanLayout -RayOffset 16`):
+
+| cluster | option 100 | option 130 | blocks | callstack head |
+|---|---|---|---|---|
+| **world** | tanH 1.1918 (100.0 deg) | tanH 2.1445 | 229 | `0xBE9E68,0xAEC7B4,...` |
+| **second** | tanH **0.5774** (60.0 deg) | tanH **0.5774** | 19 | `0xBE9E68,0xAECACF,...` |
+
+`0.5774 = tan(30)` to five decimals, and it is **unchanged by the FOV option** while the world lens
+tracks it. The two clusters are separated by a distinct callstack (the third frame differs:
+`0xAECACF` vs `0xAEC7B4`), not merely by tangent, so this is a structurally different pass. Both
+lenses share the same aspect convention (tanH/tanV = 16/9 at 16:9), so the difference is purely
+magnitude.
+
+**This is the leading explanation for the user's stereo viewmodel report** ("wrong depth",
+"moves/slides with the head", possibly "wrong size"), and it fits better than BS1's mechanism ever
+could:
+
+- One projection layer carries ONE fov claim for the whole eye image. With the claim matching the
+  world, a feature in the 60-deg layer at angle `t` is displayed at `atan(tan(t) * k)` where
+  `k = tan(50)/tan(30) = 2.06` at option 100 - it swings ~2x too far as the head turns, which reads
+  exactly as the weapon sliding off the hand, and it sits at the wrong apparent size and depth.
+- **It is NOT aspect-gated**, so it is present at 1920x1080 - which is where the user tested. BS1's
+  aspect-gated split could not have produced a symptom at 16:9, which is why the BS1 story never
+  quite fit this report.
+- **It gets WORSE with FOV**: k = 2.06 at option 100, 3.99 at option 130. The manual `gfov` lever
+  defaults to 130, and raising FOV was a habit carried over from BS1.
+
+**NOT yet proven: that the 60-deg cluster IS the viewmodel.** The evidence is circumstantial though
+consistent (distinct pass, small draw count, FOV-independent, same viewport). BS1's rule applies -
+identify it by making it MOVE, never by draw counts. Since BS2 has no fg-lens lever, the test to
+run first is: holster or switch the weapon and re-dump, and see whether the 19-block cluster
+disappears or changes. Until that is done, "second lens" is the honest name for it.
+
+Note this does NOT contradict session 25's finding that BS2's foreground follows the world FOV
+natively - that was measured in mono by poking the option and watching the drill re-lens visually.
+Both can be true if the drill viewmodel rides the world lens while some OTHER fixed-60-deg pass is
+what the dump is showing. Resolving that is the same holster test.
+
+### 5. BS2's cb0 ray block is at float 16 (BS1's is 12) - same shape, different offset
+
+`constexpr int kRayBlockCb0FloatIndex = 16` in `patterns.h`, published to core at adapter init via
+`bvr::hud::set_ray_block_offset`. The layout is BS1's exactly, four floats later:
+`(2tanH, 0, -tanH, 0, 0, -2tanV, tanV)` at floats 16..22.
+
+Derivation, and the ORDER matters because the first attempt misled:
+
+1. `-ScanLayout` over a **2048x2048** dump found NOTHING at any offset across 534 blocks, which
+   looked like "BS2's layout is a different shape". **That conclusion was wrong** - it was the
+   square-aspect projection degeneracy (section 2) breaking the vertical pair check, not a
+   different layout. The lesson: derive layouts at an aspect the game renders CORRECTLY.
+2. `-Diff` between dumps at option 100 and 130 - which assumes no layout at all - flagged floats
+   16, 18, 21, 22 as scaling exactly with `tan(opt/2)`, pointing straight at the block.
+3. `-ScanLayout` over a **1920x1080** dump then matched at exactly ONE offset - 16 - across 249
+   blocks, with both clusters decoding cleanly.
+4. Cross-checked live and independently: core's self-correcting hunt logged `ray block decodes at
+   float 16, not the configured 12 - adopting 16`.
+
+The signature is specific, not loose: over a BS1 dump the same scan matches only offset 12, out of
+roughly 100,000 candidate positions tested.
+
+### 6. BS2 had no `vrinput` command at all (fixed)
+
+`bvr::input::handle_command` is core and BS1 dispatches to it; b2r never did. So the synthetic
+gamepad, `pitchkill`, `pitchservo` AND the entire core swing-gesture flat test suite were
+unreachable on BS2. One line in `apply_command` fixes all of it. Worth remembering as a CLASS of
+bug: **core growing a feature does not give an adapter access to it** when the adapter owns the
+command surface. Worth auditing the rest of b2r's vocabulary against BS1's for the same gap.
+
+### 7. The frozen-pitch fix landed, and the brief's confirmation method did not work
+
+`publish_pitch_error` now fires immediately before the `rot->pitch` overwrite (b2r `camera.cpp`),
+mirroring BS1. Two notes for whoever verifies it:
+
+- **The heartbeat could not have shown the bug.** It runs LAST by design, reporting the FINAL
+  camera handed back to the game - so its `rot` is the head's pitch, never the engine's. The
+  "look for the pitch field not moving" check would have shown a moving value either way. The
+  heartbeat now carries `enginePitch=` (sampled pre-overwrite) and `pitchErr=`, which is an
+  instrument that can actually show it.
+- Flat, with `drive=0`, `pitchErr` is 0 by construction (the not-driving branch keeps it fresh
+  rather than stale). A meaningful reading needs the HMD driving, so **the sign check is still
+  outstanding and needs the headset** - `vrinput pitchservo status|invert`, now reachable.

--- a/docs/bioshock2/TESTING.md
+++ b/docs/bioshock2/TESTING.md
@@ -148,3 +148,66 @@ view)`, heartbeat `drive=1`, and moving `headOff` values are the acceptance sign
    (save/restore leak check). While there, note the slider's min/max endpoints - they are
    still unrecorded in ENGINE_NOTES.
 8. Report: fisheye gone? world-drag gone? viewmodel correct with vrfov on? slider endpoints?
+
+## Resolution (`vrres`, session 32)
+
+**BS2's lever is `Shared.ini`, not the file BS1 uses.** See ENGINE_NOTES section 1 - the
+`[WinDrv.WindowsClient]` keys exist on BS2 and are ignored.
+
+```
+vrres                 # status: Shared.ini (governs) | Bioshock2SP.ini (synced) | live backbuffer
+vrres 2048x2048       # or `vrres 2048 2048`; takes effect on the NEXT launch
+```
+
+Acceptance, end to end - **the only acceptance that counts is the backbuffer**, because the write
+verifies its own read-back even when the engine ignores it:
+
+1. `vrres 1600x1200` -> expect `viewport set to 1600x1200 in Shared.ini [SharedOptions] (verified)`
+   and, on the first write, two `original backed up to ...bvr-bak-res` lines.
+2. Relaunch. Grep the log for the startup line: `first Present: backbuffer 1600x1200`.
+   **If it says something else, the write did not take effect regardless of what `vrres` logged.**
+3. Safety check: `diff Shared.ini.bvr-bak-res Shared.ini` should show ONLY `ViewportX`/`ViewportY`,
+   and the Bioshock2SP.ini diff ONLY the four keys in `[WinDrv.WindowsClient]` (lines 471-474).
+   Any change inside `[XeDrv.XenonClient]` (509), `[PS3Drv.PS3Client]` (541),
+   `[DurangoDrv.DurangoClient]` (573) or `[OrbisDrv.OrbisClient]` (605) is a section-scoping bug.
+
+**WARNING - do not set a square resolution on BS2.** At 2048x2048 the scene renders into a
+2048x1421 viewport with a black band across the bottom ~30%, and the projection degenerates
+(horizontal collapses 100 -> 67.7 deg). This is a real BS2 difference from BS1, where square is the
+RECOMMENDED VR setting. Until the aspect bisection in ENGINE_NOTES section 2 is done, stay at 16:9
+and use the lane for sharpness (e.g. 2560x1440, 3840x2160).
+
+## Lens / FOV measurement (session 32)
+
+```
+dumpframe full 2                                    # in GAMEPLAY - the menu has no world pass
+tools\decode-framedump.ps1 -Path <dump> -ScanLayout -RayOffset 16 -FgBakeRvas @() `
+    -OptionFov 100 -Aspect 1920x1080
+```
+
+- `-RayOffset 16` is BS2's (BS1's is 12, the default). `-FgBakeRvas @()` because the fg-bake RVAs
+  are BS1-only.
+- `-ScanLayout` brute-forces every offset and validates the structural signature - use it to
+  re-derive after a game patch. **Derive at 16:9**: at square aspect the check fails for a real
+  reason (the projection is degenerate there), which reads as "no layout found".
+- `-Diff <other dump> -DiffFovs 100,130` compares two dumps taken at different FOV options and
+  flags the floats that scale as `tan(fov/2)`. It assumes NOTHING about layout - the instrument to
+  reach for when `-ScanLayout` finds nothing.
+- `fovaudit` prints the live watch's verdict including `lenses=`. On BS2 expect **`lenses=2`** in
+  gameplay: a world lens following the FOV option, and a fixed 60 deg one that does not.
+
+## Frozen engine pitch (session 32) - IN-HEADSET CHECK STILL OWED
+
+The fix (`publish_pitch_error` before the `rot->pitch` overwrite) is in, but its SIGN is unverified
+because a meaningful `pitchErr` needs the HMD actually driving - flat, with `drive=0`, it is 0 by
+construction.
+
+1. In VR, gameplay, `camlog on`. The heartbeat now prints `enginePitch=<units> pitchErr=<deg>`.
+2. Look up and down for ~30 s. **`enginePitch` must MOVE.** If it parks at one value while `rot`
+   changes, the servo is not steering and the drill will aim where the engine last believed.
+3. `vrinput pitchservo status` (now reachable on BS2 - it was not before this session).
+4. If the view fights you or the error grows instead of shrinking, the sign is inverted:
+   `vrinput pitchservo invert`.
+5. Drill an enemy while looking DOWN - the BS1 symptom was hits landing on the floor.
+6. Residual: BS1 settles at 4-8 deg because the proportional term falls under the game's own
+   deadzone. **BS2's deadzone is its own - measure it, do not assume BS1's number.**

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,6 +77,8 @@ add_library(bioshockvr SHARED
     game/bioshock2r/bioshock2r_adapter.h
     game/bioshock2r/camera.cpp
     game/bioshock2r/camera.h
+    game/bioshock2r/game_ini.cpp
+    game/bioshock2r/game_ini.h
     game/bioshock2r/patterns.cpp
     game/bioshock2r/patterns.h
     game/bioshock2r/scenedraw.cpp

--- a/src/core/gfx/hud_capture.cpp
+++ b/src/core/gfx/hud_capture.cpp
@@ -95,13 +95,30 @@ std::atomic<unsigned> g_cHudDraws{0}, g_cRedirects{0}, g_cLeaks{0}, g_cIntervals
 // So: sample several distinct blocks, cluster them, and publish the cluster the
 // MOST distinct buffers agree on. The world pass outnumbers the foreground pass
 // roughly 6:1, exactly as tools/decode-framedump.ps1 clusters it offline.
-constexpr UINT kFovCbBytes = 80; // floats 0..19
+// SESSION 32: the copy window used to be 80 bytes (floats 0..19), which is
+// exactly wide enough for BS1's ray block at float 12 and nothing else. That is
+// a per-GAME fact, and BS2's layout is its own - so a game whose block sits past
+// float 19 was not merely mis-decoded, it was never even COPIED. Widened to the
+// same 1344 bytes the offline frame dump captures, so the live watch and
+// tools/decode-framedump.ps1 now see identical data. Cost is 10.5 KB of staging.
+constexpr UINT kFovCbBytes = 1344; // floats 0..335, matching frame_inspector
 constexpr int kFovSlots = 8;
 ID3D11Buffer* g_fovStaging = nullptr;
 bool g_fovPending = false; // copied, not yet mapped
 int g_fovPendingAge = 0;   // presents since the copy
 int g_fovSlots = 0;        // slots filled in the round being collected
 int g_fovPendingSlots = 0; // slots the outstanding map must decode
+// Bytes actually copied into each slot. Source buffers vary in size (the tier
+// gate admits anything >= 320), so a slot may be partly stale from an earlier
+// round - the decode must never read past this.
+UINT g_fovSlotBytes[kFovSlots] = {};
+// Float index of the screen-ray helper inside cb0. PER-GAME: 12 is BS1's
+// (session 21). An adapter overrides it via set_ray_block_offset(); the
+// self-correcting hunt in decode_ray_block() is the backstop.
+int g_fovRayOffset = 12;
+int g_fovOffsetMisses = 0;         // consecutive decode failures at that offset
+int g_fovOffsetCandidate = -1;     // offset the hunt is currently corroborating
+int g_fovOffsetCandidateHits = 0;
 // STRIDE sampling (session 28, second cut). Taking the first kFovSlots distinct
 // buffers is NOT representative: the foreground pass draws FIRST, so 5 of the
 // first 8 distinct buffers were fg and the majority vote picked the viewmodel
@@ -487,13 +504,19 @@ bool ensure_fov_staging(ID3D11DeviceContext* ctx) {
 // session 28 (the two cross-checks it did run are intra-axis - H against H and
 // V against V - and carry no axis information at all). Ported from the offline
 // decoder tools/decode-framedump.ps1, which has always applied them.
-bool decode_ray_block(const float* f, float* tanH, float* tanV) {
-    float h1 = f[12] * 0.5f, h2 = -f[14];
-    float v1 = -f[17] * 0.5f, v2 = f[18];
+//
+// SESSION 32: the OFFSET is a per-GAME constant, not a core fact - the
+// never-copy rule covers cb layouts exactly as it covers addresses. 12 is
+// BS1's, measured in session 21; an adapter publishes its own via
+// set_ray_block_offset().
+bool decode_ray_block_at(const float* f, int floatCount, int o, float* tanH, float* tanV) {
+    if (o < 0 || o + 7 > floatCount) return false;
+    float h1 = f[o] * 0.5f, h2 = -f[o + 2];
+    float v1 = -f[o + 5] * 0.5f, v2 = f[o + 6];
     if (!std::isfinite(h1) || !std::isfinite(h2) || !std::isfinite(v1) ||
         !std::isfinite(v2))
         return false;
-    if (fabsf(f[13]) > 0.001f || fabsf(f[15]) > 0.001f || fabsf(f[16]) > 0.001f)
+    if (fabsf(f[o + 1]) > 0.001f || fabsf(f[o + 3]) > 0.001f || fabsf(f[o + 4]) > 0.001f)
         return false; // not the ray block (or a non-perspective all-zero pass)
     // 8.0 = tan(rather more than 160 deg half-angle); the offline decoder uses
     // 4.0, loosened only because a forced claim can legitimately go wider.
@@ -502,6 +525,47 @@ bool decode_ray_block(const float* f, float* tanH, float* tanV) {
     *tanH = h1;
     *tanV = v1;
     return true;
+}
+
+// The configured offset first; only if that has been failing for a while, hunt
+// for the block elsewhere in the copied window and adopt an offset that proves
+// itself across several samples. The hunt exists so that a wrong or unset
+// per-game constant NAMES ITS OWN CORRECTION in the log instead of silently
+// publishing nothing - the same house pattern as the view-actor vtable RVA
+// line. It costs a game with the right constant nothing, because it only runs
+// after a failure, and it can never fire on BS1 (offset 12 validates on the
+// first sample of every round).
+//
+// Measured basis for trusting a hit: run offline over a BS1 dump, this
+// signature matched at exactly ONE offset out of ~100,000 candidate positions
+// across 333 blocks. It is a specific test, not a loose one.
+bool decode_ray_block(const float* f, int floatCount, float* tanH, float* tanV) {
+    if (decode_ray_block_at(f, floatCount, g_fovRayOffset, tanH, tanV)) {
+        g_fovOffsetMisses = 0;
+        return true;
+    }
+    if (++g_fovOffsetMisses < 400) return false;
+    for (int o = 0; o + 7 <= floatCount; ++o) {
+        if (o == g_fovRayOffset) continue;
+        if (!decode_ray_block_at(f, floatCount, o, tanH, tanV)) continue;
+        if (o == g_fovOffsetCandidate) {
+            if (++g_fovOffsetCandidateHits >= 8) {
+                BVR_LOG("[hud] fov watch: ray block decodes at float %d, not the configured "
+                        "%d - adopting %d. The adapter should publish this as its own "
+                        "constant (hud::set_ray_block_offset) with the derivation written "
+                        "into its ENGINE_NOTES.",
+                        o, g_fovRayOffset, o);
+                g_fovRayOffset = o;
+                g_fovOffsetMisses = 0;
+                g_fovOffsetCandidateHits = 0;
+            }
+        } else {
+            g_fovOffsetCandidate = o;
+            g_fovOffsetCandidateHits = 1;
+        }
+        return true;
+    }
+    return false;
 }
 
 // Map attempt + mismatch bookkeeping, once per present (from on_present).
@@ -521,7 +585,11 @@ void fov_watch_on_present(ID3D11DeviceContext* ctx) {
             for (int s = 0; s < g_fovPendingSlots && s < kFovSlots; ++s) {
                 const float* f = reinterpret_cast<const float*>(
                     static_cast<const uint8_t*>(m.pData) + s * kFovCbBytes);
-                if (decode_ray_block(f, &h[n], &v[n])) ++n;
+                // Only what THIS slot's source buffer actually supplied: the
+                // tier gate admits anything >= 320 bytes, so the tail of a
+                // slot can be stale from an earlier round.
+                int floats = static_cast<int>(g_fovSlotBytes[s] / 4);
+                if (decode_ray_block(f, floats, &h[n], &v[n])) ++n;
             }
             ctx->Unmap(g_fovStaging, 0);
             g_fovPending = false;
@@ -846,10 +914,18 @@ void on_draw_indexed(ID3D11DeviceContext* ctx) {
                     if (stride < 1) stride = 1;
                     if (!g_fovPending && g_fovSlots < kFovSlots &&
                         idx % stride == 0 && ensure_fov_staging(ctx)) {
-                        D3D11_BOX box{0, 0, 0, kFovCbBytes, 1, 1};
+                        // Clamp to the SOURCE size: the box must lie inside the
+                        // source buffer, and the gate admits buffers smaller
+                        // than the window. Remember what was copied so the
+                        // decode cannot read a neighbouring slot's leftovers.
+                        UINT copyBytes =
+                            bd.ByteWidth < kFovCbBytes ? bd.ByteWidth : kFovCbBytes;
+                        copyBytes &= ~3u; // whole floats only
+                        D3D11_BOX box{0, 0, 0, copyBytes, 1, 1};
                         ctx->CopySubresourceRegion(g_fovStaging, 0,
                                                    g_fovSlots * kFovCbBytes, 0, 0,
                                                    cb0, 0, &box);
+                        g_fovSlotBytes[g_fovSlots] = copyBytes;
                         if (g_fovSlots == 0) g_fovStrideUsed = stride;
                         ++g_fovSlots;
                     }
@@ -1352,6 +1428,23 @@ bool fov_watch_fg(float* tanH, float* tanV, unsigned long long* ageMs,
 }
 
 int fov_lens_count() { return g_fovLenses.load(std::memory_order_relaxed); }
+
+void set_ray_block_offset(int cb0FloatIndex) {
+    if (cb0FloatIndex < 0 || cb0FloatIndex + 7 > static_cast<int>(kFovCbBytes / 4)) {
+        BVR_LOG("[hud] fov watch: refusing ray block offset %d (outside 0..%d)", cb0FloatIndex,
+                static_cast<int>(kFovCbBytes / 4) - 7);
+        return;
+    }
+    if (cb0FloatIndex == g_fovRayOffset) return;
+    BVR_LOG("[hud] fov watch: ray block offset %d -> %d (per-game constant)", g_fovRayOffset,
+            cb0FloatIndex);
+    g_fovRayOffset = cb0FloatIndex;
+    g_fovOffsetMisses = 0;
+    g_fovOffsetCandidate = -1;
+    g_fovOffsetCandidateHits = 0;
+}
+
+int ray_block_offset() { return g_fovRayOffset; }
 
 // Backbuffer dims as last sampled by the letterbox watch. Exposed because the
 // lens laws are aspect-parameterised and the audit used to fall back to a

--- a/src/core/gfx/hud_capture.h
+++ b/src/core/gfx/hud_capture.h
@@ -236,6 +236,19 @@ void get_counters(unsigned* hudDraws, unsigned* redirects, unsigned* leaks,
 //                  against bvr::vr::rendered_hfov_deg(), logs transitions - the
 //                  flat-testable instrument; the VR runtime keys the cinematic
 //                  quad fallback on it)
+// SESSION 32: the float index of the screen-ray helper inside cb0 is a PER-GAME
+// constant, not a core one - the never-copy rule covers cb layouts exactly as it
+// covers addresses. Core defaults to BS1's 12 (measured session 21); an adapter
+// publishes its own from its patterns header at init, with the derivation
+// written into that game's ENGINE_NOTES. Deriving a new game's: take a
+// `dumpframe full` and run tools/decode-framedump.ps1 -ScanLayout; if that finds
+// nothing, the layout is a different SHAPE and -Diff (two dumps at different FOV
+// options) identifies the projection terms with no layout assumption at all.
+// If the configured value is wrong the watch says so in the log and adopts what
+// it finds, rather than silently publishing nothing.
+void set_ray_block_offset(int cb0FloatIndex);
+int ray_block_offset();
+
 bool fov_watch(float* tanH, float* tanV, unsigned long long* ageMs,
                unsigned long long maxAgeMs = 500);
 bool fov_watch_fg(float* tanH, float* tanV, unsigned long long* ageMs,

--- a/src/game/bioshock2r/bioshock2r_adapter.cpp
+++ b/src/game/bioshock2r/bioshock2r_adapter.cpp
@@ -1,5 +1,6 @@
 #include "game/bioshock2r/bioshock2r_adapter.h"
 
+#include "core/gfx/hud_capture.h"
 #include "core/util/log.h"
 #include "game/bioshock2r/camera.h"
 #include "game/bioshock2r/patterns.h"
@@ -24,6 +25,11 @@ bool Bioshock2RAdapter::init(const bvr::pattern_scan::ProcessImage& image) {
     if (!patterns::resolve(image, symbols)) return false; // resolve() logged why
     camera::init_image(image); // vtable-RVA identity checks need the bounds
     scenedraw::init(image);    // RVA math for the discovery instruments
+    // BS2's cb0 ray block sits at float 16, not BS1's 12 (session 32; the
+    // derivation is in patterns.h next to the constant). Core defaults to
+    // BS1's, so without this the live fov watch decodes nothing on BS2 -
+    // which is exactly the state session 26 recorded.
+    bvr::hud::set_ray_block_offset(patterns::kRayBlockCb0FloatIndex);
     if (!camera::install(symbols)) return false;
     BVR_LOG("[b2r] adapter ready, capabilities 0x%X", capabilities());
     return true;

--- a/src/game/bioshock2r/camera.cpp
+++ b/src/game/bioshock2r/camera.cpp
@@ -15,6 +15,7 @@
 #include "core/ui/overlay.h"
 #include "core/util/log.h"
 #include "core/vr/openxr_runtime.h"
+#include "game/bioshock2r/game_ini.h"
 #include "game/bioshock2r/scenedraw.h"
 #include "game/shared/ue_math.h"
 
@@ -140,6 +141,13 @@ uint32_t g_heartbeatBaseCount = 0;
 bool g_wasWritingGameFov = false;
 int32_t g_savedGameFov = 0;
 uint64_t g_lastCalcViewMs = 0;
+// Session 32: the ENGINE's own view pitch, sampled BEFORE the drive overwrites
+// it, and the error handed to the core pitch servo. These exist because the
+// heartbeat below runs LAST and prints the FINAL rot by design - so it reports
+// the head's pitch, never the engine's, and could not have shown the engine's
+// pitch frozen. Game thread only.
+int32_t g_enginePitchUnits = 0;
+float g_pitchErrDeg = 0.0f;
 bool g_haveRecenter = false;
 bvr::vr::HeadPose g_recenterPose{};
 // The seated frame's yaw zero, in ROTATOR UNITS (65536/turn), integer for the
@@ -219,11 +227,19 @@ void apply_eye_offset(FVector* loc, const FRotator& rot, int sign) {
 //   camlog on|off                1 Hz heartbeat
 //   vroverlay on|off             core overlay visibility (bring-up A/B)
 //   vrcine <args>                core cinematic-fallback A/B (vrcine status..)
+//   vrinput <args>               core input surface (session 32): synthetic
+//                                gamepad `test stick|trig|press|clear`,
+//                                `pitchkill`, `pitchservo on|off|invert|status`,
+//                                `swing ...` - all core, all previously
+//                                unreachable on BS2 for want of this branch
 // FOV (session 25; both write levers DEFAULT OFF):
 //   vrfov on|off|status          forced headset FOV write (strict gameplay +
 //                                HMD driving only; save/restore of the option)
 //   gfov <deg>|off               manual game FOV write (flat test lever)
 //   fovaudit                     option vs submitted claim vs rendered fov
+// Resolution (session 32; the eye render IS the backbuffer):
+//   vrres <w>x<h> | <w> <h>      write the game's own viewport keys (next
+//                                launch); bare `vrres` reports current vs live
 // Discovery commands (route to core/debug/value_scan; game thread only),
 // ported from BS1's dispatcher for the session-25 FOV derivation - the
 // duplicate-now seam policy applies (see the ARCHITECTURE decision log):
@@ -356,13 +372,28 @@ void apply_command(const char* cmd, const char* args) {
         int src = -1;
         unsigned sw = 0, sh = 0;
         bvr::vr::fov_audit(&tanH, &tanV, &src, &sw, &sh);
-        // Option-derived expectation. Flat there is no session (swap dims
-        // 0x0) - assume the 16:9 render aspect.
+        // Option-derived expectation. Session 32: the old fallback assumed 16:9
+        // whenever there was no XR session - i.e. always, flat, which is where
+        // the measuring happens, and wrong at every aspect but one. Use the
+        // real backbuffer (published every present, headset or not) and fall
+        // back to the swap dims, not to a constant. BS1 made the same fix in
+        // session 28 for the same reason.
         float optTanH = 0.0f, optTanV = 0.0f;
+        unsigned bw = 0, bh = 0;
+        bvr::hud::backbuffer_dims(&bw, &bh);
+        if (!bw || !bh) {
+            bw = sw;
+            bh = sh;
+        }
         if (opt) {
             optTanH = tanf(static_cast<float>(*opt) * 0.5f / kRadToDeg);
-            optTanV = optTanH * ((sw && sh) ? (static_cast<float>(sh) / static_cast<float>(sw))
-                                            : (9.0f / 16.0f));
+            // BS2's world law measured at 16:9 (session 32): tanH = tan(opt/2),
+            // vertical follows the window. NOT confirmed at a second CLEAN
+            // aspect - BS2 letterboxes non-16:9 and its projection degenerates
+            // there, so the two candidate laws remain indistinguishable. Do not
+            // promote this to settled without a clean second aspect.
+            optTanV = optTanH * ((bw && bh) ? (static_cast<float>(bh) / static_cast<float>(bw))
+                                            : 0.0f);
         }
         BVR_LOG("[b2r] fovaudit: option=%d gfovWrite=%s(%.1f) vrfov=%s | submitted "
                 "tanH=%.6f tanV=%.6f src=%s swap=%ux%u | option-derived tanH=%.6f "
@@ -478,6 +509,36 @@ void apply_command(const char* cmd, const char* args) {
         } else {
             BVR_LOG("[b2r] usage: vtscan <hexRva> [needBytesHex]");
         }
+    } else if (strcmp(cmd, "vrres") == 0) {
+        // The eye render IS the game's backbuffer, so the game's resolution is
+        // the VR resolution - and a headset eye is roughly square, which is why
+        // this lane comes BEFORE any FOV or viewmodel tuning (BS1's settled
+        // policy, sessions 27-28). BS2 has no engine Exec seam at all, so there
+        // is no live path to try; the game's own ini is the only lever and a
+        // change lands on the next launch. Deliberately explicit, never
+        // automatic - this writes the user's config file.
+        unsigned rw = 0, rh = 0;
+        if (sscanf_s(args, "%ux%u", &rw, &rh) == 2 && rw && rh) {
+            game_ini::write_viewport(rw, rh);
+        } else if (sscanf_s(args, "%u %u", &rw, &rh) == 2 && rw && rh) {
+            game_ini::write_viewport(rw, rh);
+        } else {
+            // The REAL backbuffer, not the XR swapchain: flat there is no
+            // session, so fov_audit's swap dims are 0x0 and the status line
+            // could never do its one job (compare the config against what is
+            // actually being rendered). backbuffer_dims is published every
+            // present, headset or not.
+            unsigned bw = 0, bh = 0;
+            bvr::hud::backbuffer_dims(&bw, &bh);
+            game_ini::log_status(bw, bh);
+        }
+    } else if (strcmp(cmd, "vrinput") == 0) {
+        // Session 32: the whole core input surface was unreachable on BS2 -
+        // b2r never dispatched here, so the synthetic gamepad, the pitch servo
+        // (`vrinput pitchservo on|off|invert|status`, which is how step 0's
+        // sign gets checked) and the swing detector's entire flat test suite
+        // had no way in. One line, all of it core, none of it BS1-specific.
+        bvr::input::handle_command(args); // logs its own echoes
     } else if (strcmp(cmd, "reentry") == 0) {
         scenedraw::handle_command(args);
     } else if (strcmp(cmd, "vrstereo") == 0) {
@@ -642,6 +703,25 @@ void calcview_tail(void* self, CalcViewParams* p) {
         int32_t headYawUnits = static_cast<int32_t>(lroundf(a.yawRad * kRotUnitsPerRadian));
         int32_t residualUnits = wrap_rot(headYawUnits - g_recenterYawUnits);
         float gameYawRad = static_cast<float>(gameYawUnits) / kRotUnitsPerRadian;
+        // Session 32 (BS1 session 30, same defect in shared code): publish how
+        // far the ENGINE's own pitch is from the head's BEFORE we overwrite it,
+        // so the core pitch servo can steer the engine's value back through the
+        // pad. This read has to happen here and ONLY here - one line below,
+        // rot->pitch is the head's value and the error is identically zero,
+        // which is exactly why nobody notices the engine's pitch is frozen.
+        // Yaw needs no equivalent: it is written RELATIVE just below (the
+        // engine's own yaw plus a residual), so the engine's yaw stays real.
+        // Without this, publish_vr_gameplay below arms the shared pitch kill,
+        // the engine's view pitch never changes again for the session, and
+        // melee - BS2's DRILL - aims with it.
+        {
+            int32_t headPitchUnits =
+                static_cast<int32_t>(lroundf(a.pitchRad * kRotUnitsPerRadian));
+            int32_t errUnits = wrap_rot(headPitchUnits - rot->pitch);
+            g_enginePitchUnits = rot->pitch;
+            g_pitchErrDeg = static_cast<float>(errUnits) / kRotUnitsPerDegree;
+            bvr::input::publish_pitch_error(g_pitchErrDeg);
+        }
         rot->pitch = static_cast<int32_t>(a.pitchRad * kRotUnitsPerRadian);
         rot->roll = static_cast<int32_t>(a.rollRad * kRotUnitsPerRadian);
         rot->yaw = gameYawUnits + residualUnits;
@@ -698,6 +778,11 @@ void calcview_tail(void* self, CalcViewParams* p) {
         g_headOffX.store(0.0f, std::memory_order_relaxed);
         g_headOffY.store(0.0f, std::memory_order_relaxed);
         g_headOffZ.store(0.0f, std::memory_order_relaxed);
+        // Not driving means the pitch kill is not armed either, so the engine
+        // owns its pitch outright and the error is zero by definition. Kept
+        // fresh rather than stale so the heartbeat never shows a leftover.
+        g_enginePitchUnits = rot->pitch;
+        g_pitchErrDeg = 0.0f;
     }
     // Stick-pitch-kill gate for the core input bridge, same funnel BS1 feeds.
     bvr::input::publish_vr_gameplay(vrDrove && strictGameplay);
@@ -768,13 +853,19 @@ void calcview_tail(void* self, CalcViewParams* p) {
             g_lastHeartbeatMs = now;
             g_heartbeatBaseCount = count;
         } else if (now - g_lastHeartbeatMs >= 1000) {
+            // enginePitch is the value the engine believed BEFORE the drive
+            // overwrote it, so a frozen engine pitch shows up here as a number
+            // that never moves while `rot` does. pitchErr is what the servo is
+            // being fed; it should shrink as the servo converges.
             BVR_LOG("[b2r] camera: loc=(%.1f %.1f %.1f) rot=(%d %d %d) fov=%d "
-                    "headOff=(%.1f %.1f %.1f) drive=%d (%u calls/s)",
+                    "headOff=(%.1f %.1f %.1f) drive=%d enginePitch=%d "
+                    "pitchErr=%.1f deg (%u calls/s)",
                     loc->x, loc->y, loc->z, rot->pitch, rot->yaw, rot->roll,
                     g_lastOptionFov.load(std::memory_order_relaxed),
                     g_headOffX.load(std::memory_order_relaxed),
                     g_headOffY.load(std::memory_order_relaxed),
                     g_headOffZ.load(std::memory_order_relaxed), vrDrove ? 1 : 0,
+                    g_enginePitchUnits, g_pitchErrDeg,
                     count - g_heartbeatBaseCount);
             // SR flat measure (G6): live inter-eye camera delta from the two
             // passes of the current pair. Expect |d| == ipdMm/1000 x

--- a/src/game/bioshock2r/game_ini.cpp
+++ b/src/game/bioshock2r/game_ini.cpp
@@ -1,0 +1,368 @@
+#include "game/bioshock2r/game_ini.h"
+
+#include "core/util/log.h"
+
+#include <windows.h>
+#include <shlobj.h>
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+namespace bvr::b2r::game_ini {
+namespace {
+
+// THE section that governs (Shared.ini). Measured, not assumed - see the
+// header's truth table.
+constexpr char kSharedSection[] = "[SharedOptions]";
+
+// The PC driver section of Bioshock2SP.ini. FOUR others carry identical
+// viewport key names in the shipped BS2 file - [XeDrv.XenonClient] (509),
+// [PS3Drv.PS3Client] (541), [DurangoDrv.DurangoClient] (573) and
+// [OrbisDrv.OrbisClient] (605), all verified present at those lines on the live
+// install. BS1 has only three decoys; the PS3 one is BS2's addition, and it is
+// also the marker that tells the two games' config files apart (BS1 ships
+// GNMDrv, never PS3Drv). Never touch any of them. These keys do NOT drive the
+// engine on BS2 - they are kept in sync, not relied on.
+constexpr char kPcSection[] = "[WinDrv.WindowsClient]";
+constexpr char kBs2Marker[] = "[PS3Drv.PS3Client]";
+
+// Shared.ini is the governing file; Bioshock2SP.ini sits beside it.
+wchar_t g_path[MAX_PATH] = {};   // Shared.ini
+wchar_t g_spPath[MAX_PATH] = {}; // Bioshock2SP.ini ("" if absent)
+bool g_searched = false;
+
+bool file_exists(const wchar_t* p) {
+    DWORD a = GetFileAttributesW(p);
+    return a != INVALID_FILE_ATTRIBUTES && !(a & FILE_ATTRIBUTE_DIRECTORY);
+}
+
+bool read_all(const wchar_t* p, std::string& out) {
+    HANDLE h = CreateFileW(p, GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING,
+                           FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (h == INVALID_HANDLE_VALUE) return false;
+    LARGE_INTEGER size{};
+    if (!GetFileSizeEx(h, &size) || size.QuadPart <= 0 || size.QuadPart > (8 << 20)) {
+        CloseHandle(h);
+        return false;
+    }
+    out.resize(static_cast<size_t>(size.QuadPart));
+    DWORD got = 0;
+    bool ok = ReadFile(h, out.data(), static_cast<DWORD>(out.size()), &got, nullptr) &&
+              got == out.size();
+    CloseHandle(h);
+    if (!ok) out.clear();
+    return ok;
+}
+
+bool write_all(const wchar_t* p, const std::string& data) {
+    HANDLE h = CreateFileW(p, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL,
+                           nullptr);
+    if (h == INVALID_HANDLE_VALUE) return false;
+    DWORD wrote = 0;
+    bool ok = WriteFile(h, data.data(), static_cast<DWORD>(data.size()), &wrote, nullptr) &&
+              wrote == data.size();
+    // Flush before the rename: a crash between the two would otherwise leave a
+    // zero-length temp file to be promoted over the real config.
+    if (ok) FlushFileBuffers(h);
+    CloseHandle(h);
+    return ok;
+}
+
+// [start, end) byte span of `section`'s BODY, or false. Scoping every read and
+// every write through this is the whole defence against the decoy sections.
+bool section_span(const std::string& text, const char* section, size_t& start, size_t& end) {
+    size_t at = text.find(section);
+    if (at == std::string::npos) return false;
+    size_t bodyStart = text.find('\n', at);
+    if (bodyStart == std::string::npos) return false;
+    ++bodyStart;
+    // The section ends at the next line that begins a new section.
+    size_t p = bodyStart;
+    while (p < text.size()) {
+        if (text[p] == '[') break;
+        size_t nl = text.find('\n', p);
+        if (nl == std::string::npos) {
+            p = text.size();
+            break;
+        }
+        p = nl + 1;
+    }
+    start = bodyStart;
+    end = p;
+    return true;
+}
+
+// Value of `key` inside [start, end), or -1. Key must match at a line start.
+long section_value(const std::string& text, size_t start, size_t end, const char* key) {
+    const size_t keyLen = strlen(key);
+    size_t p = start;
+    while (p < end) {
+        size_t nl = text.find('\n', p);
+        size_t lineEnd = (nl == std::string::npos || nl > end) ? end : nl;
+        if (lineEnd - p > keyLen && text.compare(p, keyLen, key) == 0 && text[p + keyLen] == '=') {
+            return strtol(text.c_str() + p + keyLen + 1, nullptr, 10);
+        }
+        if (nl == std::string::npos) break;
+        p = nl + 1;
+    }
+    return -1;
+}
+
+// Replace `key`'s value inside [start, end) in place. Returns false if the key
+// is not present in that section - this code never ADDS keys. The shipped file
+// has all of them, and inventing one is how a config stops loading.
+bool set_section_value(std::string& text, size_t start, size_t& end, const char* key,
+                       uint32_t value) {
+    const size_t keyLen = strlen(key);
+    size_t p = start;
+    while (p < end) {
+        size_t nl = text.find('\n', p);
+        size_t lineEnd = (nl == std::string::npos || nl > end) ? end : nl;
+        if (lineEnd - p > keyLen && text.compare(p, keyLen, key) == 0 && text[p + keyLen] == '=') {
+            // Keep the line's terminator (CR and/or LF) exactly as it was.
+            size_t valStart = p + keyLen + 1;
+            size_t valEnd = valStart;
+            while (valEnd < lineEnd && text[valEnd] != '\r' && text[valEnd] != '\n') ++valEnd;
+            char buf[16];
+            int n = _snprintf_s(buf, sizeof buf, _TRUNCATE, "%u", value);
+            if (n <= 0) return false;
+            const size_t oldLen = valEnd - valStart;
+            text.replace(valStart, oldLen, buf, static_cast<size_t>(n));
+            end += static_cast<size_t>(n) - oldLen; // span shifts with the edit
+            return true;
+        }
+        if (nl == std::string::npos) break;
+        p = nl + 1;
+    }
+    return false;
+}
+
+bool section_bool(const std::string& text, size_t start, size_t end, const char* key) {
+    const size_t keyLen = strlen(key);
+    size_t p = start;
+    while (p < end) {
+        size_t nl = text.find('\n', p);
+        size_t lineEnd = (nl == std::string::npos || nl > end) ? end : nl;
+        if (lineEnd - p > keyLen && text.compare(p, keyLen, key) == 0 && text[p + keyLen] == '=')
+            return _strnicmp(text.c_str() + p + keyLen + 1, "True", 4) == 0;
+        if (nl == std::string::npos) break;
+        p = nl + 1;
+    }
+    return false;
+}
+
+// A candidate only wins if it EXISTS and actually carries the named section.
+bool candidate_has(const wchar_t* p, const char* section) {
+    if (!file_exists(p)) return false;
+    std::string text;
+    if (!read_all(p, text)) return false;
+    return text.find(section) != std::string::npos;
+}
+
+void search() {
+    g_searched = true;
+    wchar_t roaming[MAX_PATH]{}, docs[MAX_PATH]{};
+    SHGetFolderPathW(nullptr, CSIDL_APPDATA, nullptr, 0, roaming);
+    SHGetFolderPathW(nullptr, CSIDL_PERSONAL, nullptr, 0, docs);
+
+    // Verified on the live Steam install: %APPDATA%\BioshockHD\Bioshock2\ holds
+    // Shared.ini (the pair that governs), Bioshock2SP.ini and User.ini; the
+    // matching Documents\BioshockHD\BioShock2\ holds ONLY SaveGames, so there is
+    // no competing candidate there today. The Documents entries cover layouts
+    // other installs may use. The game directory is deliberately NOT searched:
+    // under Program Files a write there is silently redirected to VirtualStore,
+    // which reads back as success and changes nothing.
+    const wchar_t* dirs[][2] = {
+        {roaming, L"\\BioshockHD\\Bioshock2"},
+        {roaming, L"\\Bioshock2"},
+        {docs, L"\\BioshockHD\\Bioshock2"},
+        {docs, L"\\BioShock 2 Remastered"},
+    };
+    for (const auto& d : dirs) {
+        if (!d[0][0]) continue;
+        wchar_t shared[MAX_PATH], sp[MAX_PATH];
+        if (_snwprintf_s(shared, MAX_PATH, _TRUNCATE, L"%s%s\\Shared.ini", d[0], d[1]) < 0)
+            continue;
+        if (!candidate_has(shared, kSharedSection)) {
+            BVR_LOG("[b2r] game ini: not here - %ls", shared);
+            continue;
+        }
+        wcscpy_s(g_path, shared);
+        // The secondary file is optional: it is kept in sync when present and
+        // its absence must never block the write that actually matters.
+        if (_snwprintf_s(sp, MAX_PATH, _TRUNCATE, L"%s%s\\Bioshock2SP.ini", d[0], d[1]) > 0 &&
+            candidate_has(sp, kPcSection)) {
+            wcscpy_s(g_spPath, sp);
+        }
+        bool marker = g_spPath[0] && candidate_has(g_spPath, kBs2Marker);
+        BVR_LOG("[b2r] game ini: %ls (governs) | %ls%s", g_path,
+                g_spPath[0] ? g_spPath : L"<no Bioshock2SP.ini - not needed>",
+                g_spPath[0] && !marker
+                    ? " (note: no [PS3Drv.PS3Client] - the BS2 section layout may have "
+                      "changed; writes stay section-scoped regardless)"
+                    : "");
+        return;
+    }
+    BVR_LOG("[b2r] game ini: Shared.ini NOT FOUND - resolution cannot be set from the mod");
+}
+
+// Replace one key inside one section of one file, with the whole safety chain:
+// section-scoped, never adds a key, one-time backup, temp + ReplaceFileW.
+// `keys`/`values` are parallel arrays so a file is rewritten exactly once.
+bool edit_section_keys(const wchar_t* file, const char* section, const char* const* keys,
+                       const uint32_t* values, int n) {
+    std::string text;
+    if (!read_all(file, text)) {
+        BVR_LOG("[b2r] game ini: read failed on %ls (err %lu)", file, GetLastError());
+        return false;
+    }
+    size_t start = 0, end = 0;
+    if (!section_span(text, section, start, end)) {
+        BVR_LOG("[b2r] game ini: %s not found in %ls - refusing to guess", section, file);
+        return false;
+    }
+    for (int i = 0; i < n; ++i) {
+        if (!set_section_value(text, start, end, keys[i], values[i])) {
+            BVR_LOG("[b2r] game ini: key %s missing from %s in %ls - nothing written", keys[i],
+                    section, file);
+            return false;
+        }
+    }
+
+    // One-time backup, matching the existing .bvr-bak-* convention. Never
+    // overwritten, so the first backup is always the user's original.
+    wchar_t bak[MAX_PATH];
+    if (_snwprintf_s(bak, MAX_PATH, _TRUNCATE, L"%s.bvr-bak-res", file) > 0 && !file_exists(bak)) {
+        if (CopyFileW(file, bak, TRUE))
+            BVR_LOG("[b2r] game ini: original backed up to %ls", bak);
+        else
+            BVR_LOG("[b2r] game ini: backup FAILED (err %lu) - writing anyway", GetLastError());
+    }
+
+    // Temp file then ReplaceFileW, so an interrupted write cannot truncate the
+    // user's config.
+    wchar_t tmp[MAX_PATH];
+    if (_snwprintf_s(tmp, MAX_PATH, _TRUNCATE, L"%s.bvr-tmp", file) < 0) return false;
+    if (!write_all(tmp, text)) {
+        BVR_LOG("[b2r] game ini: temp write failed (err %lu)", GetLastError());
+        return false;
+    }
+    if (!ReplaceFileW(file, tmp, nullptr, REPLACEFILE_IGNORE_MERGE_ERRORS, nullptr, nullptr)) {
+        DWORD err = GetLastError();
+        DeleteFileW(tmp);
+        BVR_LOG("[b2r] game ini: replace failed on %ls (err %lu) - config untouched", file, err);
+        return false;
+    }
+    return true;
+}
+
+} // namespace
+
+const wchar_t* path() {
+    if (!g_searched) search();
+    return g_path;
+}
+
+Viewport read_viewport() {
+    Viewport v{};
+    if (!path()[0]) return v;
+
+    // The governing pair.
+    std::string text;
+    if (!read_all(g_path, text)) return v;
+    size_t start = 0, end = 0;
+    if (!section_span(text, kSharedSection, start, end)) return v;
+    long sx = section_value(text, start, end, "ViewportX");
+    long sy = section_value(text, start, end, "ViewportY");
+    if (sx <= 0 || sy <= 0) return v;
+    v.w = static_cast<uint32_t>(sx);
+    v.h = static_cast<uint32_t>(sy);
+    v.startupFullscreen = section_bool(text, start, end, "StartupFullscreen");
+    v.valid = true;
+
+    // The ignored-but-kept-in-sync pair, reported only.
+    std::string sp;
+    if (g_spPath[0] && read_all(g_spPath, sp)) {
+        size_t s2 = 0, e2 = 0;
+        if (section_span(sp, kPcSection, s2, e2)) {
+            long wx = section_value(sp, s2, e2, "WindowedViewportX");
+            long wy = section_value(sp, s2, e2, "WindowedViewportY");
+            long fx = section_value(sp, s2, e2, "FullscreenViewportX");
+            long fy = section_value(sp, s2, e2, "FullscreenViewportY");
+            v.windowedW = wx > 0 ? static_cast<uint32_t>(wx) : 0;
+            v.windowedH = wy > 0 ? static_cast<uint32_t>(wy) : 0;
+            v.fullscreenW = fx > 0 ? static_cast<uint32_t>(fx) : 0;
+            v.fullscreenH = fy > 0 ? static_cast<uint32_t>(fy) : 0;
+        }
+    }
+    return v;
+}
+
+bool write_viewport(uint32_t w, uint32_t h) {
+    if (w < 640 || h < 480 || w > 16384 || h > 16384) {
+        BVR_LOG("[b2r] game ini: refusing %ux%u (outside 640x480..16384x16384)", w, h);
+        return false;
+    }
+    if (!path()[0]) {
+        BVR_LOG("[b2r] game ini: cannot write - no Shared.ini located");
+        return false;
+    }
+
+    // 1. The pair that actually governs.
+    const char* sharedKeys[] = {"ViewportX", "ViewportY"};
+    const uint32_t sharedVals[] = {w, h};
+    if (!edit_section_keys(g_path, kSharedSection, sharedKeys, sharedVals, 2)) return false;
+
+    // 2. Keep the ignored pair in sync. Best effort: a failure here cannot undo
+    // the write that matters, so it is logged and swallowed rather than
+    // reported as failure. Both windowed and fullscreen, because UE2 keeps two
+    // and reads whichever mode it starts in.
+    if (g_spPath[0]) {
+        const char* spKeys[] = {"WindowedViewportX", "WindowedViewportY",
+                                "FullscreenViewportX", "FullscreenViewportY"};
+        const uint32_t spVals[] = {w, h, w, h};
+        if (!edit_section_keys(g_spPath, kPcSection, spKeys, spVals, 4))
+            BVR_LOG("[b2r] game ini: Bioshock2SP.ini not synced - harmless (the engine ignores "
+                    "those keys on BS2), but a config regeneration could revert the resolution");
+    }
+
+    // 3. READ BACK. A write that reports success and changes nothing is the
+    // failure mode worth catching by hand - it is what UAC redirection looks
+    // like. Note this proves the FILE took the value, never that the ENGINE
+    // honours it: on BS2 the WinDrv keys verify perfectly and do nothing, which
+    // is how they were caught. The only real acceptance is the backbuffer at
+    // first Present after a relaunch.
+    Viewport after = read_viewport();
+    if (!after.valid || after.w != w || after.h != h) {
+        BVR_LOG("[b2r] game ini: WROTE %ux%u but it reads back %ux%u - the write did not stick",
+                w, h, after.w, after.h);
+        return false;
+    }
+    // Deliberately does NOT spell out the startup line's exact wording: quoting
+    // it here made this message match every `grep "first Present: backbuffer"`
+    // and hid the real one.
+    BVR_LOG("[b2r] game ini: viewport set to %ux%u in Shared.ini [SharedOptions] (verified) "
+            "- takes effect on the NEXT launch; confirm against the startup backbuffer line",
+            w, h);
+    return true;
+}
+
+void log_status(uint32_t liveW, uint32_t liveH) {
+    Viewport v = read_viewport();
+    if (!v.valid) {
+        BVR_LOG("[b2r] game ini: Shared.ini unreadable or missing %s", kSharedSection);
+        return;
+    }
+    const bool agrees = liveW == 0 || (v.w == liveW && v.h == liveH);
+    BVR_LOG("[b2r] game ini: Shared.ini %ux%u (GOVERNS) startupFullscreen=%s | "
+            "Bioshock2SP.ini windowed %ux%u fullscreen %ux%u (ignored by the engine, synced) | "
+            "live backbuffer %ux%u%s",
+            v.w, v.h, v.startupFullscreen ? "True" : "False", v.windowedW, v.windowedH,
+            v.fullscreenW, v.fullscreenH, liveW, liveH,
+            agrees ? "" : " - NOT HONOURED YET (a change takes effect on the next launch; if it "
+                          "persists past a relaunch, something else is winning - measure, do "
+                          "not assume)");
+}
+
+} // namespace bvr::b2r::game_ini

--- a/src/game/bioshock2r/game_ini.h
+++ b/src/game/bioshock2r/game_ini.h
@@ -1,0 +1,99 @@
+#pragma once
+// Read and write the GAME's own config, specifically the render resolution.
+// Per-game on purpose, and NOT a shared module: the file names, their directory
+// and the sections that actually govern the viewport are all BioShock-2 facts,
+// derived fresh from the live install (session 32) rather than inherited from
+// BS1. Only the SHAPE of bioshock1r/game_ini is reused.
+//
+// THE FINDING THAT MADE THIS NOT A PORT (session 32, measured over three
+// relaunches). BS1's whole lane writes `[WinDrv.WindowsClient]`'s
+// Windowed/FullscreenViewportX/Y. **BS2 IGNORES THOSE KEYS.** The file that
+// governs is `Shared.ini`, section `[SharedOptions]`, keys `ViewportX`/
+// `ViewportY` - a file BS1 does not have at all:
+//
+//   Bioshock2SP.ini WinDrv | Shared.ini SharedOptions | rendered
+//   -----------------------|--------------------------|------------
+//   2048x2048              | 1920x1080                | 1920x1080
+//   2048x2048              | 2048x2048                | 2048x2048
+//   1920x1080              | 2048x2048                | 2048x2048   <- decisive
+//
+// Shared.ini wins in every case, including when it is the ONLY file asking.
+// This is exactly what the never-copy rule protects against: the BS1-shaped
+// port wrote its four keys, re-read them, logged "verified", and the engine
+// rendered 1920x1080 anyway. **A verified write is not an honoured one** - the
+// only acceptance that means anything here is the backbuffer at first Present.
+//
+// Both files are still written. Shared.ini is authoritative and is what gets
+// verified; the WinDrv pair is kept in SYNC rather than left stale, so that if
+// Shared.ini is ever deleted or regenerated (config reset, Steam file verify)
+// it cannot silently drag the resolution back to a value the user changed
+// months ago. Disagreeing configs are a trap; agreeing ones cost nothing.
+//
+// WHY IT MATTERS. The eye render IS the game's backbuffer, so the game's
+// resolution is the VR resolution, and a headset eye is roughly square while a
+// 16:9 render leaves unfilled bands top and bottom. BS1 learned over sessions
+// 27-28 that those bands are an ASPECT problem and that raising FOV compensates
+// on the wrong axis: match the render aspect to the eye and a sane FOV fills it
+// exactly. That is why this lane exists before any FOV or viewmodel tuning on
+// BS2 - trims tuned at the wrong aspect bake the error in and stop being
+// portable across resolutions.
+//
+// WHY NOT A LIVE RESOLUTION CHANGE. BS2 has no engine `Exec` seam at all (b1r
+// has console_exec.cpp; b2r has nothing), so the live `SETRES` question cannot
+// even be ASKED without first deriving one - and BS1's answer, measured, is
+// that its viewport-Exec SETRES faults with a near-null dereference and no
+// ResizeBuffers follows. Deferred deliberately, not overlooked. If it is ever
+// wanted, the BS2-native route is the ProcessEvent-by-name seam reaching
+// PlayerController.ConsoleCommand (an FString param block: ptr/count/max),
+// NOT a port of BS1's faulting viewport Exec. A change here therefore takes
+// effect on the NEXT launch.
+//
+// SAFETY - AND BS2 IS WORSE THAN BS1 HERE. FIVE sections of Bioshock2SP.ini
+// carry identical viewport key names: the PC driver plus the Xbox 360, PS3,
+// Xbox One and PS4 ones (verified at lines 470/509/541/573/605). BS1 has four
+// (no PS3). A naive key replacement finds the Xenon section and appears to
+// succeed, so every write is section-scoped. Shared.ini has one section and is
+// scoped the same way for the same reason. Both files are ANSI with CRLF
+// endings and are edited in place, preserving every other byte.
+
+#include <cstdint>
+
+namespace bvr::b2r::game_ini {
+
+// Full path to the located Shared.ini (the file that governs), or an empty
+// string. Cached after the first call; the search is logged once.
+const wchar_t* path();
+
+struct Viewport {
+    // The GOVERNING pair, from Shared.ini [SharedOptions].
+    uint32_t w = 0, h = 0;
+    // Bioshock2SP.ini [WinDrv.WindowsClient], reported only. Ignored by the
+    // engine on this game; kept in sync so a config regeneration cannot revert
+    // the resolution behind the user's back.
+    uint32_t windowedW = 0, windowedH = 0;
+    uint32_t fullscreenW = 0, fullscreenH = 0;
+    bool startupFullscreen = false;
+    bool valid = false; // true when the governing pair was read
+};
+
+Viewport read_viewport();
+
+// Set the render resolution to w x h. Writes Shared.ini's ViewportX/Y (the
+// authoritative pair, verified by read-back) and then keeps Bioshock2SP.ini's
+// windowed AND fullscreen pairs in sync (best effort, non-fatal - the engine
+// does not read them). MenuViewportX/Y is deliberately left alone: it is the
+// pre-game menu surface, not the render target.
+//
+// Each file is backed up once to <name>.bvr-bak-res before its first edit.
+// Returns false and logs on any failure; never leaves a partially written
+// file. Game thread, on explicit request only. Takes effect on the NEXT
+// launch - see the header note on why there is no live path.
+bool write_viewport(uint32_t w, uint32_t h);
+
+// One log line: both files' geometry and whether the governing pair agrees
+// with the live backbuffer. A disagreement after a relaunch is the signal that
+// something else is winning - which is precisely how the WinDrv keys were
+// caught doing nothing.
+void log_status(uint32_t liveBackbufferW, uint32_t liveBackbufferH);
+
+} // namespace bvr::b2r::game_ini

--- a/src/game/bioshock2r/patterns.h
+++ b/src/game/bioshock2r/patterns.h
@@ -126,6 +126,27 @@ constexpr uint32_t kCamActorRotOffset = 0x1F8; // 3 int32 rotator units
 // counted, so doubling can never run inside a loader.
 constexpr uint32_t kSceneBuildGameplayRetRva = 0xCD5D7B;
 
+// Float index of the screen-ray helper inside the scene VS cb0 (session 32).
+// BS1's is 12; this is BS2's OWN, derived fresh - the never-copy rule covers cb
+// layouts exactly as it covers addresses. Same SHAPE as BS1's
+// (2tanH, 0, -tanH, 0, 0, -2tanV, tanV), four floats later.
+//
+// DERIVATION: `dumpframe full` in gameplay at 1920x1080, then
+// `tools/decode-framedump.ps1 -ScanLayout`, which validates the structural
+// signature (the three zero slots plus both pair checks) at every offset of
+// every captured block. It matched at exactly ONE offset - 16 - across 249
+// blocks, yielding tanH=1.1918 (= tan(50), the option-100 horizontal) for the
+// world cluster. The same scan over a BS1 dump finds only offset 12, so the
+// test is specific, not loose. Cross-checked live: the core watch's
+// self-correcting hunt independently reported "ray block decodes at float 16".
+//
+// CAVEAT worth keeping: this validates at 16:9. At a 2048x2048 backbuffer BS2
+// letterboxes the scene into 2048x1421 and the block's two vertical encodings
+// stop agreeing (-f[21]/2 = 0.9662 vs f[22] = 0.6704), so the structural check
+// REJECTS it there. That is the engine's projection degenerating off 16:9, not
+// a wrong offset - see ENGINE_NOTES "BS2 does not render non-16:9 cleanly".
+constexpr int kRayBlockCb0FloatIndex = 16;
+
 // Render-thread sync pair (banked for the 1t fallback, unconsumed): the
 // endframe fn 0x501EA0 triggers FEventWin global [0x1A69294] once per
 // present (kick2 site 0x5029BA) and reads its sibling [0x1A69298]; static

--- a/tools/decode-framedump.ps1
+++ b/tools/decode-framedump.ps1
@@ -14,10 +14,26 @@
 # per-section fg-bake RVAs (0x3DBF7C / 0x3EDCBF) in their callstack, which is
 # lens-independent (ENGINE_NOTES "Foreground scene FOV").
 #
+# THE LAYOUT IS PER-GAME (session 32). Floats 12..18 is a BS1 fact. BS2 decodes
+# ZERO blocks with it, so the offset is a parameter (-RayOffset) and there are
+# two instruments for deriving a new game's:
+#
+#   -ScanLayout   brute-force every offset in every captured block, validate the
+#                 structural signature at each, and print a histogram of the
+#                 offsets that pass with the tangents they yield. Finds a
+#                 same-shape-different-offset layout in one run.
+#   -Diff <other> compare two dumps taken at DIFFERENT FOV options and report
+#                 which float indices moved, with the ratio. The projection
+#                 terms are the ones whose ratio matches tan(fovA/2)/tan(fovB/2)
+#                 or its reciprocal. Assumes NOTHING about layout, so this is
+#                 the instrument to use when -ScanLayout comes back empty.
+#
 # Usage:
 #   .\decode-framedump.ps1 -Path "$env:LOCALAPPDATA\BioshockVR\framedump_*_q*.txt"
 #   .\decode-framedump.ps1 -Path <file> -SubmittedTanH 1.19175 -SubmittedTanV 0.67036
-#   .\decode-framedump.ps1 -Path <file> -OptionFov 100
+#   .\decode-framedump.ps1 -Path <file> -OptionFov 100 -Aspect 2048x2048
+#   .\decode-framedump.ps1 -Path <bs2 dump> -ScanLayout
+#   .\decode-framedump.ps1 -Path <dump @ fov 90> -Diff <dump @ fov 130> -DiffFovs 90,130
 #   -ShowDraws N   lists the first N depth-tested draws per cluster (rig hunting)
 #   -Tolerance     gate tolerance on |tangent - reference| (default 0.0002,
 #                  the dump prints cb0 at %.4f)
@@ -27,12 +43,29 @@ param(
     [double]$SubmittedTanV = 0,
     [int]$OptionFov = 0,
     [int]$ShowDraws = 0,
-    [double]$Tolerance = 0.0002
+    [double]$Tolerance = 0.0002,
+    # Float index of the screen-ray helper block. 12 = BS1 (measured session 21).
+    [int]$RayOffset = 12,
+    # Backbuffer the dump was taken at, e.g. "2048x2048". The -OptionFov
+    # expectation is aspect-dependent and assuming 16:9 is exactly the trap that
+    # cost BS1 two sessions - given this, both candidate laws are printed.
+    [string]$Aspect = "",
+    # Per-game fg-bake RVAs whose presence in a callstack marks a foreground
+    # draw, lens-independently. BS1's two by default; pass @() for another game.
+    [string[]]$FgBakeRvas = @('3DBF7C', '3EDCBF'),
+    [switch]$ScanLayout,
+    [string]$Diff = "",
+    [double[]]$DiffFovs = @()
 )
 
 $ErrorActionPreference = 'Stop'
 $inv = [System.Globalization.CultureInfo]::InvariantCulture
-$fgBakeRvas = @('3DBF7C', '3EDCBF')
+$fgBakeRvas = $FgBakeRvas
+
+$aspectW = 0.0; $aspectH = 0.0
+if ($Aspect -match '^(\d+)\s*[xX]\s*(\d+)$') {
+    $aspectW = [double]$Matches[1]; $aspectH = [double]$Matches[2]
+}
 
 # cb0 contents are raw buffer bytes reinterpreted as floats - garbage prints
 # as nan/1.#IND and must not kill the parse. Unparseable -> NaN.
@@ -49,11 +82,10 @@ if ($files.Count -eq 0) { throw "no dump files match: $Path" }
 $eventRe = [regex]'^(\d{5}) (\S+)\s+a=(\d+)\s+b=(\d+)\s+rtv0=T(-?\d+)\s+dsv=T(-?\d+)\s+vp=(\d+)x(\d+) cb=(\d+)/(\d+)/(\d+) srv0=T(-?\d+)\s+ret=0x([0-9A-Fa-f]+) stk=(\S*)'
 $drawKinds = @('DrawIndexed', 'Draw', 'DrawIdxInst', 'DrawInst', 'DrawIndexedInstanced', 'DrawInstanced')
 
-foreach ($file in $files) {
-    Write-Output ""
-    Write-Output "== $($file.Name) =="
-
-    # ---- parse ----------------------------------------------------------
+# Parse one dump into events + captured cb0 blocks, with each event attributed
+# to its governing block (a block is written whenever the VS b0 buffer OBJECT
+# changes, so "most recent block at or before the draw" is exact).
+function Parse-Dump($file) {
     $events = New-Object System.Collections.Generic.List[object]
     $blocks = New-Object System.Collections.Generic.List[object]  # each: @{ev=<event idx in list>; f=double[]}
     $curBlock = $null
@@ -91,24 +123,134 @@ foreach ($file in $files) {
         if ($null -ne $curBlock) { $blocks.Add($curBlock) }
     } finally { $reader.Close() }
 
-    # attribute: governing block = most recent captured block at or before the event
     $bi = 0
     for ($ei = 0; $ei -lt $events.Count; $ei++) {
         while ($bi + 1 -lt $blocks.Count -and $blocks[$bi + 1].ev -le $ei) { $bi++ }
         if ($blocks.Count -gt 0 -and $blocks[$bi].ev -le $ei) { $events[$ei].blk = $bi }
     }
+    return @{ events = $events; blocks = $blocks }
+}
 
-    # ---- tangents per block ----------------------------------------------
-    # screen-ray helper at floats 12..18: (2tanH, 0, -tanH, 0, 0, -2tanV, tanV)
+# The screen-ray helper at floats o..o+6: (2tanH, 0, -tanH, 0, 0, -2tanV, tanV).
+# The three ZERO slots (o+1, o+3, o+4) are the whole axis-disambiguation - the
+# two pair checks are intra-axis and carry no information about which axis is
+# which. Returns @(tanH, tanV) or $null.
+function Decode-RayBlock($f, [int]$o) {
+    if ($f.Count -lt ($o + 7)) { return $null }
+    $tanH1 = $f[$o] / 2.0; $tanH2 = -$f[$o + 2]
+    $tanV1 = -$f[$o + 5] / 2.0; $tanV2 = $f[$o + 6]
+    $okH = ([math]::Abs($f[$o + 1]) -lt 0.001) -and ([math]::Abs($tanH1 - $tanH2) -lt 0.001) -and ($tanH1 -gt 0.05) -and ($tanH1 -lt 4.0)
+    $okV = ([math]::Abs($f[$o + 3]) -lt 0.001) -and ([math]::Abs($f[$o + 4]) -lt 0.001) -and ([math]::Abs($tanV1 - $tanV2) -lt 0.001) -and ($tanV1 -gt 0.05) -and ($tanV1 -lt 4.0)
+    if ($okH -and $okV) { return @([math]::Round($tanH1, 4), [math]::Round($tanV1, 4)) }
+    return $null
+}
+
+# Modal (most common) value at each float index across all captured blocks -
+# the per-file summary the -Diff instrument compares. Values are already printed
+# at %.4f in the dump, so exact string equality is the right bucketing.
+function Block-Modes($blocks, [int]$n) {
+    $modes = @{}
+    for ($i = 0; $i -lt $n; $i++) {
+        $counts = @{}
+        foreach ($b in $blocks) {
+            if ($b.f.Count -le $i) { continue }
+            $v = $b.f[$i]
+            if ([double]::IsNaN($v)) { continue }
+            $k = '{0:F4}' -f $v
+            if (-not $counts.ContainsKey($k)) { $counts[$k] = 0 }
+            $counts[$k]++
+        }
+        if ($counts.Count -eq 0) { continue }
+        $best = ($counts.Keys | Sort-Object { - $counts[$_] } | Select-Object -First 1)
+        $modes[$i] = @{ v = [double]::Parse($best, $inv); n = $counts[$best]; distinct = $counts.Count }
+    }
+    return $modes
+}
+
+# ---- -Diff: derive the layout with no layout assumption at all -------------
+if ($Diff) {
+    $fileA = @(Get-Item -Path $Path[0])[0]
+    $fileB = @(Get-Item -Path $Diff)[0]
+    Write-Output ""
+    Write-Output "== DIFF: $($fileA.Name)  vs  $($fileB.Name) =="
+    $a = Parse-Dump $fileA
+    $b = Parse-Dump $fileB
+    Write-Output ("A: {0} blocks, B: {1} blocks" -f $a.blocks.Count, $b.blocks.Count)
+    $ma = Block-Modes $a.blocks 336
+    $mb = Block-Modes $b.blocks 336
+    $expect = @()
+    if ($DiffFovs.Count -eq 2) {
+        $r = [math]::Tan($DiffFovs[0] * [math]::PI / 360.0) / [math]::Tan($DiffFovs[1] * [math]::PI / 360.0)
+        $expect = @(@{ name = 'tan ratio'; v = $r }, @{ name = '1/tan ratio'; v = 1.0 / $r },
+                    @{ name = '2x tan ratio'; v = 2.0 * $r })
+        Write-Output ("FOV {0} vs {1}: tan(a/2)/tan(b/2) = {2:F6} (reciprocal {3:F6})" -f `
+            $DiffFovs[0], $DiffFovs[1], $r, (1.0 / $r))
+    }
+    Write-Output "float indices whose modal value MOVED between the two dumps:"
+    $moved = 0
+    for ($i = 0; $i -lt 336; $i++) {
+        if (-not $ma.ContainsKey($i) -or -not $mb.ContainsKey($i)) { continue }
+        $va = $ma[$i].v; $vb = $mb[$i].v
+        if ([math]::Abs($va - $vb) -le 0.0005) { continue }
+        $moved++
+        $ratio = if ([math]::Abs($vb) -gt 1e-9) { $va / $vb } else { [double]::NaN }
+        $tag = ''
+        foreach ($e in $expect) {
+            if (-not [double]::IsNaN($ratio) -and [math]::Abs($ratio - $e.v) -lt 0.002) {
+                $tag = "  <== $($e.name) - PROJECTION TERM"
+            }
+        }
+        Write-Output ("  f[{0,3}]  A={1,12:F4}  B={2,12:F4}  A/B={3,10:F4}{4}" -f $i, $va, $vb, $ratio, $tag)
+    }
+    Write-Output "$moved indices moved. A contiguous run of flagged indices IS the ray block; its first index is -RayOffset."
+    return
+}
+
+foreach ($file in $files) {
+    Write-Output ""
+    Write-Output "== $($file.Name) =="
+
+    $parsed = Parse-Dump $file
+    $events = $parsed.events
+    $blocks = $parsed.blocks
+
+    # ---- -ScanLayout: which offsets carry a valid ray block? ---------------
+    if ($ScanLayout) {
+        $hits = @{}
+        foreach ($b in $blocks) {
+            $maxOff = $b.f.Count - 7
+            for ($o = 0; $o -lt $maxOff; $o++) {
+                $t = Decode-RayBlock $b.f $o
+                if ($null -eq $t) { continue }
+                $k = '{0}|{1:F4}|{2:F4}' -f $o, $t[0], $t[1]
+                if (-not $hits.ContainsKey($k)) { $hits[$k] = 0 }
+                $hits[$k]++
+            }
+        }
+        if ($hits.Count -eq 0) {
+            Write-Output ("SCAN: no offset in any of the $($blocks.Count) captured blocks carries " +
+                          "the (2tanH,0,-tanH,0,0,-2tanV,tanV) signature. This game's layout is a " +
+                          "DIFFERENT SHAPE, not just a different offset - use -Diff.")
+        } else {
+            Write-Output "SCAN: offsets carrying a valid ray block (offset | tanH | tanV | blocks):"
+            foreach ($k in ($hits.Keys | Sort-Object { - $hits[$_] })) {
+                $p = $k -split '\|'
+                Write-Output ("  offset {0,3}  tanH={1,8}  tanV={2,8}  blocks={3}" -f $p[0], $p[1], $p[2], $hits[$k])
+            }
+            Write-Output "The offset with the most blocks is the candidate for -RayOffset / the per-game constant."
+        }
+    }
+
+    # ---- tangents per block ------------------------------------------------
     $blockTan = @{}
     for ($i = 0; $i -lt $blocks.Count; $i++) {
-        $f = $blocks[$i].f
-        if ($f.Count -lt 19) { continue }
-        $tanH1 = $f[12] / 2.0; $tanH2 = -$f[14]
-        $tanV1 = -$f[17] / 2.0; $tanV2 = $f[18]
-        $okH = ([math]::Abs($f[13]) -lt 0.001) -and ([math]::Abs($tanH1 - $tanH2) -lt 0.001) -and ($tanH1 -gt 0.05) -and ($tanH1 -lt 4.0)
-        $okV = ([math]::Abs($f[15]) -lt 0.001) -and ([math]::Abs($f[16]) -lt 0.001) -and ([math]::Abs($tanV1 - $tanV2) -lt 0.001) -and ($tanV1 -gt 0.05) -and ($tanV1 -lt 4.0)
-        if ($okH -and $okV) { $blockTan[$i] = @([math]::Round($tanH1, 4), [math]::Round($tanV1, 4)) }
+        $t = Decode-RayBlock $blocks[$i].f $RayOffset
+        if ($null -ne $t) { $blockTan[$i] = $t }
+    }
+    if ($blockTan.Count -eq 0 -and $blocks.Count -gt 0) {
+        Write-Output ("NO blocks decoded at -RayOffset $RayOffset (this default is a BioShock 1 " +
+                      "fact). Re-run with -ScanLayout; if that is also empty, use -Diff against a " +
+                      "dump taken at another FOV option.")
     }
 
     # ---- cluster depth-tested draws ---------------------------------------
@@ -148,8 +290,11 @@ foreach ($file in $files) {
         $c = $clusters[$key]
         $tierStr = ($c.tiers.Keys | Sort-Object | ForEach-Object { '{0}:{1}' -f $_, $c.tiers[$_] }) -join ' '
         $hfov = 2.0 * [math]::Atan($c.tanH) * 180.0 / [math]::PI
-        Write-Output ("cluster tanH={0:F4} tanV={1:F4} (hfov {2:F1} deg @16:9)  draws={3} blocks={4} fgBakeStacks={5}  b0tiers[{6}]" -f `
-            $c.tanH, $c.tanV, $hfov, $c.draws, $c.blocks.Count, $c.fgBake, $tierStr)
+        # hfov/vfov are 2*atan of the half-tangents, so they are the rendered
+        # angles at ANY aspect - the old "@16:9" label on this line was wrong.
+        $vfov = 2.0 * [math]::Atan($c.tanV) * 180.0 / [math]::PI
+        Write-Output ("cluster tanH={0:F4} tanV={1:F4} (rendered {2:F1}x{3:F1} deg)  draws={4} blocks={5} fgBakeStacks={6}  b0tiers[{7}]" -f `
+            $c.tanH, $c.tanV, $hfov, $vfov, $c.draws, $c.blocks.Count, $c.fgBake, $tierStr)
         if ($ShowDraws -gt 0) {
             $c.sample | Select-Object -First $ShowDraws | ForEach-Object {
                 $stkHead = ($_.stk -split ',' | Select-Object -First 4) -join ','
@@ -165,12 +310,28 @@ foreach ($file in $files) {
                 $SubmittedTanH, $SubmittedTanV, $dh, $dv, $verdict)
         }
         if ($OptionFov -gt 0) {
-            $oH = [math]::Tan($OptionFov * [math]::PI / 360.0); $oV = $oH * 9.0 / 16.0
-            $dh = [math]::Abs($c.tanH - $oH); $dv = [math]::Abs($c.tanV - $oV)
-            $verdict = 'FAIL'
-            if ($dh -le $Tolerance -and $dv -le $Tolerance) { $verdict = 'PASS' }
-            Write-Output ("    vs OPTION {0} tanH={1:F5} tanV={2:F5}: dH={3:F5} dV={4:F5} -> {5}" -f `
-                $OptionFov, $oH, $oV, $dh, $dv, $verdict)
+            # The option-derived expectation is ASPECT-DEPENDENT and the two
+            # candidate laws coincide exactly at 16:9 - which is why a single
+            # aspect cannot tell them apart, and why assuming 9/16 here was
+            # wrong at every aspect but one. Both laws are printed; the one that
+            # PASSes at TWO different aspects is the game's.
+            $tanOpt = [math]::Tan($OptionFov * [math]::PI / 360.0)
+            $ar = if ($aspectW -gt 0 -and $aspectH -gt 0) { $aspectH / $aspectW } else { 9.0 / 16.0 }
+            $note = if ($aspectW -gt 0) { "aspect $Aspect (h/w $('{0:F4}' -f $ar))" }
+                    else { "NO -Aspect GIVEN, assuming 16:9 - pass -Aspect WxH" }
+            # Law A - the option is a TRUE horizontal, vertical follows the window.
+            $aH = $tanOpt; $aV = $tanOpt * $ar
+            # Law B - the option is a 16:9-REFERENCED horizontal, so what the
+            # engine really fixes is the VERTICAL and the horizontal follows.
+            $bV = $tanOpt * 9.0 / 16.0; $bH = $bV / $ar
+            foreach ($law in @(@{ n = 'A true-horizontal'; h = $aH; v = $aV },
+                               @{ n = 'B 16:9-referenced'; h = $bH; v = $bV })) {
+                $dh = [math]::Abs($c.tanH - $law.h); $dv = [math]::Abs($c.tanV - $law.v)
+                $verdict = 'FAIL'
+                if ($dh -le $Tolerance -and $dv -le $Tolerance) { $verdict = 'PASS' }
+                Write-Output ("    vs OPTION {0} law {1}: tanH={2:F5} tanV={3:F5} dH={4:F5} dV={5:F5} -> {6}  [{7}]" -f `
+                    $OptionFov, $law.n, $law.h, $law.v, $dh, $dv, $verdict, $note)
+            }
         }
     }
 }


### PR DESCRIPTION
All BS2. Steps 0-2 of the session brief; steps 3-4 re-scoped in STATUS by what was measured.

## Three BS1 assumptions died, each caught by an acceptance test

**1. The ini file.** BS1's whole lane writes `[WinDrv.WindowsClient]`'s viewport keys. BS2 has those keys, in a file with the same section name, and ignores them - `Shared.ini [SharedOptions] ViewportX/Y` governs. Proven by changing one variable at a time over three relaunches.

The port wrote its keys, re-read them, logged `verified`, and the engine rendered 1920x1080 anyway. **A verified write is not an honoured one** - now a standing rule in the decision log next to the `-> HANDLED` lesson.

**2. The square-backbuffer policy - this one changes the plan.** BS1's biggest banked conclusion does not transfer. At 2048x2048 BS2 renders the scene into a **2048x1421 viewport** with a black band across the bottom ~30%, collapses the world horizontal from **100 to 67.7 deg**, and produces a ray block whose two vertical encodings disagree. 16:9 is the only aspect proven to render correctly, so on BS2 the resolution lane is a sharpness lever, not an aspect-matching one.

**3. The cb0 layout.** BS2's ray block is at float 16, not BS1's 12 - and core was only *copying* 80 bytes, so no offset could have rescued it.

## The lens verdict

Unlike BS1's aspect-gated split (two conventions coinciding at 16:9), BS2's lenses differ **at 16:9**:

| cluster | option 100 | option 130 | blocks | callstack |
|---|---|---|---|---|
| world | tanH 1.1918 (100.0 deg) | 2.1445 | 229 | `...AEC7B4...` |
| second | **0.5774** (60.0 deg) | **0.5774 unchanged** | 19 | `...AECACF...` |

`0.5774 = tan(30)`, and it ignores the FOV option. One claim cannot serve two lenses, so that is **2.06x angular gain at option 100, 3.99x at 130** - present at the aspect the user tested, which fits their "wrong depth / moves with the head" report where BS1's mechanism could not.

**Not yet proven to be the viewmodel.** Evidence is circumstantial; the holster test is queued, and it must be the identification rather than draw counts (BS1's rule).

The world FOV law is deliberately left **partially derived**: the two candidate laws coincide at 16:9 and BS2 offers no clean second aspect yet. The decoder reports both as PASS - the honest answer.

## Also in here

- **Frozen engine pitch fixed** (`publish_pitch_error`) - BS1's wrench bug in shared code, and BS2 has a drill. Sign check still owed in-headset.
- **`vrinput` dispatched on BS2 for the first time** - the synthetic gamepad, `pitchservo` and core's whole swing-gesture flat suite were unreachable. A class of bug worth auditing.
- **`decode-framedump.ps1`**: `-RayOffset`, `-Aspect`, `-FgBakeRvas`, `-ScanLayout`, `-Diff`. `-Diff` assumes nothing about layout and is what cracked BS2 after `-ScanLayout` came back empty on a square dump - itself a false lead caused by the degeneracy above.

## Verification

- `vrres 2048x2048` -> relaunch -> `first Present: backbuffer 2048x2048`; both configs backed up; diffs show only the intended keys with all four decoy sections byte-unchanged.
- Clean quit (`WM_CLOSE`) does not clobber the write - answers a question BS1 left open (menu-quit path only).
- **BS1 no-regression: `WORLD tanH=1.191754 tanV=1.191754` at 2048x2048**, bit-identical to the banked session-28 value, offset hunt never fired.
