### PR TITLE
docs: close the BS2 viewmodel diagnosis, retract session 25's fg claim

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -739,8 +739,15 @@ kill. Both prerequisites below are now MET.):**
 - [ ] **BS2 aspect bisection** - find the squarest aspect BS2 renders full-height with a consistent
       frustum. That is BS2's best VR configuration AND the clean second aspect needed to settle its
       world FOV law (the two candidate laws coincide at 16:9).
-- [ ] **Identify BS2's 60-deg lens** by making it MOVE (holster/switch weapon, re-dump), never by
-      draw counts. Decides whether the viewmodel fix is a lens match or something else entirely.
+- [x] **Identify BS2's 60-deg lens** - DONE session 32 by two in-headset FOV A/Bs rather than a
+      dump: the defect worsens at option 130 and VANISHES at option 60, exactly as
+      `k = tan(option/2)/tan(30)` predicts. It is the viewmodel. Session 25's "foreground follows
+      the world FOV natively" is retracted; BS2 has a fixed fg lens like BS1.
+- [ ] **BS2 viewmodel lens match (USER PRIORITY 2)** - find BS2's foreground FOV field and write
+      the world's value into it, so the world stays wide AND the weapon is correct. Leads: the fg
+      callstack frame `0xAECACF` (vs the world's `0xAEC7B4`), the round 60.0 value, b2r's existing
+      memscan set, and a native BS2 route checked first. Acceptance: `lenses=1` at 16:9 and a
+      stable weapon at option 100+.
 - [ ] **BS2 pitch-servo sign check in-headset** - the one thing flat cannot answer about the
       session-32 fix.
 - [ ] **BS2 swing-to-attack** - one `swing::publish_gate` line plus the melee-equipped predicate

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -972,11 +972,16 @@ Predicted: the angular-gain error is `k = tan(option/2) / tan(30)`, so 2.06x at 
 This is much stronger evidence than the callstack/draw-count circumstantials, and it converts the
 lens split from "leading hypothesis" to the working diagnosis.
 
-**The clincher still to run, and it is free:** the same arithmetic predicts the error VANISHES at
-option **60**, where `k = tan(30)/tan(30) = 1.0` and the world lens exactly equals the fixed
-60-deg lens. So `gfov 60` should make the viewmodel look CORRECT (in a uselessly narrow view - it
-is a diagnostic, not a shipping config). If it does, the diagnosis is airtight and the fix is
-unambiguous. If it does not, something else is also in play and the fix must not be built yet.
+**THE CLINCHER PASSED.** The same arithmetic predicted the error VANISHES at option 60, where
+`k = tan(30)/tan(30) = 1.0` and the world lens exactly equals the fixed 60-deg lens. User, same
+session: **"gfov 60 test done, the weapon looks correct now and doesn't move."**
+
+Two predictions, at two different input values, both confirmed. **The diagnosis is closed.** A pass
+that were not the viewmodel could not make the VIEWMODEL correct at exactly the option matching its
+own tangent - so this also identifies the cluster, and the queued holster test is RETIRED as
+unnecessary. It further retracts session 25's "BS2's foreground follows the world FOV natively"
+(see the retraction in ENGINE_NOTES near line 126) - **BS2 does have a fixed foreground lens, just
+like BS1.** The defect class ports; that does not license porting BS1's specific machinery.
 
 **Immediate zero-code mitigation for the user:** keep the FOV option LOW (100 or below, and note
 `gfov` defaults to 130 when enabled - leave it off). Lower option = smaller `k` = less viewmodel
@@ -1004,17 +1009,36 @@ configuration**, and it doubles as the clean second aspect that settles the worl
 4 above). `[Engine.RenderConfig] HorizontalFOVLock=True` is an unexamined suspect for the
 mechanism.
 
-**B. Prove what the 60-deg lens IS (one dump).** It is the leading explanation for the viewmodel
-report but it is NOT confirmed to be the viewmodel. Identify it by making it MOVE, never by draw
-counts (BS1's rule, learned the hard way): holster or switch weapon, re-dump at 16:9, and see
-whether the 19-block `...AECACF...` cluster disappears or changes. If it IS the viewmodel, BS1's
-conclusion applies - MATCH the lenses, because one claim cannot serve two - and the fix is a BS2
-fg-lens write, which is underived. If it is NOT, the viewmodel cause is still open and the two
-zero-code in-headset A/Bs (sweep IPD ~20 vs ~120 mm, sweep world scale) are the next instrument.
+**B. ~~Prove what the 60-deg lens IS~~ - DONE, retired.** The two in-headset FOV A/Bs identified it
+conclusively (see 0b). It is the viewmodel. No dump needed.
 
-Note this must be reconciled with session 25, which measured BS2's foreground following the world
-FOV natively in mono. Both can be true if the drill rides the world lens and the 60-deg cluster is
-some other pass. The holster test distinguishes them.
+**B'. THE FIX: find BS2's foreground lens FOV and write the world's value into it.** This is now
+priority 2 on the user's list and the diagnosis is closed, so it is the main event.
+
+- **Direction: raise the fg lens to the world, do NOT drop the world to 60.** Matching at 60 works
+  (proven) but a 60-deg world is unusable in VR. Matching at the world's value gives a wide world
+  AND a correct viewmodel - the only state where both are right, because one projection layer
+  carries one fov claim.
+- **The field is UNDERIVED.** Leads, cheapest first:
+  1. The value is exactly `tan(30)`, i.e. **60.0 degrees** - a round number, so likely a stored
+     property or a class default rather than a computed one.
+  2. **The fg draw callstacks are already captured**: `0xBE9E68,0xAECACF,0x646054` and
+     `0xBE9E68,0xAECACF,0x6926FD` (session-32 dumps, 16:9). `0xAECACF` is the fg-specific frame -
+     the world pass goes through `0xAEC7B4` instead. Disassemble around these offline (capstone is
+     installed) to find where 60 enters the cb build. This is the highest-value lead and needs no
+     game.
+  3. b2r already has the full discovery command set (`memscan`/`memscani`/`mempoke`/`fsweep`/
+     `hexdump`/`pokeaddr`) - scan for the float `60.0` or `0.57735` and poke, watching the
+     viewmodel. Expect many candidates; use the option sweep as the discriminator (the right one
+     does NOT change when the option does).
+  4. Check for a NATIVE route first, per the standing policy: BS2 has an exposed FOV concept BS1
+     lacked, so a viewmodel/weapon FOV property may exist in `BakedScripts` or be reachable
+     through the ProcessEvent-by-name seam. Look before porting BS1's fg-bake machinery.
+- **Acceptance:** `fovaudit` reports `lenses=1` in gameplay at 16:9 (the two clusters collapse),
+  and in-headset the weapon is stable at option 100+ rather than only at 60.
+- **Interim guidance for the user until it lands:** keep the FOV option LOW. The error is
+  `k = tan(option/2)/tan(30)`, so lower is better; 60 is perfect but narrow. There is likely a
+  tolerable middle (try 75-85) trading a little world width for a much steadier weapon.
 
 **C. In-headset: the pitch servo's sign (30 s, owed).** Checklist in `docs/bioshock2/TESTING.md`.
 `enginePitch=` in the heartbeat must MOVE while looking up and down; `vrinput pitchservo invert` if

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -947,7 +947,49 @@ in case long soaks ever disprove this.
 
 ## Next steps
 
-### 0. SESSION 33 OPENER (BS2) - written with the verdicts that shape it
+### 0a. THE USER'S PRIORITY ORDER (directive, 2026-07-31, session 32 - supersedes ROADMAP ordering)
+
+Verbatim intent: **core experience first, nice-to-haves last.** Swing-to-attack is explicitly
+"a far away thing, it's a nice to have" - it drops to the bottom of the queue on BOTH games.
+
+1. **Custom resolution** (BS2 lane ships; the aspect bisection is what is left)
+2. **Correct scale, and the viewmodel not moving with the headset**
+3. **Motion controls**: weapons, movement, and aim being right
+4. **Normal controls**: weapon and plasmid switching
+5. **HUD, effects, cinematics and menu elements**
+6. Everything else core to the experience
+7. ...then nice-to-haves (swing-to-attack lives here)
+
+### 0b. ITEM 2 IS DIAGNOSED AND CONFIRMED IN-HEADSET (2026-07-31)
+
+The two-lens magnitude mismatch (Current state 3) is **confirmed as the cause of the viewmodel
+defect by an in-headset A/B that tested a QUANTITATIVE prediction**, not just a direction.
+
+Predicted: the angular-gain error is `k = tan(option/2) / tan(30)`, so 2.06x at option 100 and
+3.99x at option 130. Predicted consequence: the defect should get markedly worse at 130.
+**User's verdict: "I just did the test and it very clearly got a lot worse at 130 FOV."**
+
+This is much stronger evidence than the callstack/draw-count circumstantials, and it converts the
+lens split from "leading hypothesis" to the working diagnosis.
+
+**The clincher still to run, and it is free:** the same arithmetic predicts the error VANISHES at
+option **60**, where `k = tan(30)/tan(30) = 1.0` and the world lens exactly equals the fixed
+60-deg lens. So `gfov 60` should make the viewmodel look CORRECT (in a uselessly narrow view - it
+is a diagnostic, not a shipping config). If it does, the diagnosis is airtight and the fix is
+unambiguous. If it does not, something else is also in play and the fix must not be built yet.
+
+**Immediate zero-code mitigation for the user:** keep the FOV option LOW (100 or below, and note
+`gfov` defaults to 130 when enabled - leave it off). Lower option = smaller `k` = less viewmodel
+error, until the real fix lands.
+
+**The real fix, once the clincher passes:** make the two lenses MATCH, because one projection layer
+carries one fov claim and only matched lenses make both world and viewmodel right (BS1's session-28
+conclusion, and the one piece of BS1 reasoning that DOES transfer - the mechanism differs, the
+consequence is identical). Direction: raise the 60-deg lens to the world's value rather than
+dropping the world to 60. That needs BS2's second-lens FOV field, which is UNDERIVED. Per the
+standing policy, check for a native BS2 route before porting BS1's fg-bake machinery.
+
+### 0c. SESSION 33 OPENER (BS2) - written with the verdicts that shape it
 
 Session 32 answered the lens question and killed the square-backbuffer plan. Steps 3-4 of the
 session-32 brief were NOT reached; they are re-scoped below by what was measured.

--- a/docs/bioshock2/ENGINE_NOTES.md
+++ b/docs/bioshock2/ENGINE_NOTES.md
@@ -125,11 +125,24 @@ change, so a wrong candidate names its own correction from any session log. Obse
   ProcessEvent detour instead.
 - The graphics-options first-boot screen has a native **Field Of View slider (default 100)** -
   BS2 has an exposed FOV concept BS1 lacked. Session 25 confirmed it is the
-  `UShockUserSettings.HorizontalFOV` int (offset below) - and, decisively: **BS2's foreground
-  viewmodel follows the world FOV natively** (poking the option re-lensed the drill WITH the
-  world, screenshot-verified). BS1's entire fg counter-model (fovA/fovB, kFgEyeComp, vrfgfov)
-  exists because BS1's fg rig has a FIXED lens; BS2 does not have that defect, so none of that
-  machinery ports. First applied case of the "BS2 is not bound by BS1's methods" directive.
+  `UShockUserSettings.HorizontalFOV` int (offset below).
+- **RETRACTED 2026-07-31 (session 32): "BS2's foreground viewmodel follows the world FOV
+  natively" is WRONG.** Session 25 read it that way from a mono screenshot A/B (poking the option
+  appeared to re-lens the drill with the world), and it was the stated reason none of BS1's fg
+  machinery was ported. Two independent measurements kill it:
+  - The fg cluster's tangent is **fixed at tan(30) = 0.5774 across option 100 AND 130** while the
+    world lens tracks the option (frame-dump clusters, session 32). A lens that followed the
+    option could not be constant.
+  - In-headset A/B: the viewmodel defect scales exactly as `k = tan(option/2)/tan(30)` - markedly
+    worse at 130 - and at `gfov 60`, where `k` collapses to 1.0, the user reports **"the weapon
+    looks correct now and doesn't move"**.
+
+  What session 25 most likely saw was the WORLD re-lensing around a viewmodel that did not move.
+  **So BS2 DOES have a fixed foreground lens, exactly like BS1** - the defect class ports even
+  though (per the standing policy) none of BS1's specific machinery should be assumed to. This is
+  a useful corrective to the directive, not a contradiction of it: check whether the DEFECT
+  exists before porting the CURE, and a mono screenshot is not a sufficient check for a
+  lens question.
 - Flat 6DOF checks (session 24, log-measured via the final-camera heartbeat): `offset 0 0 50` ->
   z +50.0 exact; `simhead 0 20 0` -> pitch 3640; roll 15 -> 2730; yaw residual integer-exact
   (16450 -> 10989 = -5461 = -30.0 deg); sim position (0.10, 0.20, -0.30) m at worldscale 100 ->
@@ -705,10 +718,23 @@ identify it by making it MOVE, never by draw counts. Since BS2 has no fg-lens le
 run first is: holster or switch the weapon and re-dump, and see whether the 19-block cluster
 disappears or changes. Until that is done, "second lens" is the honest name for it.
 
-Note this does NOT contradict session 25's finding that BS2's foreground follows the world FOV
-natively - that was measured in mono by poking the option and watching the drill re-lens visually.
-Both can be true if the drill viewmodel rides the world lens while some OTHER fixed-60-deg pass is
-what the dump is showing. Resolving that is the same holster test.
+**CLOSED, same day, by the FOV sweep rather than the holster test.** The holster test was never
+needed: the option sweep identifies the cluster more decisively than a dump could, because it
+tests a QUANTITATIVE prediction rather than a correlation.
+
+- Predicted `k = tan(option/2)/tan(30)`: 2.06x at option 100, 3.99x at 130 -> the defect should
+  worsen sharply at 130. User: *"it very clearly got a lot worse at 130 FOV."*
+- Predicted `k = 1.0` at option 60, where the world lens exactly equals the fixed lens -> the
+  defect should VANISH. User: *"gfov 60 test done, the weapon looks correct now and doesn't
+  move."*
+
+A pass that is not the viewmodel cannot make the VIEWMODEL look correct at exactly the option
+where its own tangent is matched. **The 60-deg cluster is the viewmodel**, and session 25's
+"foreground follows the world FOV natively" is retracted (see the retraction near line 126).
+
+Method note worth keeping: two zero-code in-headset A/Bs beat a queued frame-dump investigation
+here, because the model made a numeric prediction at a specific input value. Prefer a falsifiable
+prediction over another capture whenever the arithmetic offers one.
 
 ### 5. BS2's cb0 ray block is at float 16 (BS1's is 12) - same shape, different offset
 

--- a/docs/bioshock2/TESTING.md
+++ b/docs/bioshock2/TESTING.md
@@ -211,3 +211,91 @@ construction.
 5. Drill an enemy while looking DOWN - the BS1 symptom was hits landing on the floor.
 6. Residual: BS1 settles at 4-8 deg because the proportional term falls under the game's own
    deadzone. **BS2's deadzone is its own - measure it, do not assume BS1's number.**
+
+## Test loadouts: getting weapons and plasmids on BS2 (researched session 32, UNTESTED)
+
+**The console is not usable on either game** (user, session 32 - same as BS1 despite
+`-allowconsole` being documented). So the working mechanism is the one BS1 already uses: **bind a
+cheat command to an unbound key in `User.ini`.** Everything below is prepared, not proven - nothing
+here has been run on BS2 yet.
+
+### The mechanism, from BS1's working precedent
+
+BS1's `User.ini.bvr-bak-cheatkeys` diff is the ground truth - these lines are live and working on
+BS1 today:
+
+```
+F7=stat fps
+F11=givebioshockweapons
+F12=testAddAvailablePlasmid ElectricBolt
+```
+
+Format is `<KEY>=<command>`, one per line, in a key-binding section. Press the key in game, the
+command runs. A Steam community post confirms the same approach for both remasters and notes that
+making `User.ini` read-only is NOT necessary.
+
+### THE SECTION TRAP - the same class of bug as the viewport keys
+
+BS2's `User.ini` carries the same key names in **at least seven sections**: `[Default]` (133),
+`[RadialActive]` (477), `[RadialActive_TriggerSwap]` (760),
+`[RadialActive_SouthpawTriggerSwap]` (1044), `[GathererChoice]` (1328), `[RescueVentChoice]`
+(1629), and more. **Binding in the wrong one silently does nothing in normal gameplay** - exactly
+how `Bioshock2SP.ini`'s five viewport sections would have swallowed a resolution write. The
+gameplay binds are the ones in **`[Default]`**.
+
+**Free keys on BS2 today: `F9` and `F12`** (both `F9=` and `F12=` are empty at lines 249 and 253),
+plus `F23`/`F24` at 424-425. Note BS2's layout differs from BS1's: BS2 uses F7/F8 for
+EquipAbility7/8 and puts QuickLoad/QuickSave on F10/F11, so **do not copy BS1's key choices**.
+
+### Command ladder - try in this order, broadest first
+
+Names collected from community sources; **none verified on this install.**
+
+| command | expected effect |
+|---|---|
+| `GiveAll` | all obtainable weapons + 999 of every ammo type |
+| `IGBigBucks` | money (sources disagree: 500 or 600 dollars) |
+| `GiveWeapon Weapons.PlayerDrill` | one weapon; also `PlayerMachineGun`, `PlayerShotgun`, `PlayerSpeargun` |
+| `GiveItem Plasmids.ElectroBoltBasicPlasmid` | one plasmid; `...MasterPlasmid` for level 3 |
+| `GiveItem ShockGame.ActiveGeneticSlotUpgrade` | an extra plasmid slot |
+| `exec fulleverything.debug` | everything: items, research, upgrades (the nuclear option) |
+| `testAddAvailablePlasmid <name>` | BS1's plasmid command - may not exist on BS2, try it anyway |
+
+### VERIFY BY EFFECT, NOT BY THE BIND EXISTING
+
+This session's most expensive lesson applies directly: **a write that reports success proves
+nothing.** A key bind that saves cleanly into `User.ini` is not evidence the command ran, and a
+command name that is wrong for this game will fail exactly as silently as one that is right.
+
+For each command, the acceptance is an observable change:
+
+- weapon appears in the wheel / ammo counter moves -> `game-shot -Game bs2` before and after, and
+  diff the two with `tools/img-diff.ps1`
+- plasmid appears in the radial
+- money changes on the HUD
+
+If the effect cannot be observed, record the command as UNPROVEN. Do not build a test procedure on
+a command that was never seen to do anything.
+
+**Harness gap to close first:** `vrinput test press` composes XInput PAD buttons, not keyboard
+keys, so nothing in the harness can press F9/F12 today. Either ask the user to press the key (they
+are at the machine anyway, and this is a one-off per test session) or add a SendInput keyboard poke
+to the harness. Ask before building the second.
+
+### The authoritative source for item names is LOCAL, not the web
+
+Both link targets that would carry a full item table are unreachable to tooling: the BioShock Wiki
+console-commands page and the Scribd cheat sheet both return HTTP 402. Do not sink more time into
+scraping them.
+
+The real source is the game's own scripts: `BakedScripts/` in the BS2 install, via the existing
+`tools/uscript/` decompile workspace (gitignored - and per the hard rule, **summarise findings
+here, never paste game script into the repo**). That gives exact class names rather than
+community-transcribed ones, which is what the `GiveItem`/`GiveWeapon` paths need.
+
+### Fallback if no command lands: a prepared save
+
+Exactly what BS1 fell back to. Saves are fair game (standing permission) and BS2's live in
+`Documents\BioshockHD\BioShock2\SaveGames`. Make one save with everything unlocked in an open area
+and reuse it as the test fixture - it also removes the per-session save-loading step that currently
+needs a human.


### PR DESCRIPTION
Docs only. Closes the BS2 viewmodel diagnosis and records two user directives.

## The diagnosis is closed, by two confirmed quantitative predictions

The model said the viewmodel's angular-gain error is `k = tan(option/2) / tan(30)`. Tested at two different input values, in-headset:

| option | predicted k | result |
|---|---|---|
| 130 | 3.99x | *"it very clearly got a lot worse at 130 FOV"* |
| 60 | **1.00x** | *"the weapon looks correct now and doesn't move"* |

Two hits at two values. This also **identifies** the cluster - a pass that were not the viewmodel could not make the viewmodel correct at exactly the option matching its own tangent - so the queued holster test is retired unrun.

## Retraction

Session 25's **"BS2's foreground viewmodel follows the world FOV natively"** is wrong and is retracted. It was read off a mono screenshot A/B, and it was the stated reason none of BS1's foreground machinery was ported. The fg tangent is *fixed* at `tan(30)` across options 100 and 130.

BS2 does have a fixed foreground lens, like BS1. The corrective to the standing policy: checking whether the defect exists before porting the cure is right, but the check must be adequate to the question - a mono screenshot cannot answer a lens question. The defect class porting still does not license porting BS1's specific cure.

## Also recorded

- **User priority order** (core experience first; swing-to-attack explicitly a nice-to-have, bottom of the queue on both games).
- **The interlock**: resolution -> world FOV law -> viewmodel -> world scale is one dependency chain. World scale and IPD must not be tuned until the lens fix lands; BS2's worldscale 100 is demoted from "accepted" to "unconfirmed" because session 26 judged it against a wrong viewmodel.
- **Fix direction**: raise the fg lens to the world's value, never drop the world to 60. Implement as a live FOV-degrees equality, never a baked tangent constant - that is the BS1 mistake.
- **Test-loadout plan** for weapons/plasmids: the console works on neither game, so bind commands to unbound keys in `User.ini` `[Default]` (F9/F12 free on BS2; BS2's key layout differs from BS1's). Seven-plus sections carry the same key names. Every command UNPROVEN until an effect is observed.
