### PR TITLE
VR QoL: controller-bound recenter, two anchor/bootstrap fixes, and opt-in hands-off startup

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,6 +77,8 @@ add_library(bioshockvr SHARED
     game/bioshock1r/recorder.h
     game/bioshock1r/scenedraw.cpp
     game/bioshock1r/scenedraw.h
+    game/bioshock1r/startup_dialog.cpp
+    game/bioshock1r/startup_dialog.h
     game/bioshock2r/aim.cpp
     game/bioshock2r/aim.h
     game/bioshock2r/bioshock2r_adapter.cpp

--- a/src/core/input/xinput_bridge.cpp
+++ b/src/core/input/xinput_bridge.cpp
@@ -66,7 +66,11 @@ std::atomic<uint64_t> g_moveYawOffMs{0};
 // Controller-bound recenter (see the header). The bind default is the
 // thumbrest chord; the request latch is raised on the render thread by the XR
 // action layer and drained on the game thread by the adapter.
-std::atomic<RecenterBind> g_recenterBind{RecenterBind::Thumbrest};
+// Default OFF: this arms a NEW controller binding, and whether the mod
+// should claim two more inputs out of the box is the author's call, not
+// this patch's. `vrinput recenterbind thumbrest` (or the overlay combo)
+// opts in, and recenterBind persists with the other preset values.
+std::atomic<RecenterBind> g_recenterBind{RecenterBind::Off};
 std::atomic<bool> g_recenterRequest{false};
 std::atomic<bool> g_recenterArmed{false};
 std::atomic<bool> g_ammolessWeapon{false};

--- a/src/core/input/xinput_bridge.cpp
+++ b/src/core/input/xinput_bridge.cpp
@@ -63,6 +63,15 @@ std::atomic<bool> g_pitchLiftOnBumpers{true};
 std::atomic<float> g_moveYawOffDeg{0.0f};
 std::atomic<uint64_t> g_moveYawOffMs{0};
 
+// Controller-bound recenter (see the header). The bind default is the
+// thumbrest chord; the request latch is raised on the render thread by the XR
+// action layer and drained on the game thread by the adapter.
+std::atomic<RecenterBind> g_recenterBind{RecenterBind::Thumbrest};
+std::atomic<bool> g_recenterRequest{false};
+std::atomic<bool> g_recenterArmed{false};
+std::atomic<bool> g_ammolessWeapon{false};
+std::atomic<uint64_t> g_ammolessWeaponMs{0};
+
 // ---- Session 30: the pitch SERVO, and why zeroing the stick was not enough ---
 //
 // Killing the stick's pitch stops it fighting the HMD, but it also means the
@@ -812,6 +821,41 @@ void set_pad_profile(PadProfile p) {
             was == 0 ? "bioshock1" : "infinite", v == 0 ? "bioshock1" : "infinite");
 }
 
+RecenterBind recenter_bind() {
+    return g_recenterBind.load(std::memory_order_relaxed);
+}
+void set_recenter_bind(RecenterBind m) {
+    g_recenterBind.store(m, std::memory_order_relaxed);
+}
+
+void request_recenter() {
+    g_recenterRequest.store(true, std::memory_order_relaxed);
+}
+bool take_recenter_request() {
+    return g_recenterRequest.exchange(false, std::memory_order_relaxed);
+}
+
+void publish_ammoless_weapon(bool on) {
+    g_ammolessWeapon.store(on, std::memory_order_relaxed);
+    g_ammolessWeaponMs.store(GetTickCount64(), std::memory_order_relaxed);
+}
+bool ammoless_weapon_active() {
+    if (!g_ammolessWeapon.load(std::memory_order_relaxed)) return false;
+    const uint64_t stamp = g_ammolessWeaponMs.load(std::memory_order_relaxed);
+    return stamp != 0 && GetTickCount64() - stamp <= kVrGameplayStaleMs;
+}
+
+void publish_recenter_armed(bool armed) {
+    g_recenterArmed.store(armed, std::memory_order_relaxed);
+}
+bool recenter_armed() { return g_recenterArmed.load(std::memory_order_relaxed); }
+
+bool vr_gameplay_active() {
+    if (!g_vrGameplay.load(std::memory_order_relaxed)) return false;
+    const uint64_t stamp = g_vrGameplayLastMs.load(std::memory_order_relaxed);
+    return stamp != 0 && GetTickCount64() - stamp <= kVrGameplayStaleMs;
+}
+
 float turn_scale() { return g_turnScale.load(std::memory_order_relaxed); }
 void set_turn_scale(float s) {
     if (s < 0.1f) s = 0.1f;
@@ -936,6 +980,19 @@ void handle_command(const char* args) {
                 m == AmmoMod::Click       ? "CLICK (hold right stick click)"
                 : m == AmmoMod::Thumbrest ? "THUMBREST (rest left thumb)"
                                           : "BOTH (either)");
+    } else if (strcmp(verb, "recenterbind") == 0) {
+        if (strncmp(rest, "thumbrest", 9) == 0) set_recenter_bind(RecenterBind::Thumbrest);
+        else if (strncmp(rest, "click", 5) == 0) set_recenter_bind(RecenterBind::Click);
+        else if (strncmp(rest, "off", 3) == 0) set_recenter_bind(RecenterBind::Off);
+        const RecenterBind b = recenter_bind();
+        BVR_LOG("input: recenter bind = %s (vrinput recenterbind thumbrest|click|off) - "
+                "gameplay view only; stands down while the ammo modifier owns the "
+                "right stick click",
+                b == RecenterBind::Thumbrest
+                    ? "THUMBREST (right thumbrest touch + right stick click)"
+                : b == RecenterBind::Click
+                    ? "CLICK (hold right stick click ~1 s)"
+                    : "OFF");
     } else if (strcmp(verb, "swing") == 0) {
         bvr::input::swing::handle_command(rest); // logs its own echoes
     } else if (strcmp(verb, "sticklog") == 0) {
@@ -1065,6 +1122,21 @@ void draw_debug_ui() {
                           "ammo slot.\nThe thumbrest is the pad above the buttons - it is "
                           "the LEFT one,\nbecause your right thumb cannot rest and push the "
                           "right stick at once.");
+
+    // Controller-bound recenter - the one control here a player in a headset
+    // cannot reach the keyboard to use, which is the whole point of it.
+    int rb = static_cast<int>(recenter_bind());
+    const char* rbNames[] = {"Off", "Right thumbrest + stick click", "Hold right-stick click"};
+    if (ImGui::Combo("Recenter bind", &rb, rbNames, 3))
+        set_recenter_bind(static_cast<RecenterBind>(rb));
+    if (ImGui::IsItemHovered())
+        ImGui::SetTooltip("Recenters the VR camera without the F10 overlay.\nFires only in "
+                          "gameplay view, with a %u ms cooldown.\nStands down while the "
+                          "ammo-select modifier owns the right stick click.",
+                          static_cast<unsigned>(kRecenterCooldownMs));
+    if (recenter_bind() != RecenterBind::Off && !recenter_armed())
+        ImGui::TextDisabled("  stood down - see the log (ammo modifier owns the click,"
+                            " or no XR session)");
 
     // Session 31 swing-to-attack (its own module; see core/input/swing.h).
     ImGui::Separator();

--- a/src/core/input/xinput_bridge.h
+++ b/src/core/input/xinput_bridge.h
@@ -162,6 +162,59 @@ enum class PadProfile { Bioshock1 = 0, Infinite = 1 };
 PadProfile pad_profile();
 void set_pad_profile(PadProfile p);
 
+// Controller-bound recenter. The F10 overlay's Recenter button and the
+// `recenter` seam command both need a keyboard, which is exactly what a player
+// in a headset does not have; the runtime's own recenter is worse than nothing
+// here, because it slides the LOCAL reference space out from under the cached
+// recenter yaw and the world lands on a wrong heading.
+//
+// Thumbrest = the RIGHT thumbrest touch + RIGHT stick click chord (mirrors the
+// left-thumbrest-as-modifier idiom above); Click = right stick click HELD past
+// kRecenterHoldMs, the fallback for controllers whose thumb cannot reach the
+// pad and the stick at once. Both consume the right stick CLICK, so both stand
+// down while the ammo modifier is configured to consume it (see
+// openxr_input.cpp) - two consumers of one button is a bug, not a feature.
+enum class RecenterBind { Off = 0, Thumbrest = 1, Click = 2 };
+RecenterBind recenter_bind();
+void set_recenter_bind(RecenterBind m);
+
+// Recenter resets the body-follow probe (camera.cpp -> body::on_reset), so a
+// repeated trigger would keep re-probing the transfer; the cooldown is the
+// cheapest way to make a held or fumbled gesture harmless. The hold is the
+// Click bind's arming time.
+constexpr uint64_t kRecenterCooldownMs = 500;
+constexpr uint64_t kRecenterHoldMs = 1000;
+
+// The game layer publishes "the equipped weapon has no ammo types" once per
+// frame, next to the vr-gameplay gate. While that holds, the ammo-select
+// modifier has nothing to select, so the recenter bind may take the right stick
+// click even in an ammomod mode that would otherwise own it - which is what
+// makes the bind usable out of the box, before any left-thumbrest touch has
+// been seen. Self-expiring on the same rule as the gameplay gate, so a stopped
+// publisher fails CLOSED (back to the plain guard).
+void publish_ammoless_weapon(bool on);
+bool ammoless_weapon_active();
+
+// The XR action layer publishes whether the bind is actually armed each frame,
+// so the overlay and `vrinput status` report the real state instead of
+// re-deriving the guard and drifting out of step with it.
+void publish_recenter_armed(bool armed);
+bool recenter_armed();
+
+// The XR action layer raises the request when the bound gesture fires (render
+// thread); the game adapter drains it once per frame on the GAME thread and
+// turns it into its own recenter, because what "recenter" means is the
+// adapter's business - core has no camera. Latching: a request raised between
+// two drains survives to the next one.
+void request_recenter();
+bool take_recenter_request();
+
+// The vr-gameplay gate (publish_vr_gameplay) with its staleness rule applied -
+// "a real gameplay view is on screen right now". Recenter stands down outside
+// it: firing mid-cutscene, while the authored camera drives, is the case most
+// likely to look broken.
+bool vr_gameplay_active();
+
 // Install the bridge's composing XInputGetState wrapper into an import slot
 // (e.g. the game module's IAT entry for xinput1_3 ordinal 2). The slot's
 // previous target becomes the passthrough, so a hook chain already wrapping
@@ -175,6 +228,9 @@ bool hijack_import_slot(void** slot);
 //   pitchkill on|off|status
 //   turnscale <0.1..4> | snap on|off | snapangle <deg> | sticklog on|off
 //   padlog on|off                     composed BUTTON word, edge-triggered
+
+//   ammomod click|thumbrest|both      ammo-select modifier
+//   recenterbind thumbrest|click|off  controller-bound VR recenter
 //   swing ...                         wrench swing-to-attack (core/input/swing.h)
 //   test stick l|r <x> <y> [holdMs]   raw -32768..32767
 //   test trig  l|r <0..255> [holdMs]

--- a/src/core/vr/openxr_input.cpp
+++ b/src/core/vr/openxr_input.cpp
@@ -702,8 +702,15 @@ void input_sync(XrSession session, XrTime predictedDisplayTime) {
         // the bind work from the first second of a session, before any left
         // thumbrest touch has taught the ammo lane to let go.
         const bool borrow = ammoOwnsClick && bvr::input::ammoless_weapon_active();
-        const bool armed =
-            bind != bvr::input::RecenterBind::Off && (!ammoOwnsClick || borrow);
+        // ...and stand down entirely where the pad map FORWARDS the stick click
+        // to the game. On BioShock 1 that bit is 0 and the click is free, which
+        // is what this bind relies on; Infinite forwards it as XToggleZoom, and
+        // one physical click must not both zoom and recenter. Read off the same
+        // map the composer uses rather than testing the profile enum, so the two
+        // cannot disagree about who owns the button.
+        const bool padForwardsClick = map.stickClickR != 0;
+        const bool armed = bind != bvr::input::RecenterBind::Off &&
+                           !padForwardsClick && (!ammoOwnsClick || borrow);
 
         if (armed != g_recenterArmed || (armed && borrow != g_recenterBorrowed)) {
             g_recenterArmed = armed;
@@ -719,6 +726,10 @@ void input_sync(XrSession session, XrTime predictedDisplayTime) {
             else if (bind == bvr::input::RecenterBind::Off)
                 BVR_LOG("xr-input: recenter bind off ('vrinput recenterbind "
                         "thumbrest|click')");
+            else if (padForwardsClick)
+                BVR_LOG("xr-input: recenter bind STANDS DOWN - this game's pad map "
+                        "forwards the right stick click to the game, so the bind "
+                        "cannot claim it");
             else
                 BVR_LOG("xr-input: recenter bind STANDS DOWN - the ammo modifier owns "
                         "the right stick click (ammomod %s). Set 'vrinput ammomod "

--- a/src/core/vr/openxr_input.cpp
+++ b/src/core/vr/openxr_input.cpp
@@ -182,6 +182,14 @@ uint64_t g_flickPulseUntilMs = 0;
 uint64_t g_flickCooldownMs = 0;
 bool g_rsClickWasDown = false;
 
+// Controller-bound recenter state (render thread; see the block in input_sync).
+bool g_recenterArmed = false;
+bool g_recenterBorrowed = false;
+bool g_recenterChordDown = false;
+uint64_t g_recenterClickDownMs = 0;
+bool g_recenterFiredThisHold = false;
+uint64_t g_recenterCooldownUntilMs = 0;
+
 // M6 hand poses. Located on the render thread in input_sync; read from the
 // GAME thread by the adapter's aim path, so publish through atomics-guarded
 // snapshots (relaxed is fine: a group torn by one frame is invisible at
@@ -460,6 +468,12 @@ void input_on_session_teardown() {
     g_gripLatchedL = g_gripLatchedR = false;
     g_menuDownMs = 0;
     g_startPulseUntilMs = 0;
+    g_recenterArmed = false;
+    g_recenterBorrowed = false;
+    g_recenterChordDown = false;
+    g_recenterClickDownMs = 0;
+    g_recenterFiredThisHold = false;
+    bvr::input::publish_recenter_armed(false);
     bvr::input::publish_xr_state({}, false);
 }
 
@@ -656,6 +670,116 @@ void input_sync(XrSession session, XrTime predictedDisplayTime) {
                     g_flourishChordEdges.fetch_add(1, std::memory_order_relaxed);
             }
             g_chordAWasDown = aDown;
+        }
+    }
+
+    // Controller-bound recenter. The overlay's Recenter button and the
+    // `recenter` seam command both need a keyboard, which is the one input a
+    // player wearing the headset does not have; the runtime's own recenter is
+    // actively wrong here, because it slides the LOCAL reference space out from
+    // under the adapter's cached recenter yaw and the world lands on a heading
+    // nobody asked for. So the gesture has to be read here, from actions this
+    // action set already suggests - no new binding, just a new consumer.
+    //
+    // The RIGHT thumbrest is the free input: the runtime reports it (the ammo
+    // modifier deliberately takes the LEFT one, because a right thumb cannot
+    // rest on the right pad and push the right stick at once) and nothing else
+    // consumes it. RS-click is free too - it never reaches the game. Pairing
+    // them mirrors the mod's own thumbrest-as-modifier idiom.
+    //
+    // Both binds spend the stick click, so both stand down whenever the ammo
+    // modifier is configured to take it - the guard re-derives the ammo block's
+    // OWN predicate above rather than approximating it, so the two can never
+    // disagree about who owns the button.
+    {
+        const bvr::input::RecenterBind bind = bvr::input::recenter_bind();
+        const bvr::input::AmmoMod ammo = bvr::input::ammo_mod();
+        const bool ammoOwnsClick =
+            ammo != bvr::input::AmmoMod::Thumbrest || !g_thumbrestSeen[0];
+        // ...except while the equipped weapon has no ammo types (the wrench).
+        // The modifier is still "held", but there is nothing for it to select,
+        // so the click is free and the bind can borrow it - which is what makes
+        // the bind work from the first second of a session, before any left
+        // thumbrest touch has taught the ammo lane to let go.
+        const bool borrow = ammoOwnsClick && bvr::input::ammoless_weapon_active();
+        const bool armed =
+            bind != bvr::input::RecenterBind::Off && (!ammoOwnsClick || borrow);
+
+        if (armed != g_recenterArmed || (armed && borrow != g_recenterBorrowed)) {
+            g_recenterArmed = armed;
+            g_recenterBorrowed = borrow;
+            if (armed)
+                BVR_LOG("xr-input: recenter bind ARMED (%s)%s - gameplay view only, "
+                        "%u ms cooldown",
+                        bind == bvr::input::RecenterBind::Thumbrest
+                            ? "right thumbrest + right stick click"
+                            : "hold right stick click",
+                        borrow ? " [borrowing the click: ammoless weapon]" : "",
+                        static_cast<unsigned>(bvr::input::kRecenterCooldownMs));
+            else if (bind == bvr::input::RecenterBind::Off)
+                BVR_LOG("xr-input: recenter bind off ('vrinput recenterbind "
+                        "thumbrest|click')");
+            else
+                BVR_LOG("xr-input: recenter bind STANDS DOWN - the ammo modifier owns "
+                        "the right stick click (ammomod %s). Set 'vrinput ammomod "
+                        "thumbrest' to free it, or equip the wrench (no ammo types, "
+                        "so the bind borrows the click)",
+                        ammo == bvr::input::AmmoMod::Click       ? "click"
+                        : ammo == bvr::input::AmmoMod::Both      ? "both"
+                        : "thumbrest, but no left thumbrest touch seen yet");
+        }
+        bvr::input::publish_recenter_armed(armed);
+
+        if (!armed) {
+            g_recenterChordDown = false;
+            g_recenterClickDownMs = 0;
+            g_recenterFiredThisHold = false;
+        } else {
+            const bool rsClick = read_bool(session, g_stickClickR);
+            const bool restR = read_bool(session, g_thumbrestR);
+
+            // Thumbrest bind fires on the RISING edge of the chord; Click bind
+            // fires once per hold, the moment the hold matures.
+            bool fired = false;
+            if (bind == bvr::input::RecenterBind::Thumbrest) {
+                const bool chord = rsClick && restR;
+                if (chord && !g_recenterChordDown) fired = true;
+                g_recenterChordDown = chord;
+            } else {
+                if (rsClick) {
+                    if (g_recenterClickDownMs == 0) {
+                        g_recenterClickDownMs = now;
+                        g_recenterFiredThisHold = false;
+                    } else if (!g_recenterFiredThisHold &&
+                               now - g_recenterClickDownMs >=
+                                   bvr::input::kRecenterHoldMs) {
+                        fired = true;
+                        g_recenterFiredThisHold = true;
+                    }
+                } else {
+                    g_recenterClickDownMs = 0;
+                    g_recenterFiredThisHold = false;
+                }
+            }
+
+            if (fired) {
+                if (now < g_recenterCooldownUntilMs) {
+                    // Silent: recenter resets the body-follow probe, and a
+                    // fumbled double is exactly what the cooldown is for.
+                } else if (!bvr::input::vr_gameplay_active()) {
+                    // Menus and cutscenes drive an AUTHORED camera; recentering
+                    // under one is the case most likely to look broken.
+                    g_recenterCooldownUntilMs = now + bvr::input::kRecenterCooldownMs;
+                    BVR_LOG("xr-input: recenter gesture ignored - not in gameplay view");
+                } else {
+                    g_recenterCooldownUntilMs = now + bvr::input::kRecenterCooldownMs;
+                    bvr::input::request_recenter();
+                    BVR_LOG("xr-input: recenter gesture FIRED (%s)",
+                            bind == bvr::input::RecenterBind::Thumbrest
+                                ? "right thumbrest + right stick click"
+                                : "right stick click held");
+                }
+            }
         }
     }
 

--- a/src/game/bioshock1r/bioshock1r_adapter.cpp
+++ b/src/game/bioshock1r/bioshock1r_adapter.cpp
@@ -9,6 +9,7 @@
 #include "game/bioshock1r/input_drive.h"
 #include "game/bioshock1r/patterns.h"
 #include "game/bioshock1r/scenedraw.h"
+#include "game/bioshock1r/startup_dialog.h"
 
 namespace bvr::b1r {
 
@@ -20,6 +21,12 @@ uint32_t Bioshock1RAdapter::capabilities() const {
 }
 
 bool Bioshock1RAdapter::init(const bvr::pattern_scan::ProcessImage& image) {
+    // First, and deliberately above the early returns below: the revert-Options
+    // modal appears whether or not the pattern scan succeeds, and it is exactly
+    // the launch after a crash - the one where the scan is most likely to be the
+    // thing that failed - that the player least wants to answer by hand.
+    startup_dialog::init();
+
     patterns::Symbols symbols{};
     if (!patterns::resolve(image, symbols)) return false; // resolve() logged why
     if (!camera::install(symbols.eventPlayerCalcView)) return false;

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -770,6 +770,7 @@ void save_vr_preset() {
     fprintf(f, "turnScale=%.2f\n", bvr::input::turn_scale());
     fprintf(f, "snapTurn=%d\n", bvr::input::snap_turn() ? 1 : 0);
     fprintf(f, "snapAngleDeg=%.0f\n", bvr::input::snap_angle_deg());
+    fprintf(f, "recenterBind=%d\n", static_cast<int>(bvr::input::recenter_bind()));
     fprintf(f, "swingOn=%d\n", bvr::input::swing::enabled() ? 1 : 0);
     fprintf(f, "swingThreshold=%.2f\n", bvr::input::swing::threshold_ms());
     fprintf(f, "swingRearm=%.2f\n", bvr::input::swing::rearm_ms());
@@ -847,6 +848,11 @@ void load_vr_preset_values() {
         else if (strcmp(key, "turnScale") == 0) bvr::input::set_turn_scale(v);
         else if (strcmp(key, "snapTurn") == 0) bvr::input::set_snap_turn(v != 0.0f);
         else if (strcmp(key, "snapAngleDeg") == 0) bvr::input::set_snap_angle_deg(v);
+        else if (strcmp(key, "recenterBind") == 0) {
+            const int rb = static_cast<int>(v);
+            if (rb >= 0 && rb <= 2)
+                bvr::input::set_recenter_bind(static_cast<bvr::input::RecenterBind>(rb));
+        }
         else if (strcmp(key, "swingOn") == 0) bvr::input::swing::set_enabled(v != 0.0f);
         else if (strcmp(key, "swingThreshold") == 0) bvr::input::swing::set_threshold_ms(v);
         else if (strcmp(key, "swingRearm") == 0) bvr::input::swing::set_rearm_ms(v);
@@ -1149,6 +1155,17 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
     bool strictGameplay = body::is_gameplay_view(viewActor ? *viewActor : nullptr);
     bvr::vr::publish_gameplay_view(strictGameplay);
 
+    // Controller-bound recenter: the XR action layer raises a latch on the
+    // render thread when the bound gesture fires (core/input/xinput_bridge.h);
+    // draining it HERE turns it into exactly the same request the overlay
+    // button and the `recenter` command make, on the game thread, one frame
+    // before the drive lane below consumes it. The gameplay gate lives at the
+    // detector; this is only the seam between threads.
+    if (bvr::input::take_recenter_request()) {
+        g_recenterRequested.store(true, std::memory_order_relaxed);
+        BVR_LOG("[b1r] recenter requested by controller bind");
+    }
+
     // Session 29: the cinematic drive policy (vrcine drive off|authored|
     // authored+look). `cineHold` is the draw-based signal ORed with the pixel
     // watch - it must NOT be plain letterbox(), because with the bars
@@ -1444,6 +1461,14 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
         // XR session anyway, and leaving it out is what lets `vrinput swing sim`
         // exercise the whole decision path flat.
         bvr::input::swing::publish_gate(strictGameplay && aim::weapon_key_is("Wrench"));
+
+        // The recenter bind's "can I borrow the stick click?" signal. Derived
+        // independently of the swing gate above even though it reads the same
+        // today: they answer different questions ("may I swing" vs "does the
+        // ammo modifier have anything to select"), and one of them changing
+        // must not silently move the other.
+        bvr::input::publish_ammoless_weapon(strictGameplay &&
+                                            aim::weapon_key_is("Wrench"));
 
         static int s_lastViewState = -1;
         int viewState = strictGameplay ? 1 : 0;

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -107,6 +107,12 @@ std::atomic<bool> g_lockOnDisabled{true};
 int g_lockOnApplied = -1;
 uint64_t g_lockOnAssertMs = 0;
 std::atomic<bool>  g_recenterRequested{true};  // auto-recenter on first drive
+// Opt-in (default OFF): recenter again on every menu/cutscene -> GAMEPLAY
+// transition. The preset already recenters once when it arms; doing it on the
+// transition too is what fixes heading drift after a load without asking the
+// player for an input. Off by default because it overrides a deliberate
+// mid-session recenter every time a cutscene ends.
+std::atomic<bool>  g_autoRecenterOnGameplay{false};
 std::atomic<bool>  g_vrDriving{false};         // telemetry for the UI
 std::atomic<bool>  g_forceHeadsetFov{false};   // session 4: now writes the REAL control (the
                                                // UShockUserSettings HorizontalFOV int that the
@@ -379,6 +385,17 @@ void apply_command(const char* cmd, const char* args) {
     } else if (strcmp(cmd, "recenter") == 0) {
         g_recenterRequested.store(true, std::memory_order_relaxed);
         BVR_LOG("[b1r] command: recenter");
+    } else if (strcmp(cmd, "autorecenter") == 0) {
+        if (strncmp(args, "on", 2) == 0)
+            g_autoRecenterOnGameplay.store(true, std::memory_order_relaxed);
+        else if (strncmp(args, "off", 3) == 0)
+            g_autoRecenterOnGameplay.store(false, std::memory_order_relaxed);
+        BVR_LOG("[b1r] auto-recenter on entering gameplay: %s "
+                "(autorecenter on|off) - recenters on every menu/cutscene -> "
+                "GAMEPLAY transition, which is where heading drift after a load "
+                "shows up",
+                g_autoRecenterOnGameplay.load(std::memory_order_relaxed) ? "ON"
+                                                                        : "off");
     } else if (strcmp(cmd, "offset") == 0) {
         if (sscanf_s(args, "%f %f %f", &x, &y, &z) == 3) {
             g_offsetX.store(x, std::memory_order_relaxed);
@@ -771,6 +788,8 @@ void save_vr_preset() {
     fprintf(f, "snapTurn=%d\n", bvr::input::snap_turn() ? 1 : 0);
     fprintf(f, "snapAngleDeg=%.0f\n", bvr::input::snap_angle_deg());
     fprintf(f, "recenterBind=%d\n", static_cast<int>(bvr::input::recenter_bind()));
+    fprintf(f, "autoRecenterOnGameplay=%d\n",
+            g_autoRecenterOnGameplay.load(std::memory_order_relaxed) ? 1 : 0);
     fprintf(f, "swingOn=%d\n", bvr::input::swing::enabled() ? 1 : 0);
     fprintf(f, "swingThreshold=%.2f\n", bvr::input::swing::threshold_ms());
     fprintf(f, "swingRearm=%.2f\n", bvr::input::swing::rearm_ms());
@@ -848,6 +867,8 @@ void load_vr_preset_values() {
         else if (strcmp(key, "turnScale") == 0) bvr::input::set_turn_scale(v);
         else if (strcmp(key, "snapTurn") == 0) bvr::input::set_snap_turn(v != 0.0f);
         else if (strcmp(key, "snapAngleDeg") == 0) bvr::input::set_snap_angle_deg(v);
+        else if (strcmp(key, "autoRecenterOnGameplay") == 0)
+            g_autoRecenterOnGameplay.store(v != 0.0f, std::memory_order_relaxed);
         else if (strcmp(key, "recenterBind") == 0) {
             const int rb = static_cast<int>(v);
             if (rb >= 0 && rb <= 2)
@@ -1481,6 +1502,11 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
             // event that plausibly created what they were looking for, so it is
             // the one place allowed to wake them.
             if (strictGameplay) {
+                if (g_autoRecenterOnGameplay.load(std::memory_order_relaxed)) {
+                    g_recenterRequested.store(true, std::memory_order_relaxed);
+                    BVR_LOG("[b1r] auto-recenter: entered gameplay view "
+                            "('autorecenter off' to disable)");
+                }
                 patterns::hfov_scan_rearm("entered gameplay view");
                 aim::weapon_scan_rearm("entered gameplay view");
                 // Same event drives the engine-property re-assert, which used to
@@ -2056,6 +2082,13 @@ void draw_debug_ui() {
         atomic_slider("Head offset fwd (UU)", g_headOffFwdUu, -80.0f, 80.0f);
         if (ImGui::Button("Recenter (seated pose + view yaw)"))
             g_recenterRequested.store(true, std::memory_order_relaxed);
+        bool autoRc = g_autoRecenterOnGameplay.load(std::memory_order_relaxed);
+        if (ImGui::Checkbox("Auto-recenter on entering gameplay", &autoRc))
+            g_autoRecenterOnGameplay.store(autoRc, std::memory_order_relaxed);
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Recenters on every menu/cutscene -> GAMEPLAY transition.\n"
+                              "Fixes heading drift after a load with no input from you;\n"
+                              "costs you any deliberate recenter made mid-session.");
         bool forceFov = g_forceHeadsetFov.load(std::memory_order_relaxed);
         if (ImGui::Checkbox("Force headset FOV (off = game FOV, narrower)", &forceFov))
             g_forceHeadsetFov.store(forceFov, std::memory_order_relaxed);

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -886,6 +886,26 @@ void load_startup_prefs() {
                 g_autoPresetOnGameplay.load(std::memory_order_relaxed) ? 1 : 0,
                 g_autoRecenterOnGameplay.load(std::memory_order_relaxed) ? 1 : 0,
                 static_cast<int>(bvr::input::recenter_bind()));
+
+    // Arm the synthetic pad NOW, not with the preset.
+    //
+    // The pad's A button already works the title screen and the load - that is
+    // how the harness boots this game (`vrinput test press A` in boot.ps1). But
+    // synthetic input is OFF until the preset arms it, and the preset cannot arm
+    // until a gameplay view exists, which needs the menu you cannot press. That
+    // circle is the entire reason the main menu still needed a keyboard.
+    //
+    // It does NOT skip the startup Bink movies (measured) - those play out and
+    // then A activates Continue.
+    //
+    // Only under autopreset, so a player who has not opted into a hands-off
+    // launch sees no change at all.
+    if (g_autoPresetOnGameplay.load(std::memory_order_relaxed)) {
+        bvr::input::set_enabled(true);
+        BVR_LOG("[b1r] autopreset: synthetic pad armed at startup - the Touch A "
+                "button now drives the main menu and the save load, so no part of "
+                "the launch needs a keyboard");
+    }
 }
 
 void load_vr_preset_values() {

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -123,6 +123,30 @@ std::atomic<bool>  g_autoPresetOnGameplay{false};
 // Seated play (default OFF): ignore the vertical component of the head offset,
 // pinning eye height to the game's own camera. See the note at its use site.
 std::atomic<bool>  g_heightLock{false};
+
+// World-scale measurement capture (`vrscale [seconds]`, default off).
+//
+// worldScale is UU per real metre, and almost every way of checking it is
+// circular: ask the mod how far your hand moved and it answers
+// metres * worldScale by construction. Gravity is not circular - it is the
+// ENGINE's own physics. Capture the engine's camera height at CalcView rate
+// through a jump or a fall, fit the acceleration in UU/s^2, and
+// UU-per-metre = accel / 9.81. (Unreal's default zone gravity of -950 UU/s^2
+// implies ~97 UU/m, which is the same ballpark as the ~100 upstream measured
+// by a different method - see docs/bioshock2/ENGINE_NOTES.md.)
+//
+// The timestamp has to be QPC: this samples at frame rate, and
+// GetTickCount64's ~15 ms granularity would swamp a 14 ms frame.
+std::atomic<uint64_t> g_scaleCaptureUntilMs{0};
+std::atomic<uint32_t> g_scaleSamples{0};
+
+double qpc_seconds() {
+    static LARGE_INTEGER freq{};
+    if (!freq.QuadPart) QueryPerformanceFrequency(&freq);
+    LARGE_INTEGER now{};
+    QueryPerformanceCounter(&now);
+    return static_cast<double>(now.QuadPart) / static_cast<double>(freq.QuadPart);
+}
 std::atomic<bool>  g_vrDriving{false};         // telemetry for the UI
 std::atomic<bool>  g_forceHeadsetFov{false};   // session 4: now writes the REAL control (the
                                                // UShockUserSettings HorizontalFOV int that the
@@ -397,6 +421,18 @@ void apply_command(const char* cmd, const char* args) {
         BVR_LOG("[b1r] command: recenter");
     } else if (strcmp(cmd, "vrpopup") == 0) {
         startup_dialog::handle_command(args); // logs its own echo
+    } else if (strcmp(cmd, "vrscale") == 0) {
+        unsigned secs = 0;
+        if (sscanf_s(args, "%u", &secs) != 1 || secs == 0) secs = 20;
+        if (secs > 120) secs = 120; // the capture is one line per CalcView
+        g_scaleSamples.store(0, std::memory_order_relaxed);
+        g_scaleCaptureUntilMs.store(GetTickCount64() + secs * 1000ull,
+                                    std::memory_order_relaxed);
+        BVR_LOG("[vrscale] capture ARMED for %u s - JUMP a few times, or drop off a "
+                "ledge. Logging the ENGINE's camera height per CalcView; gravity in "
+                "UU/s^2 divided by 9.81 gives UU per metre, which is what worldScale "
+                "(now %.0f) should be. Nothing is changed by this.",
+                secs, g_worldScale.load(std::memory_order_relaxed));
     } else if (strcmp(cmd, "headoff") == 0) {
         // The head-anchor offsets were overlay-only sliders, which means they
         // needed F10 and a keyboard - useless to a player already in the
@@ -1281,6 +1317,26 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
         g_lastLocX.store(loc->x, std::memory_order_relaxed);
         g_lastLocY.store(loc->y, std::memory_order_relaxed);
         g_lastLocZ.store(loc->z, std::memory_order_relaxed);
+
+        // World-scale capture. Deliberately HERE, on the incoming camera, before
+        // any VR head offset is added below - the head offset is computed FROM
+        // worldScale, so including it would feed the answer back into the
+        // measurement and guarantee agreement.
+        const uint64_t until = g_scaleCaptureUntilMs.load(std::memory_order_relaxed);
+        if (until) {
+            if (GetTickCount64() <= until) {
+                BVR_LOG("[vrscale] t=%.6f z=%.3f x=%.1f y=%.1f", qpc_seconds(), loc->z,
+                        loc->x, loc->y);
+                g_scaleSamples.fetch_add(1, std::memory_order_relaxed);
+            } else {
+                g_scaleCaptureUntilMs.store(0, std::memory_order_relaxed);
+                BVR_LOG("[vrscale] capture done - %u samples. Fit the free-fall "
+                        "segments: accel in UU/s^2 / 9.81 = UU per metre (worldScale "
+                        "is %.0f).",
+                        g_scaleSamples.load(std::memory_order_relaxed),
+                        g_worldScale.load(std::memory_order_relaxed));
+            }
+        }
     }
     if (rot) {
         g_lastPitch.store(rot->pitch, std::memory_order_relaxed);

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -421,6 +421,22 @@ void apply_command(const char* cmd, const char* args) {
         BVR_LOG("[b1r] command: recenter");
     } else if (strcmp(cmd, "vrpopup") == 0) {
         startup_dialog::handle_command(args); // logs its own echo
+    } else if (strcmp(cmd, "worldscale") == 0) {
+        // Overlay-only until now, same trap headoff had. worldScale does TWO
+        // jobs: it converts head translation into camera translation, and it
+        // converts the IPD into world units (ipd/1000 * worldScale UU), which
+        // is what sets PERCEIVED world size. Too low a value makes the stereo
+        // baseline too small, the world reads as oversized, and the player
+        // feels short - which is the symptom that started this.
+        float v = 0.0f;
+        if (sscanf_s(args, "%f", &v) == 1 && v >= 10.0f && v <= 400.0f)
+            g_worldScale.store(v, std::memory_order_relaxed);
+        const float ws = g_worldScale.load(std::memory_order_relaxed);
+        BVR_LOG("[b1r] worldScale = %.1f UU/m (worldscale <10..400>) - eye "
+                "separation %.2f UU at ipd %.1f mm; 1 UU = %.1f mm. "
+                "'vrpreset save' to keep",
+                ws, g_ipdMm.load(std::memory_order_relaxed) / 1000.0f * ws,
+                g_ipdMm.load(std::memory_order_relaxed), 1000.0f / ws);
     } else if (strcmp(cmd, "vrscale") == 0) {
         unsigned secs = 0;
         if (sscanf_s(args, "%u", &secs) != 1 || secs == 0) secs = 20;

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -424,15 +424,15 @@ void apply_command(const char* cmd, const char* args) {
     } else if (strcmp(cmd, "vrscale") == 0) {
         unsigned secs = 0;
         if (sscanf_s(args, "%u", &secs) != 1 || secs == 0) secs = 20;
-        if (secs > 120) secs = 120; // the capture is one line per CalcView
+        if (secs > 1800) secs = 1800; // sampling is gated on vertical motion
         g_scaleSamples.store(0, std::memory_order_relaxed);
         g_scaleCaptureUntilMs.store(GetTickCount64() + secs * 1000ull,
                                     std::memory_order_relaxed);
-        BVR_LOG("[vrscale] capture ARMED for %u s - JUMP a few times, or drop off a "
-                "ledge. Logging the ENGINE's camera height per CalcView; gravity in "
-                "UU/s^2 divided by 9.81 gives UU per metre, which is what worldScale "
-                "(now %.0f) should be. Nothing is changed by this.",
-                secs, g_worldScale.load(std::memory_order_relaxed));
+        BVR_LOG("[vrscale] capture ARMED for %u s (%u min) - RUN, JUMP, and drop off "
+                "ledges; a long fall is the best signal. Sampling only while the "
+                "camera moves vertically. Gravity in UU/s^2 / 9.81 = UU per metre, "
+                "which is what worldScale (now %.0f) should be. Changes nothing.",
+                secs, secs / 60, g_worldScale.load(std::memory_order_relaxed));
     } else if (strcmp(cmd, "headoff") == 0) {
         // The head-anchor offsets were overlay-only sliders, which means they
         // needed F10 and a keyboard - useless to a player already in the
@@ -1325,9 +1325,21 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
         const uint64_t until = g_scaleCaptureUntilMs.load(std::memory_order_relaxed);
         if (until) {
             if (GetTickCount64() <= until) {
-                BVR_LOG("[vrscale] t=%.6f z=%.3f x=%.1f y=%.1f", qpc_seconds(), loc->z,
-                        loc->x, loc->y);
-                g_scaleSamples.fetch_add(1, std::memory_order_relaxed);
+                // Only log while the camera is actually moving vertically, plus a
+                // short tail. A capture long enough to go and FIND a ledge would
+                // otherwise be mostly the player standing still - 11 of the first
+                // 18 test seconds were a z pinned to one value - and the arcs are
+                // the only part that carries any signal.
+                static float s_lastZ = 0.0f;
+                static double s_activeUntil = 0.0;
+                const double tnow = qpc_seconds();
+                if (fabsf(loc->z - s_lastZ) > 0.02f) s_activeUntil = tnow + 0.5;
+                s_lastZ = loc->z;
+                if (tnow <= s_activeUntil) {
+                    BVR_LOG("[vrscale] t=%.6f z=%.3f x=%.1f y=%.1f", tnow, loc->z,
+                            loc->x, loc->y);
+                    g_scaleSamples.fetch_add(1, std::memory_order_relaxed);
+                }
             } else {
                 g_scaleCaptureUntilMs.store(0, std::memory_order_relaxed);
                 BVR_LOG("[vrscale] capture done - %u samples. Fit the free-fall "

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -71,6 +71,10 @@ std::atomic<float> g_worldScale{100.0f};       // Unreal units per meter
 // anchor. Defaults 0 by the user's call (session 16 part 4) - they tune by
 // eye and persist their value via the VR preset ini.
 std::atomic<float> g_headOffUpUu{0.0f};
+// Whether the head anchor also moves the HAND anchor (see the FrameContext
+// publish). On by default because it is a no-op while the anchor is 0, which
+// is the shipped value; `headoff hands off` is the rollback.
+std::atomic<bool>  g_headAnchorHands{true};
 std::atomic<float> g_headOffFwdUu{0.0f};
 // VR preset 1 (session 16 part 3): one button/command arming the user's full
 // VR configuration - every switch they flipped by hand, in a safe order,
@@ -456,18 +460,28 @@ void apply_command(const char* cmd, const char* args) {
         // lower than the game's own camera implies. Same values, same
         // vrpreset.ini keys, now reachable from the seam.
         char which[8] = {};
+        char val[8] = {};
         float v = 0.0f;
-        if (sscanf_s(args, "%7s %f", which, static_cast<unsigned>(sizeof which), &v) == 2) {
+        if (sscanf_s(args, "%7s %7s", which, static_cast<unsigned>(sizeof which), val,
+                     static_cast<unsigned>(sizeof val)) == 2 &&
+            strcmp(which, "hands") == 0) {
+            g_headAnchorHands.store(strncmp(val, "on", 2) == 0,
+                                    std::memory_order_relaxed);
+        } else if (sscanf_s(args, "%7s %f", which,
+                            static_cast<unsigned>(sizeof which), &v) == 2) {
             if (strcmp(which, "up") == 0)
                 g_headOffUpUu.store(v, std::memory_order_relaxed);
             else if (strcmp(which, "fwd") == 0)
                 g_headOffFwdUu.store(v, std::memory_order_relaxed);
         }
-        BVR_LOG("[b1r] head anchor: up=%.1f fwd=%.1f UU (headoff up <uu> | headoff fwd "
-                "<uu>; worldScale %.0f UU/m, so 1 UU is %.1f mm of real height) - "
+        BVR_LOG("[b1r] head anchor: up=%.1f fwd=%.1f UU, hands %s (headoff up <uu> | "
+                "fwd <uu> | hands on|off; worldScale %.0f UU/m, 1 UU = %.1f mm) - "
                 "'vrpreset save' to keep",
                 g_headOffUpUu.load(std::memory_order_relaxed),
                 g_headOffFwdUu.load(std::memory_order_relaxed),
+                g_headAnchorHands.load(std::memory_order_relaxed)
+                    ? "FOLLOW (gun stays on the controller axis)"
+                    : "detached (camera only - the old behaviour)",
                 g_worldScale.load(std::memory_order_relaxed),
                 1000.0f / g_worldScale.load(std::memory_order_relaxed));
     } else if (strcmp(cmd, "heightlock") == 0) {
@@ -875,6 +889,8 @@ void save_vr_preset() {
     fprintf(f, "worldScale=%.1f\n", g_worldScale.load(std::memory_order_relaxed));
     fprintf(f, "headUpUu=%.1f\n", g_headOffUpUu.load(std::memory_order_relaxed));
     fprintf(f, "headFwdUu=%.1f\n", g_headOffFwdUu.load(std::memory_order_relaxed));
+    fprintf(f, "headAnchorHands=%d\n",
+            g_headAnchorHands.load(std::memory_order_relaxed) ? 1 : 0);
     fprintf(f, "ipdMm=%.1f\n", g_ipdMm.load(std::memory_order_relaxed));
     fprintf(f, "gameFovDeg=%.1f\n", g_gameFovDeg.load(std::memory_order_relaxed));
     fprintf(f, "aimTrimLPitch=%.1f\n", aim::trim_pitch_deg(0));
@@ -1018,6 +1034,8 @@ void load_vr_preset_values() {
         ++n;
         if (strcmp(key, "worldScale") == 0) g_worldScale.store(v, std::memory_order_relaxed);
         else if (strcmp(key, "headUpUu") == 0) g_headOffUpUu.store(v, std::memory_order_relaxed);
+        else if (strcmp(key, "headAnchorHands") == 0)
+            g_headAnchorHands.store(v != 0.0f, std::memory_order_relaxed);
         else if (strcmp(key, "headFwdUu") == 0) g_headOffFwdUu.store(v, std::memory_order_relaxed);
         else if (strcmp(key, "ipdMm") == 0) g_ipdMm.store(v, std::memory_order_relaxed);
         else if (strcmp(key, "gameFovDeg") == 0) g_gameFovDeg.store(v, std::memory_order_relaxed);
@@ -1725,6 +1743,36 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
         fc.baseX = baseLoc.x;
         fc.baseY = baseLoc.y;
         fc.baseZ = baseLoc.z;
+
+        // Head anchor -> the SHARED base, so the hands ride it too.
+        //
+        // baseLoc is the engine's own camera, and the system is otherwise
+        // coherent: the camera adds its recenter-relative head offset to it,
+        // the hands add the controller's recenter-relative offset to it, and
+        // because both offsets are measured from the same recenter pose, head
+        // and hands move together for free.
+        //
+        // The head ANCHOR (headoff up/fwd) broke that. It was added to the
+        // camera further down and never to the base, so a lift raised the eye
+        // while the engine kept placing the hands at its own eye height - at
+        // 25 UU that is a 25 cm decoupling, and the gun visibly stops sitting
+        // on the controller's axis. Applying it here, in the frame both
+        // consumers read, is the whole fix.
+        //
+        // Same composition as the camera's own: fwd rides the FINAL view yaw,
+        // up is world-up. `headoff hands off` restores the old behaviour
+        // without a rebuild, and with the anchor at 0 this is a no-op either
+        // way.
+        if (g_headAnchorHands.load(std::memory_order_relaxed)) {
+            const float hoUp = g_headOffUpUu.load(std::memory_order_relaxed);
+            const float hoFwd = g_headOffFwdUu.load(std::memory_order_relaxed);
+            if (rot && (hoUp != 0.0f || hoFwd != 0.0f)) {
+                const float vyaw = static_cast<float>(rot->yaw) / kRotUnitsPerRadian;
+                fc.baseX += cosf(vyaw) * hoFwd;
+                fc.baseY += sinf(vyaw) * hoFwd;
+                fc.baseZ += hoUp;
+            }
+        }
         if (rot) {
             fc.camPitch = rot->pitch;
             fc.camYaw = rot->yaw;

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -22,6 +22,7 @@
 #include "game/bioshock1r/patterns.h"
 #include "game/bioshock1r/recorder.h"
 #include "game/bioshock1r/scenedraw.h"
+#include "game/bioshock1r/startup_dialog.h"
 #include "game/shared/ue_math.h"
 
 #include <windows.h>
@@ -385,6 +386,8 @@ void apply_command(const char* cmd, const char* args) {
     } else if (strcmp(cmd, "recenter") == 0) {
         g_recenterRequested.store(true, std::memory_order_relaxed);
         BVR_LOG("[b1r] command: recenter");
+    } else if (strcmp(cmd, "vrpopup") == 0) {
+        startup_dialog::handle_command(args); // logs its own echo
     } else if (strcmp(cmd, "autorecenter") == 0) {
         if (strncmp(args, "on", 2) == 0)
             g_autoRecenterOnGameplay.store(true, std::memory_order_relaxed);

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -114,6 +114,12 @@ std::atomic<bool>  g_recenterRequested{true};  // auto-recenter on first drive
 // player for an input. Off by default because it overrides a deliberate
 // mid-session recenter every time a cutscene ends.
 std::atomic<bool>  g_autoRecenterOnGameplay{false};
+// Opt-in (default OFF): arm VR PRESET 1 by itself, ONCE, the first time a
+// gameplay view appears. vrpreset.ini persists the tuned VALUES but nothing
+// persists the toggles - the preset has to be pressed in the F10 overlay every
+// launch, which is the one thing a player in a headset cannot reach. Firing it
+// on the first gameplay transition is exactly when a human presses it.
+std::atomic<bool>  g_autoPresetOnGameplay{false};
 std::atomic<bool>  g_vrDriving{false};         // telemetry for the UI
 std::atomic<bool>  g_forceHeadsetFov{false};   // session 4: now writes the REAL control (the
                                                // UShockUserSettings HorizontalFOV int that the
@@ -388,6 +394,15 @@ void apply_command(const char* cmd, const char* args) {
         BVR_LOG("[b1r] command: recenter");
     } else if (strcmp(cmd, "vrpopup") == 0) {
         startup_dialog::handle_command(args); // logs its own echo
+    } else if (strcmp(cmd, "autopreset") == 0) {
+        if (strncmp(args, "on", 2) == 0)
+            g_autoPresetOnGameplay.store(true, std::memory_order_relaxed);
+        else if (strncmp(args, "off", 3) == 0)
+            g_autoPresetOnGameplay.store(false, std::memory_order_relaxed);
+        BVR_LOG("[b1r] auto-preset on entering gameplay: %s (autopreset on|off) - "
+                "arms VR PRESET 1 once per session so the headset needs no "
+                "keyboard to get into VR",
+                g_autoPresetOnGameplay.load(std::memory_order_relaxed) ? "ON" : "off");
     } else if (strcmp(cmd, "autorecenter") == 0) {
         if (strncmp(args, "on", 2) == 0)
             g_autoRecenterOnGameplay.store(true, std::memory_order_relaxed);
@@ -793,6 +808,8 @@ void save_vr_preset() {
     fprintf(f, "recenterBind=%d\n", static_cast<int>(bvr::input::recenter_bind()));
     fprintf(f, "autoRecenterOnGameplay=%d\n",
             g_autoRecenterOnGameplay.load(std::memory_order_relaxed) ? 1 : 0);
+    fprintf(f, "autoPresetOnGameplay=%d\n",
+            g_autoPresetOnGameplay.load(std::memory_order_relaxed) ? 1 : 0);
     fprintf(f, "swingOn=%d\n", bvr::input::swing::enabled() ? 1 : 0);
     fprintf(f, "swingThreshold=%.2f\n", bvr::input::swing::threshold_ms());
     fprintf(f, "swingRearm=%.2f\n", bvr::input::swing::rearm_ms());
@@ -872,6 +889,8 @@ void load_vr_preset_values() {
         else if (strcmp(key, "snapAngleDeg") == 0) bvr::input::set_snap_angle_deg(v);
         else if (strcmp(key, "autoRecenterOnGameplay") == 0)
             g_autoRecenterOnGameplay.store(v != 0.0f, std::memory_order_relaxed);
+        else if (strcmp(key, "autoPresetOnGameplay") == 0)
+            g_autoPresetOnGameplay.store(v != 0.0f, std::memory_order_relaxed);
         else if (strcmp(key, "recenterBind") == 0) {
             const int rb = static_cast<int>(v);
             if (rb >= 0 && rb <= 2)
@@ -1560,6 +1579,25 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
             // event that plausibly created what they were looking for, so it is
             // the one place allowed to wake them.
             if (strictGameplay) {
+                // ONCE per session: re-applying the preset would re-run the
+                // whole vrstereo sequence on every cutscene exit.
+                static bool s_autoPresetDone = false;
+                if (!s_autoPresetDone &&
+                    g_autoPresetOnGameplay.load(std::memory_order_relaxed)) {
+                    s_autoPresetDone = true;
+                    g_vrPresetPending.store(true, std::memory_order_relaxed);
+                    // ...and take the seated reference HERE. The recenter
+                    // captures the full head pose, position included, so
+                    // whatever height the player is at this instant becomes the
+                    // game's own standing eye height - which is what makes one
+                    // keyboard-free launch work whether they sat down or stayed
+                    // standing. Without it the session inherits whatever
+                    // reference the runtime happened to hand out.
+                    g_recenterRequested.store(true, std::memory_order_relaxed);
+                    BVR_LOG("[b1r] auto-preset: arming VR PRESET 1 on the first "
+                            "gameplay view, and recentering onto your current "
+                            "seated/standing pose ('autopreset off' to disable)");
+                }
                 if (g_autoRecenterOnGameplay.load(std::memory_order_relaxed)) {
                     g_recenterRequested.store(true, std::memory_order_relaxed);
                     BVR_LOG("[b1r] auto-recenter: entered gameplay view "
@@ -2140,6 +2178,13 @@ void draw_debug_ui() {
         atomic_slider("Head offset fwd (UU)", g_headOffFwdUu, -80.0f, 80.0f);
         if (ImGui::Button("Recenter (seated pose + view yaw)"))
             g_recenterRequested.store(true, std::memory_order_relaxed);
+        bool autoPre = g_autoPresetOnGameplay.load(std::memory_order_relaxed);
+        if (ImGui::Checkbox("Auto-arm VR PRESET 1 on entering gameplay", &autoPre))
+            g_autoPresetOnGameplay.store(autoPre, std::memory_order_relaxed);
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Presses this preset for you, once per session, the first\n"
+                              "time a gameplay view appears - so getting into VR needs\n"
+                              "no keyboard. Tuned values already persist; the toggles did not.");
         bool autoRc = g_autoRecenterOnGameplay.load(std::memory_order_relaxed);
         if (ImGui::Checkbox("Auto-recenter on entering gameplay", &autoRc))
             g_autoRecenterOnGameplay.store(autoRc, std::memory_order_relaxed);

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -982,6 +982,12 @@ void load_startup_prefs() {
             if (rb >= 0 && rb <= 2)
                 bvr::input::set_recenter_bind(static_cast<bvr::input::RecenterBind>(rb));
         }
+        // Must be read HERE and not with the preset values: the prompt it
+        // answers appears seconds into the launch, long before any preset is
+        // armed. The watcher polls, so setting it a few ms after its thread
+        // starts is still inside the window.
+        else if (strcmp(key, "popupDismiss") == 0)
+            startup_dialog::set_enabled(v != 0.0f);
     }
     fclose(f);
     if (g_autoPresetOnGameplay.load(std::memory_order_relaxed) ||
@@ -2419,6 +2425,31 @@ void draw_debug_ui() {
         atomic_slider("IPD (mm)", g_ipdMm, 55.0f, 75.0f);
         atomic_slider("Head offset up (UU)", g_headOffUpUu, -150.0f, 150.0f);
         atomic_slider("Head offset fwd (UU)", g_headOffFwdUu, -80.0f, 80.0f);
+        bool anchorHands = g_headAnchorHands.load(std::memory_order_relaxed);
+        if (ImGui::Checkbox("  ^ head offset moves the hands too", &anchorHands))
+            g_headAnchorHands.store(anchorHands, std::memory_order_relaxed);
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("The offsets above move the CAMERA. The engine keeps placing the\n"
+                              "hands at its own eye height, so without this a lift decouples\n"
+                              "the two and the gun stops sitting on the controller's axis.\n"
+                              "No effect while both offsets are 0. Uncheck for the old behaviour.");
+        if (ImGui::Button("Measure world scale (20 s)"))
+            apply_command("vrscale", "20");
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Logs the engine's camera height while you jump or fall, so\n"
+                              "gravity can be fitted: UU/s^2 / 9.81 = UU per metre, which is\n"
+                              "what World scale above should be. Non-circular - it measures\n"
+                              "the engine's physics, not the setting. tools/fit-worldscale.py\n"
+                              "does the fit. Changes nothing by itself.");
+        bool popup = startup_dialog::enabled();
+        if (ImGui::Checkbox("Auto-answer the post-crash 'revert Options?' prompt", &popup))
+            startup_dialog::set_enabled(popup);
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("After an unclean exit the game asks whether to revert video\n"
+                              "options, and it blocks the first Present until answered -\n"
+                              "so in a headset you must find a mouse. This clicks No for you,\n"
+                              "only during a startup window, and only a button that says No.\n"
+                              "Set popupDismiss=1 in vrpreset.ini to have it armed at launch.");
         if (ImGui::Button("Recenter (seated pose + view yaw)"))
             g_recenterRequested.store(true, std::memory_order_relaxed);
         bool hLock = g_heightLock.load(std::memory_order_relaxed);

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -397,6 +397,27 @@ void apply_command(const char* cmd, const char* args) {
         BVR_LOG("[b1r] command: recenter");
     } else if (strcmp(cmd, "vrpopup") == 0) {
         startup_dialog::handle_command(args); // logs its own echo
+    } else if (strcmp(cmd, "headoff") == 0) {
+        // The head-anchor offsets were overlay-only sliders, which means they
+        // needed F10 and a keyboard - useless to a player already in the
+        // headset, and this is the control you reach for when the VR eye sits
+        // lower than the game's own camera implies. Same values, same
+        // vrpreset.ini keys, now reachable from the seam.
+        char which[8] = {};
+        float v = 0.0f;
+        if (sscanf_s(args, "%7s %f", which, static_cast<unsigned>(sizeof which), &v) == 2) {
+            if (strcmp(which, "up") == 0)
+                g_headOffUpUu.store(v, std::memory_order_relaxed);
+            else if (strcmp(which, "fwd") == 0)
+                g_headOffFwdUu.store(v, std::memory_order_relaxed);
+        }
+        BVR_LOG("[b1r] head anchor: up=%.1f fwd=%.1f UU (headoff up <uu> | headoff fwd "
+                "<uu>; worldScale %.0f UU/m, so 1 UU is %.1f mm of real height) - "
+                "'vrpreset save' to keep",
+                g_headOffUpUu.load(std::memory_order_relaxed),
+                g_headOffFwdUu.load(std::memory_order_relaxed),
+                g_worldScale.load(std::memory_order_relaxed),
+                1000.0f / g_worldScale.load(std::memory_order_relaxed));
     } else if (strcmp(cmd, "heightlock") == 0) {
         if (strncmp(args, "on", 2) == 0)
             g_heightLock.store(true, std::memory_order_relaxed);

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -1047,6 +1047,60 @@ void poll_command_file(uint64_t now) {
 }
 
 // XR -> Unreal conversion lives in ue_math.h (shared with the aim ray).
+// The black-bands warning, said once, in the one place that knows both numbers.
+//
+// The eye is essentially square (54 x 55 deg half-angles on a Quest 3), so a
+// 16:9 backbuffer has to render a MUCH wider horizontal FOV to fill it - the
+// core computes that requirement and logs it, and the adapter reads back what
+// the engine actually renders. When the two disagree the difference is not
+// subtle: it is black bars at the top and bottom of the headset image for the
+// whole session, and the fix is one integer in the game's own ini.
+//
+// Worth a loud line because the game's options menu REWRITES HorizontalFOV
+// whenever any video setting is touched, so this is not a one-time repair.
+constexpr float kFovMismatchWarnDeg = 5.0f;
+
+void warn_fov_mismatch_once(bool strictGameplay) {
+    static bool s_checked = false;
+    if (s_checked || !strictGameplay) return;
+
+    // Read what the scene is ACTUALLY rendered at, not the settings option.
+    // The option pointer is frequently unavailable (`fovaudit: option=-1` on a
+    // normal session, measured), and the only other candidate - the frame
+    // camera's fov - reads the engine default 100 on the title screen and
+    // during scripted cameras, so latching on either warns on correctly
+    // configured launches. The decoded scene tangent is the number that
+    // actually decides whether there are bars, and requiring it FRESH and in a
+    // gameplay view keeps scripted-camera lenses out of the comparison.
+    float tanH = 0.0f, tanV = 0.0f;
+    unsigned long long age = 0;
+    if (!bvr::hud::fov_watch(&tanH, &tanV, &age, 500) || tanH <= 0.0f) return;
+    const float want = bvr::vr::suggested_hfov_deg();
+    if (want <= 0.0f) return; // headset requirement not computed yet
+    const float actualHfovDeg = 2.0f * atanf(tanH) * kRadToDeg;
+    s_checked = true;
+    if (fabsf(want - actualHfovDeg) <= kFovMismatchWarnDeg) {
+        BVR_LOG("[b1r] fov check: the world renders %.0f deg and this headset wants "
+                "%.0f - no bars",
+                actualHfovDeg, want);
+        return;
+    }
+
+    const wchar_t* ini = game_ini::path();
+    BVR_LOG("[b1r] FOV MISMATCH: this headset needs hfov %.0f deg at the current "
+            "backbuffer, but the game renders %.0f - expect BLACK BARS top and "
+            "bottom for the whole session.",
+            want, actualHfovDeg);
+    BVR_LOG("[b1r]   fix: set HorizontalFOV=%.0f in [ShockGame.ShockUserSettings] of "
+            "%ls (the lock beside it is bHorizontalFOVLock; [Engine.RenderConfig] "
+            "carries its own HorizontalFOVLock)",
+            want, (ini && *ini) ? ini : L"%APPDATA%\\BioshockHD\\Bioshock\\Bioshock.ini");
+    BVR_LOG("[b1r]   the options menu rewrites HorizontalFOV whenever you touch a "
+            "video setting, so re-check it after visiting that screen. "
+            "'gfov %.0f' forces it for this session only.",
+            want);
+}
+
 UeAngles hmd_angles(const bvr::vr::HeadPose& hp) {
     return ue_angles_from_xr_quat(hp.qx, hp.qy, hp.qz, hp.qw);
 }
@@ -1175,6 +1229,7 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
     // scripted cameras bypass CalcView entirely).
     bool strictGameplay = body::is_gameplay_view(viewActor ? *viewActor : nullptr);
     bvr::vr::publish_gameplay_view(strictGameplay);
+    warn_fov_mismatch_once(strictGameplay);
 
     // Controller-bound recenter: the XR action layer raises a latch on the
     // render thread when the bound gesture fires (core/input/xinput_bridge.h);

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -847,6 +847,47 @@ void save_vr_preset() {
     aim::save_weapon_profiles();
 }
 
+// The three preferences that must be known BEFORE the preset is armed.
+//
+// load_vr_preset_values() only runs from apply_vr_preset(), which is exactly
+// the thing autoPresetOnGameplay is supposed to trigger - read the flag there
+// and it can never bootstrap itself (measured: the flag persisted correctly and
+// was never honoured on the next launch). recenterBind has the same shape: the
+// XR action layer consumes it whether or not the preset has been armed.
+//
+// Deliberately a SEPARATE, narrow reader rather than hoisting the whole value
+// load to init: applying every persisted slider at startup would change what
+// the mod does before the preset is pressed, which is not this change's job.
+void load_startup_prefs() {
+    wchar_t path[MAX_PATH];
+    vr_preset_path(path, MAX_PATH);
+    FILE* f = nullptr;
+    if (_wfopen_s(&f, path, L"r") != 0 || !f) return; // no file = shipped defaults
+    char line[128];
+    while (fgets(line, sizeof line, f)) {
+        char key[48] = {};
+        float v = 0.0f;
+        if (sscanf_s(line, "%47[^=]=%f", key, static_cast<unsigned>(sizeof key), &v) != 2)
+            continue;
+        if (strcmp(key, "autoPresetOnGameplay") == 0)
+            g_autoPresetOnGameplay.store(v != 0.0f, std::memory_order_relaxed);
+        else if (strcmp(key, "autoRecenterOnGameplay") == 0)
+            g_autoRecenterOnGameplay.store(v != 0.0f, std::memory_order_relaxed);
+        else if (strcmp(key, "recenterBind") == 0) {
+            const int rb = static_cast<int>(v);
+            if (rb >= 0 && rb <= 2)
+                bvr::input::set_recenter_bind(static_cast<bvr::input::RecenterBind>(rb));
+        }
+    }
+    fclose(f);
+    if (g_autoPresetOnGameplay.load(std::memory_order_relaxed) ||
+        g_autoRecenterOnGameplay.load(std::memory_order_relaxed))
+        BVR_LOG("[b1r] startup prefs: autopreset=%d autorecenter=%d recenterBind=%d",
+                g_autoPresetOnGameplay.load(std::memory_order_relaxed) ? 1 : 0,
+                g_autoRecenterOnGameplay.load(std::memory_order_relaxed) ? 1 : 0,
+                static_cast<int>(bvr::input::recenter_bind()));
+}
+
 void load_vr_preset_values() {
     wchar_t path[MAX_PATH];
     vr_preset_path(path, MAX_PATH);
@@ -1933,6 +1974,7 @@ bool install(void* eventPlayerCalcView) {
     g_target = eventPlayerCalcView;
     g_hookLive.store(true, std::memory_order_relaxed);
     BVR_LOG("[b1r] calcview hook installed (target %p)", eventPlayerCalcView);
+    load_startup_prefs(); // must precede any auto-arm decision (see the reader)
     return true;
 }
 

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -120,6 +120,9 @@ std::atomic<bool>  g_autoRecenterOnGameplay{false};
 // launch, which is the one thing a player in a headset cannot reach. Firing it
 // on the first gameplay transition is exactly when a human presses it.
 std::atomic<bool>  g_autoPresetOnGameplay{false};
+// Seated play (default OFF): ignore the vertical component of the head offset,
+// pinning eye height to the game's own camera. See the note at its use site.
+std::atomic<bool>  g_heightLock{false};
 std::atomic<bool>  g_vrDriving{false};         // telemetry for the UI
 std::atomic<bool>  g_forceHeadsetFov{false};   // session 4: now writes the REAL control (the
                                                // UShockUserSettings HorizontalFOV int that the
@@ -394,6 +397,17 @@ void apply_command(const char* cmd, const char* args) {
         BVR_LOG("[b1r] command: recenter");
     } else if (strcmp(cmd, "vrpopup") == 0) {
         startup_dialog::handle_command(args); // logs its own echo
+    } else if (strcmp(cmd, "heightlock") == 0) {
+        if (strncmp(args, "on", 2) == 0)
+            g_heightLock.store(true, std::memory_order_relaxed);
+        else if (strncmp(args, "off", 3) == 0)
+            g_heightLock.store(false, std::memory_order_relaxed);
+        BVR_LOG("[b1r] height lock: %s (heightlock on|off) - %s",
+                g_heightLock.load(std::memory_order_relaxed) ? "ON" : "off",
+                g_heightLock.load(std::memory_order_relaxed)
+                    ? "eye height is pinned to the game camera; sitting or standing "
+                      "no longer changes it (lean still works)"
+                    : "eye height follows your real head, relative to the last recenter");
     } else if (strcmp(cmd, "autopreset") == 0) {
         if (strncmp(args, "on", 2) == 0)
             g_autoPresetOnGameplay.store(true, std::memory_order_relaxed);
@@ -810,6 +824,7 @@ void save_vr_preset() {
             g_autoRecenterOnGameplay.load(std::memory_order_relaxed) ? 1 : 0);
     fprintf(f, "autoPresetOnGameplay=%d\n",
             g_autoPresetOnGameplay.load(std::memory_order_relaxed) ? 1 : 0);
+    fprintf(f, "heightLock=%d\n", g_heightLock.load(std::memory_order_relaxed) ? 1 : 0);
     fprintf(f, "swingOn=%d\n", bvr::input::swing::enabled() ? 1 : 0);
     fprintf(f, "swingThreshold=%.2f\n", bvr::input::swing::threshold_ms());
     fprintf(f, "swingRearm=%.2f\n", bvr::input::swing::rearm_ms());
@@ -952,6 +967,8 @@ void load_vr_preset_values() {
             g_autoRecenterOnGameplay.store(v != 0.0f, std::memory_order_relaxed);
         else if (strcmp(key, "autoPresetOnGameplay") == 0)
             g_autoPresetOnGameplay.store(v != 0.0f, std::memory_order_relaxed);
+        else if (strcmp(key, "heightLock") == 0)
+            g_heightLock.store(v != 0.0f, std::memory_order_relaxed);
         else if (strcmp(key, "recenterBind") == 0) {
             const int rb = static_cast<int>(v);
             if (rb >= 0 && rb <= 2)
@@ -1453,7 +1470,18 @@ void __fastcall CalcViewDetour(void* self, void* edx, void** viewActor,
         float cg = cosf(gameYawRad), sg = sinf(gameYawRad);
         float ox = (lx * cg - ly * sg) * scale;
         float oy = (lx * sg + ly * cg) * scale;
-        float oz = d[2] * scale;
+        // Height lock: drop the VERTICAL head offset entirely, so the eye sits
+        // at the game's OWN camera height no matter how high the player's real
+        // head is. Lean (x/y) is untouched - peeking round a corner still works.
+        //
+        // Without it, eye height is real-head-height relative to whatever pose
+        // the last recenter captured, and at the default worldScale of 100 UU/m
+        // that is brutal: sitting down after a standing recenter drops the head
+        // ~0.4 m = ~40 UU, against an in-game eye height of only ~60-70 UU. The
+        // player ends up at waist level. Recentering again fixes it, but only
+        // until the next posture change; this removes the coupling instead.
+        float oz = g_heightLock.load(std::memory_order_relaxed) ? 0.0f
+                                                                : d[2] * scale;
         loc->x += ox;
         loc->y += oy;
         loc->z += oz;
@@ -2240,6 +2268,14 @@ void draw_debug_ui() {
         atomic_slider("Head offset fwd (UU)", g_headOffFwdUu, -80.0f, 80.0f);
         if (ImGui::Button("Recenter (seated pose + view yaw)"))
             g_recenterRequested.store(true, std::memory_order_relaxed);
+        bool hLock = g_heightLock.load(std::memory_order_relaxed);
+        if (ImGui::Checkbox("Lock eye height to the game camera (seated play)", &hLock))
+            g_heightLock.store(hLock, std::memory_order_relaxed);
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Ignores how high your real head is, so sitting down does\n"
+                              "not sink you toward the floor and standing does not raise you.\n"
+                              "Leaning still works. At worldScale 100, sitting after a\n"
+                              "standing recenter costs ~40 UU against a ~65 UU eye height.");
         bool autoPre = g_autoPresetOnGameplay.load(std::memory_order_relaxed);
         if (ImGui::Checkbox("Auto-arm VR PRESET 1 on entering gameplay", &autoPre))
             g_autoPresetOnGameplay.store(autoPre, std::memory_order_relaxed);

--- a/src/game/bioshock1r/startup_dialog.cpp
+++ b/src/game/bioshock1r/startup_dialog.cpp
@@ -23,7 +23,11 @@ constexpr uint32_t kPollMs = 100;
 const char* kDialogClass = "#32770";
 const char* kDialogTitle = "Message";
 
-std::atomic<bool> g_enabled{true};
+// Default OFF. Answering a dialog on the player's behalf is a product
+// decision, not a bug fix - some people will want to see it. The watcher
+// thread still starts (so a pref loaded a few ms later can enable it
+// inside the startup window), it simply does nothing until asked.
+std::atomic<bool> g_enabled{false};
 std::atomic<bool> g_watching{false};
 std::atomic<uint32_t> g_dismissed{0};
 uint64_t g_initMs = 0;
@@ -79,10 +83,12 @@ void init() {
     }
     CloseHandle(t);
     g_watching.store(true, std::memory_order_relaxed);
-    BVR_LOG("[b1r] startup dialog watcher armed (%u s) - the post-crash "
-            "revert-Options prompt is answered No in-process, so it cannot sit "
-            "between you and the headset ('vrpopup off' to disable)",
-            static_cast<unsigned>(kStartupWindowMs / 1000));
+    BVR_LOG("[b1r] startup dialog watcher started (%u s window) - currently %s. "
+            "When on, the post-crash revert-Options prompt is answered No "
+            "in-process instead of blocking the first Present until someone "
+            "finds a mouse ('vrpopup on', or popupDismiss=1 in vrpreset.ini)",
+            static_cast<unsigned>(kStartupWindowMs / 1000),
+            g_enabled.load(std::memory_order_relaxed) ? "ON" : "off");
 }
 
 bool enabled() { return g_enabled.load(std::memory_order_relaxed); }

--- a/src/game/bioshock1r/startup_dialog.cpp
+++ b/src/game/bioshock1r/startup_dialog.cpp
@@ -1,0 +1,104 @@
+#include "game/bioshock1r/startup_dialog.h"
+
+#include "core/util/log.h"
+
+#include <windows.h>
+
+#include <atomic>
+#include <cstring>
+
+namespace bvr::b1r::startup_dialog {
+namespace {
+
+// How long after mod init the watcher looks for the prompt. The dialog blocks
+// the FIRST Present, so it always lands inside the first few seconds; the
+// window is generous only because a cold shader cache can stretch startup a
+// long way. Once it closes, the game's dialogs behave exactly as they always
+// did - an in-game "overwrite this save?" must never be answered by a mod.
+constexpr uint64_t kStartupWindowMs = 180000;
+constexpr uint32_t kPollMs = 100;
+
+// The prompt's window class and title on this build. "#32770" is the standard
+// dialog class; the title really is the literal "Message", not the game name.
+const char* kDialogClass = "#32770";
+const char* kDialogTitle = "Message";
+
+std::atomic<bool> g_enabled{true};
+std::atomic<bool> g_watching{false};
+std::atomic<uint32_t> g_dismissed{0};
+uint64_t g_initMs = 0;
+
+// MessageBoxA/W are NOT the API behind this prompt - hooking both and watching
+// them never fire is how that was established (they armed 137 ms into the
+// process, long before the dialog appears). Rather than guess at the rest of
+// the dialog-creation surface, the watcher answers the WINDOW, which is what
+// the mod's own harness has always done from outside the process and is
+// therefore already proven on this build.
+bool try_dismiss() {
+    HWND dlg = FindWindowA(kDialogClass, kDialogTitle);
+    if (!dlg) return false;
+
+    // Only ever click a button that says No. If the prompt ever changes shape,
+    // the watcher does nothing instead of pressing something unknown.
+    HWND child = nullptr;
+    while ((child = FindWindowExA(dlg, child, "Button", nullptr)) != nullptr) {
+        char text[64] = {};
+        GetWindowTextA(child, text, sizeof text - 1);
+        if (_stricmp(text, "&No") == 0 || _stricmp(text, "No") == 0) {
+            SendMessageA(child, BM_CLICK, 0, 0);
+            g_dismissed.fetch_add(1, std::memory_order_relaxed);
+            BVR_LOG("[b1r] startup dialog: answered No to the '%s' prompt - this is "
+                    "the revert-Options box the game raises after an unclean exit "
+                    "(a crash or a force-kill). 'vrpopup off' leaves it alone.",
+                    kDialogTitle);
+            return true;
+        }
+    }
+    return false;
+}
+
+DWORD WINAPI watch_thread(LPVOID) {
+    while (GetTickCount64() - g_initMs <= kStartupWindowMs) {
+        if (g_enabled.load(std::memory_order_relaxed) && try_dismiss()) break;
+        Sleep(kPollMs);
+    }
+    g_watching.store(false, std::memory_order_relaxed);
+    return 0;
+}
+
+} // namespace
+
+void init() {
+    g_initMs = GetTickCount64();
+    HANDLE t = CreateThread(nullptr, 0, watch_thread, nullptr, 0, nullptr);
+    if (!t) {
+        BVR_LOG("[b1r] startup dialog: watcher thread failed (%lu) - the "
+                "revert-Options prompt will need a mouse as usual",
+                GetLastError());
+        return;
+    }
+    CloseHandle(t);
+    g_watching.store(true, std::memory_order_relaxed);
+    BVR_LOG("[b1r] startup dialog watcher armed (%u s) - the post-crash "
+            "revert-Options prompt is answered No in-process, so it cannot sit "
+            "between you and the headset ('vrpopup off' to disable)",
+            static_cast<unsigned>(kStartupWindowMs / 1000));
+}
+
+bool enabled() { return g_enabled.load(std::memory_order_relaxed); }
+void set_enabled(bool on) { g_enabled.store(on, std::memory_order_relaxed); }
+
+void handle_command(const char* args) {
+    if (strncmp(args, "on", 2) == 0) set_enabled(true);
+    else if (strncmp(args, "off", 3) == 0) set_enabled(false);
+    const uint64_t age = GetTickCount64() - g_initMs;
+    BVR_LOG("[b1r] vrpopup %s | watching=%d dismissed=%u | startup window %s "
+            "(%llu s of %u elapsed) (vrpopup on|off|status)",
+            enabled() ? "ON" : "off", g_watching.load(std::memory_order_relaxed) ? 1 : 0,
+            g_dismissed.load(std::memory_order_relaxed),
+            age <= kStartupWindowMs ? "OPEN" : "closed",
+            static_cast<unsigned long long>(age / 1000),
+            static_cast<unsigned>(kStartupWindowMs / 1000));
+}
+
+} // namespace bvr::b1r::startup_dialog

--- a/src/game/bioshock1r/startup_dialog.h
+++ b/src/game/bioshock1r/startup_dialog.h
@@ -1,0 +1,36 @@
+#pragma once
+// Suppress the "revert Options?" modal the game raises after an unclean exit.
+//
+// WHY THIS EXISTS. Any force-kill - and, more to the point, any CRASH - makes
+// the next launch open a `#32770` "Message" box asking whether to revert the
+// video options. It blocks the first Present entirely (the game reports alive
+// with presents=0/s until it is dismissed), and answering it needs a mouse or
+// keyboard. That is fine at a desk and useless in a headset: the player is
+// already wearing the HMD, the game is not rendering to it yet, and the only
+// way forward is to take the headset off.
+//
+// The mod's own harness has always dismissed it externally (`boot.ps1` clicks
+// the `&No` button through `BM_CLICK`), which is the proof that answering No is
+// both correct and safe - this just moves that answer inside the process, where
+// it works whether or not a harness is running.
+//
+// SCOPE. A watcher thread, only inside a startup window measured from mod init,
+// that clicks a button only if it says No, and logs every dismissal. It does
+// NOT hook the dialog APIs: MessageBoxA/W were hooked first and measured never
+// to fire for this prompt (they armed 137 ms into the process, long before the
+// box appears), so the window itself is the reliable handle on it.
+// `vrpopup off` restores the stock behaviour for the rest of the session.
+
+namespace bvr::b1r::startup_dialog {
+
+// Start the watcher thread. Fail-soft: a failed thread create logs and leaves
+// the stock dialog alone. Call once from the adapter's init.
+void init();
+
+bool enabled();
+void set_enabled(bool on);
+
+// "vrpopup on|off|status"
+void handle_command(const char* args);
+
+} // namespace bvr::b1r::startup_dialog

--- a/tools/fit-worldscale.py
+++ b/tools/fit-worldscale.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Measure worldScale (Unreal units per real metre) from a `vrscale` capture.
+
+WHY THIS IS NOT CIRCULAR. Almost every way of checking worldScale feeds the
+setting back into its own answer: ask the mod how far your hand moved and it
+replies `metres * worldScale` by construction. Gravity does not have that
+problem - it is the engine's own physics, measured in UU/s^2, and real gravity
+is 9.81 m/s^2 whatever the mod thinks. So:
+
+    UU per metre = |measured gravity| / 9.81
+
+Unreal's default zone gravity of -950 UU/s^2 implies ~97 UU/m, which is the
+same ballpark as the ~100 upstream measured by a different method (a known-
+distance hand sweep read off an engine-owned coordinate) - see
+docs/bioshock2/ENGINE_NOTES.md.
+
+HOW TO CAPTURE
+    tools\\game-cmd.ps1 "vrscale 20"
+  then, in game, JUMP five or six times on flat ground, or drop off a ledge -
+  a long fall is the best signal there is. Then:
+    python tools\\fit-worldscale.py
+
+METHOD. The capture logs the ENGINE's camera z per CalcView with a QPC
+timestamp. This fits z(t) = z0 + v0*t + 0.5*a*t^2 by least squares over each
+airborne arc - a whole-arc fit, NOT a double difference of position, because
+differentiating frame-to-frame samples twice amplifies noise so badly that a
+lift decelerating reads as gravity (it did, on the first attempt: 12 noisy
+samples claimed 286 UU/m).
+
+Arcs are only accepted when the fit is actually parabolic (low RMS residual),
+which is what rejects lifts, stairs, slopes and view bob.
+"""
+
+import argparse
+import os
+import re
+import statistics
+import sys
+
+SAMPLE = re.compile(r"\[vrscale\] t=([\d.]+) z=([-\d.]+)")
+
+# An arc has to be airborne (moving vertically), long enough to fit, and clean.
+MIN_SPEED_UU_S = 40.0   # below this the player is walking, bobbing or still
+MIN_POINTS = 10
+MAX_RMS_UU = 1.5        # a real ballistic arc fits far tighter than this
+GRAVITY_MS2 = 9.81
+
+
+def load(path):
+    with open(path, errors="ignore") as f:
+        pts = [(float(t), float(z)) for t, z in SAMPLE.findall(f.read())]
+    if not pts:
+        sys.exit(f"no [vrscale] samples in {path}\n"
+                 "Arm one with:  tools\\game-cmd.ps1 \"vrscale 20\"")
+    t0 = pts[0][0]
+    return [(t - t0, z) for t, z in pts]
+
+
+def fit_quadratic(pts):
+    """Least-squares z = a*t^2 + b*t + c. Returns (a, b, c, rms)."""
+    n = len(pts)
+    sx = sx2 = sx3 = sx4 = sy = sxy = sx2y = 0.0
+    for x, y in pts:
+        x2 = x * x
+        sx += x; sx2 += x2; sx3 += x2 * x; sx4 += x2 * x2
+        sy += y; sxy += x * y; sx2y += x2 * y
+    # 3x3 solve by Cramer's rule - no numpy dependency for one small system.
+    m = [[sx4, sx3, sx2], [sx3, sx2, sx], [sx2, sx, float(n)]]
+    v = [sx2y, sxy, sy]
+
+    def det3(a):
+        return (a[0][0] * (a[1][1] * a[2][2] - a[1][2] * a[2][1])
+                - a[0][1] * (a[1][0] * a[2][2] - a[1][2] * a[2][0])
+                + a[0][2] * (a[1][0] * a[2][1] - a[1][1] * a[2][0]))
+
+    d = det3(m)
+    if abs(d) < 1e-9:
+        return None
+    coef = []
+    for i in range(3):
+        mi = [row[:] for row in m]
+        for r in range(3):
+            mi[r][i] = v[r]
+        coef.append(det3(mi) / d)
+    a, b, c = coef
+    rms = (sum((y - (a * x * x + b * x + c)) ** 2 for x, y in pts) / n) ** 0.5
+    return a, b, c, rms
+
+
+def arcs(samples):
+    """Contiguous runs where the camera is genuinely moving vertically."""
+    vel = []
+    for (ta, za), (tb, zb) in zip(samples, samples[1:]):
+        dt = tb - ta
+        vel.append(abs((zb - za) / dt) if dt > 1e-6 else 0.0)
+    out, cur = [], []
+    for i, v in enumerate(vel):
+        if v > MIN_SPEED_UU_S:
+            cur.append(i)
+        else:
+            if len(cur) >= MIN_POINTS:
+                out.append((cur[0], cur[-1] + 2))
+            cur = []
+    if len(cur) >= MIN_POINTS:
+        out.append((cur[0], cur[-1] + 2))
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("log", nargs="?", default=os.path.join(
+        os.environ.get("LOCALAPPDATA", ""), "BioshockVR", "bioshockvr.log"))
+    ap.add_argument("--worldscale", type=float, default=100.0,
+                    help="the value currently configured, for comparison")
+    a = ap.parse_args()
+
+    s = load(a.log)
+    print(f"{len(s)} samples over {s[-1][0]:.1f}s, "
+          f"z {min(z for _, z in s):.1f}..{max(z for _, z in s):.1f} UU")
+
+    good = []
+    for lo, hi in arcs(s):
+        seg = s[lo:hi]
+        if len(seg) < MIN_POINTS:
+            continue
+        mid = seg[len(seg) // 2][0]
+        f = fit_quadratic([(t - mid, z) for t, z in seg])
+        if not f:
+            continue
+        accel = 2.0 * f[0]
+        if accel < -100.0 and f[3] <= MAX_RMS_UU:
+            good.append((accel, len(seg), f[3], seg[0][0]))
+
+    if not good:
+        print("\nNo clean ballistic arcs found.")
+        print("The capture needs the player actually airborne - jump on flat")
+        print("ground, or drop off a ledge. Lifts, stairs and slopes are")
+        print("rejected on purpose: they are not parabolic.")
+        return
+
+    print(f"\n{len(good)} clean arc(s):")
+    for accel, n, rms, t in sorted(good, key=lambda g: g[3]):
+        print(f"  t={t:6.2f}s  n={n:3d}  rms={rms:4.2f} UU  "
+              f"accel={accel:9.1f} UU/s^2  -> {abs(accel)/GRAVITY_MS2:6.1f} UU/m")
+
+    med = statistics.median([g[0] for g in good])
+    uu_per_m = abs(med) / GRAVITY_MS2
+    print(f"\nmedian gravity : {med:.1f} UU/s^2")
+    print(f"UU per metre   : {uu_per_m:.1f}")
+    print(f"worldScale set : {a.worldscale:.0f}")
+    ratio = uu_per_m / a.worldscale if a.worldscale else 0.0
+    if 0.9 <= ratio <= 1.1:
+        print(f"VERDICT: consistent (within {abs(1-ratio)*100:.0f}%) - leave it alone.")
+    else:
+        print(f"VERDICT: MISMATCH by {ratio:.2f}x - worldScale would want ~{uu_per_m:.0f}.")
+        print("Before acting on this, sanity-check it against the game's own")
+        print("gravity if you can read it: a game tuned to non-real gravity")
+        print("breaks the 9.81 assumption this whole method rests on.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/fit-worldscale.py
+++ b/tools/fit-worldscale.py
@@ -87,12 +87,43 @@ def fit_quadratic(pts):
     return a, b, c, rms
 
 
+BIN_S = 0.010   # resample step: 10 ms
+
+
+def rebin(samples):
+    """Average samples into fixed 10 ms bins before any differencing.
+
+    Necessary because the capture rate is wildly variable: paced in VR it is
+    ~90-190 Hz, but flat and unpaced the engine calls CalcView ~1750 times a
+    second (median gap 0.57 ms, measured). Differencing adjacent samples at
+    that spacing is dominated by the 0.001 UU log quantisation, which is how a
+    first pass reported |dz/dt| peaks of 38000 UU/s. Binning first makes the
+    velocity estimate independent of frame rate.
+    """
+    out, bucket, edge = [], [], None
+    for t, z in samples:
+        if edge is None:
+            edge = t
+        if t >= edge + BIN_S:
+            if bucket:
+                out.append((edge + BIN_S / 2.0, sum(bucket) / len(bucket)))
+            # skip empty bins rather than interpolating across capture gaps
+            while t >= edge + BIN_S:
+                edge += BIN_S
+            bucket = []
+        bucket.append(z)
+    if bucket:
+        out.append((edge + BIN_S / 2.0, sum(bucket) / len(bucket)))
+    return out
+
+
 def arcs(samples):
     """Contiguous runs where the camera is genuinely moving vertically."""
     vel = []
     for (ta, za), (tb, zb) in zip(samples, samples[1:]):
         dt = tb - ta
-        vel.append(abs((zb - za) / dt) if dt > 1e-6 else 0.0)
+        # a gap larger than a few bins means the capture paused - not motion
+        vel.append(abs((zb - za) / dt) if 1e-6 < dt < 0.05 else 0.0)
     out, cur = [], []
     for i, v in enumerate(vel):
         if v > MIN_SPEED_UU_S:
@@ -114,9 +145,11 @@ def main():
                     help="the value currently configured, for comparison")
     a = ap.parse_args()
 
-    s = load(a.log)
-    print(f"{len(s)} samples over {s[-1][0]:.1f}s, "
-          f"z {min(z for _, z in s):.1f}..{max(z for _, z in s):.1f} UU")
+    raw = load(a.log)
+    s = rebin(raw)
+    print(f"{len(raw)} samples over {raw[-1][0]:.1f}s "
+          f"-> {len(s)} bins of {BIN_S*1000:.0f} ms, "
+          f"z {min(z for _, z in raw):.1f}..{max(z for _, z in raw):.1f} UU")
 
     good = []
     for lo, hi in arcs(s):

--- a/tools/launch-game.ps1
+++ b/tools/launch-game.ps1
@@ -62,7 +62,11 @@ if (Get-Process $proc -ErrorAction SilentlyContinue) {
 # --- guard 2: stale command file ---------------------------------------------
 $cmd = Join-Path $dir "command.txt"
 if (Test-Path $cmd) {
-    $stale = (Get-Content $cmd -Raw).Trim()
+    # -Raw returns $null on a zero-byte file, and .Trim() on null throws
+    # "You cannot call a method on a null-valued expression", which fails the
+    # whole preflight and blocks the launch. An empty seam file is a normal
+    # state (anything that clears it by writing "" rather than deleting it).
+    $stale = ([string](Get-Content $cmd -Raw)).Trim()
     Remove-Item $cmd -Force
     if ($stale) { Write-Output "cleared a stale command.txt (would have re-applied at boot): $stale" }
 }

--- a/tools/vr-cmd.ps1
+++ b/tools/vr-cmd.ps1
@@ -1,0 +1,86 @@
+# vr-cmd.ps1 - send seam commands to a game that is being played IN A HEADSET.
+#
+# WHY THIS EXISTS ALONGSIDE game-cmd.ps1. game-cmd.ps1 always calls
+# SetForegroundWindow before writing. That is right for a flat harness run and
+# wrong for a headset session: stealing focus can drop the XR session out of
+# FOCUSED (session 33), at which point the mod publishes an inactive pad, the
+# controllers go dead, and the game may pause - in the middle of the thing you
+# were trying to tune. It has no -NoFocus switch, so this is the no-focus twin.
+#
+# The mod polls %LOCALAPPDATA%\BioshockVR\command.txt at 1 Hz on the game
+# thread and applies every line when the file's write time changes, so writing
+# the file is the whole mechanism. No focus change is needed or wanted.
+#
+# It also CONFIRMS the command landed, which game-cmd.ps1 does not: it watches
+# the log for new lines and reports what appeared. A command that silently did
+# nothing - because the game was at the title screen, or paused, or the verb was
+# a typo - otherwise looks identical to one that worked, and that has already
+# cost one debugging session here.
+#
+# Usage:
+#   .\tools\vr-cmd.ps1 "headoff up 25"
+#   .\tools\vr-cmd.ps1 "vraim laser on" "vraim muzzle on"
+#   .\tools\vr-cmd.ps1 -Quiet "recenter"
+[CmdletBinding(PositionalBinding = $false)]
+param(
+    [ValidateSet("bs1", "bs2")][string]$Game = "bs1",
+    [double]$WaitSec = 4.0,
+    [switch]$Quiet,
+    [Parameter(ValueFromRemainingArguments = $true)][string[]]$Lines
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $Lines -or $Lines.Count -eq 0) { throw "no commands given." }
+
+$dir = if ($Game -eq "bs2") { "$env:LOCALAPPDATA\BioshockVR\bs2" }
+       else { "$env:LOCALAPPDATA\BioshockVR" }
+$cmd = Join-Path $dir "command.txt"
+$log = Join-Path $dir "bioshockvr.log"
+
+$proc = if ($Game -eq "bs2") { "Bioshock2HD" } else { "BioshockHD" }
+$p = @(Get-Process $proc -ErrorAction SilentlyContinue | Where-Object { -not $_.HasExited })
+if ($p.Count -eq 0) {
+    Write-Warning "$proc is not running - the file will be written and applied at the NEXT launch."
+    Write-Warning "Note that tools\launch-game.ps1 and xrsim-launch.ps1 DELETE command.txt in preflight;"
+    Write-Warning "only a direct/Steam launch will see it."
+}
+
+# Where the log ends now, so we can report only what this command produced.
+$before = 0
+if (Test-Path $log) { $before = (Get-Item $log).Length }
+
+[System.IO.File]::WriteAllText($cmd, (($Lines -join "`n") + "`n"),
+                               [System.Text.Encoding]::ASCII)
+if (-not $Quiet) { Write-Output ("sent: " + ($Lines -join " | ")) }
+
+if ($p.Count -eq 0 -or $WaitSec -le 0) { return }
+
+# The poll is 1 Hz on the game thread, so anything under ~2 s is a false negative.
+$deadline = (Get-Date).AddSeconds($WaitSec)
+$seen = $false
+while ((Get-Date) -lt $deadline) {
+    Start-Sleep -Milliseconds 400
+    if (-not (Test-Path $log)) { continue }
+    if ((Get-Item $log).Length -gt $before) { $seen = $true; break }
+}
+
+if (-not $seen) {
+    Write-Warning "no new log output in ${WaitSec}s - the command may not have been applied."
+    Write-Warning "The seam only polls while CalcView runs: at the title screen, or while the"
+    Write-Warning "game is paused or unfocused, commands sit unapplied until gameplay resumes."
+    return
+}
+
+if (-not $Quiet) {
+    $fs = [System.IO.File]::Open($log, 'Open', 'Read', 'ReadWrite')
+    try {
+        $fs.Seek($before, 'Begin') | Out-Null
+        $sr = New-Object System.IO.StreamReader($fs)
+        $new = $sr.ReadToEnd() -split "`r?`n" | Where-Object { $_ }
+    } finally { $fs.Dispose() }
+    # Echo the lines the mod logged in response, skipping the routine per-second
+    # telemetry that would otherwise bury them.
+    $new | Where-Object { $_ -notmatch '\[reentry\]|input drive:|camera: loc=|\[vrscale\]' } |
+        Select-Object -Last 12 | ForEach-Object { "  $_" }
+}


### PR DESCRIPTION
Thanks for this mod - it is the reason BioShock is playable in a headset at all, and the
docs in `docs/` made every one of these changes findable rather than guesswork.

All of this came out of playing untethered on a Quest 3, where the recurring problem was
that several controls only exist behind F10, and F10 needs a keyboard I cannot reach with
the headset on. Everything here is additive and BioShock 1 only; BS2 is untouched.

**Nothing changes for an existing install.** The two settings that would have altered
stock behaviour (`recenterBind`, `popupDismiss`) default to **off** - whether the mod should
claim more controller inputs, or answer a dialog on the player's behalf, felt like your
calls to make rather than mine. Every new setting has an F10 control with a tooltip, and
persists through `vrpreset.ini` like the rest.

Happy to split this into separate PRs, drop any part, or rename verbs to taste. The two
fixes are the parts I would most want you to look at even if the features are not wanted.

---

### 1. Controller-bound recenter (the main one)

Recenter is reachable three ways today - the overlay button, the `recenter` seam command,
and the auto-recenter on first drive - and the first two need a keyboard. Standing or
seated away from the desk, drift becomes unrecoverable without breaking the session.

The runtime's own recenter is not a workaround, and I think this is worth a README note
even if the rest is rejected: Virtual Desktop often eats the Meta long-press, and when it
does fire it moves the `LOCAL` reference space out from under `g_recenterYawUnits`, which
was captured against the old space - so the world lands on a wrong heading. It is actively
harmful here, not merely unhelpful.

**Binding: right thumbrest touch + right stick click.** Both are already suggested on
`oculus/touch_controller` and both are free, so this needs no new action and no new
binding - only a new consumer:

- `g_thumbrestR` is created, bound and polled, but only `restL` is ever consumed (the ammo
  modifier is deliberately the left pad, per your comment in `openxr_input.cpp`).
- RS-click never reaches the game - the ammo block says so explicitly.

It also mirrors the existing left-thumbrest-as-modifier idiom rather than inventing one.

Guards, all of which turned out to be necessary rather than decorative:

1. **Gameplay view only** - firing while an authored cutscene camera drives is the case
   most likely to look broken.
2. **500 ms cooldown** - a recenter calls `body::on_reset()` and re-probes the transfer.
3. **Never shares the stick click with ammo select.** `vrinput ammomod click|both`
   reassigns that button; when it does, the bind stands down and logs why. The guard
   re-derives the ammo block's *own* predicate rather than approximating it, so the two
   cannot drift apart.
4. **Except with an ammoless weapon** (the wrench), where the modifier has nothing to
   select and the click is free to borrow. This is what makes it usable in the first
   seconds of a session, before a left-thumbrest touch has been observed.

```
vrinput recenterbind thumbrest|click|off     # default off
```

`click` is a fallback - hold the right stick click ~1 s - for thumbs that cannot reach the
pad and the stick at once. Your own comment notes a right thumb cannot rest on the right
pad and *push* the right stick simultaneously; clicking is a different motion, so the chord
is plausible, but the fallback costs one enum value and removes the risk. In practice the
chord has worked fine in-headset for me.

---

### 2. Two fixes

**`headoff up/fwd` moved the camera but not the hands.** `baseLoc` is the shared anchor and
the system is otherwise coherent - the camera adds its recenter-relative head offset to it,
the hands add the controller's recenter-relative offset to it, and because both are measured
from the same recenter pose they track each other for free. The head anchor was applied to
the camera further down and never to the base, so a lift raised the eye while the engine
kept placing the hands at its own eye height. At 25 UU that is a 25 cm decoupling and the
weapon visibly stops sitting where the controller points.

Fixed in one place, in the `FrameContext` both consumers read, with the same composition the
camera uses. Measured in the simulator at a fixed player position: hand anchor z **-1050.7**
detached vs **-1025.7** following - exactly the 25 UU lift. `headoff hands off` reverts it
without a rebuild, and with the offsets at 0 the whole path is a no-op, which is why it is
the one thing here that defaults on.

**A preference that could never bootstrap itself.** `load_vr_preset_values()` only runs from
`apply_vr_preset()`, so a flag intended to *trigger* the preset is read only after the thing
it triggers has already happened. It persisted correctly and was silently ignored on every
subsequent launch. Now a narrow reader for the three keys that must be known before anything
can act on them, at hook-install time - deliberately not a hoist of the whole value load,
since applying every persisted slider before the preset is pressed would change what the mod
does by default.

**Also, a harness fix:** `launch-game.ps1` does `(Get-Content $cmd -Raw).Trim()`, and `-Raw`
returns `$null` on a zero-byte file - so an *empty* `command.txt` throws and blocks the
launch entirely. Anything that clears the seam by writing `""` rather than deleting it
produces one.

---

### 3. Opt-in quality of life (all default off)

- **`autopreset`** - arms VR PRESET 1 once, on the first gameplay view, and takes the
  recenter there. `vrpreset.ini` persists the tuned values but nothing persisted the
  toggles, so the preset had to be pressed in the overlay every launch - the one control a
  player already wearing the headset cannot reach.
- **`autorecenter`** - recenter on every menu/cutscene -> gameplay transition, which is
  where heading drift after a load shows up.
- **`heightlock`** - ignore the vertical component of the head offset, pinning eye height to
  the game camera. Lean still works. For seated play where sitting down after a standing
  recenter otherwise costs ~40 UU against a ~65 UU eye height.
- **Synthetic pad armed at startup, under `autopreset` only.** The pad's A button already
  drives the title screen and the save load - it is how `boot.ps1` boots the game - but
  synthetic input stays off until the preset arms it, and the preset cannot arm until a
  gameplay view exists, which needs the menu you cannot press. Breaking that circle makes a
  cold launch reach gameplay in two Touch-A presses with no keyboard or mouse. (It does not
  skip the startup Bink movie; those play out first.)

---

### 4. Diagnostics

**FOV mismatch warning, once, in a gameplay view.** The required hfov and the rendered one
are both logged already, far apart and in different units, and nothing said they disagreed -
while the symptom is black bars for the whole session. It names the resolved ini path, the
section, the key and the value, because the options menu rewrites `HorizontalFOV` on every
video change.

Worth noting how it reads the number, since two other sources are wrong: the settings option
is frequently unavailable (`fovaudit: option=-1` on a normal session) and the frame camera
fov reads the engine default 100 on the title screen, which warns on correctly configured
launches. Both were tried and measured wrong before settling on the decoded scene tangent.

**Post-crash revert-Options prompt** (`vrpopup`, default off). After an unclean exit the
next launch opens a `#32770` "Message" box that blocks the first Present, so the headset
stays black until someone finds a mouse - on exactly the launch after a crash. A watcher
clicks No, bounded to a startup window, and only ever clicks a button whose text is No.
`MessageBoxA`/`MessageBoxW` are **not** the API behind it - I hooked both and measured them
never firing (they armed 137 ms into the process, long before the box appears), so the
window is the reliable handle, which is what `boot.ps1` has always done from outside.

**`vrscale` + `tools/fit-worldscale.py`** - measures `worldScale` from the engine's own
physics rather than from anything the mod computes, by fitting gravity: real gravity is
9.81 m/s² whatever the setting says, so UU-per-metre falls out of the acceleration. It logs
the engine's camera height per CalcView (QPC-timestamped, gated on vertical motion,
auto-disarming) and the script fits `z = z0 + v0t + at²/2` over whole airborne arcs.

For what it is worth, on my install the fit lands near 150 UU/m rather than the configured
100. I have deliberately **not** changed the default: the method assumes the game tunes
gravity to something near 9.81 m/s², and if it does not, the fit measures that choice
instead. It is included as an instrument, not as an argument for a different number.

---

### 5. Reachable without the overlay

`headoff` and `worldscale` were overlay-only sliders, which means a keyboard. Both now have
seam commands, and `tools/vr-cmd.ps1` sends commands **without** foregrounding the window -
`game-cmd.ps1` always steals focus, which can drop the XR session out of `FOCUSED` and kill
controller input mid-session, and it has no `-NoFocus` switch. It also reports the log lines
a command produced, since a command that silently did nothing (sent at the title screen, or
while paused) otherwise looks identical to one that worked.

---

### Verification

Everything was verified against `tools\xrsim-*` rather than by asking anyone to put a headset
on, per `CLAUDE.md`:

- recenter end to end (gesture -> request -> `vr camera recentered`, 4 ms), the 500 ms
  cooldown collapsing a double edge, `ammomod click` standing the bind down, the wrench
  borrow arming *and* firing, the gesture refused at the title screen, the `click` hold
  fallback firing on ~1 s and ignoring a short click, `recenterBind` round-tripping
- both FOV branches, mismatch and match
- the revert-Options prompt dismissed in-process
- a cold launch reaching gameplay on controller A alone, then auto-arming and recentering
- the hand-anchor fix measured numerically, above

In-headset: the chord fires and is comfortable, and a 14-minute session held 72 fps with no
faults.

Not verified: BS2 (untouched), and anything about other headsets - the chord uses standard
`touch_controller` paths, but I only have a Quest 3.
