### PR TITLE
BS1: bathysphere world FOV, and near walls dropping to the anchored quad

### DIFF
--- a/docs/bioshock1/ENGINE_NOTES.md
+++ b/docs/bioshock1/ENGINE_NOTES.md
@@ -4401,3 +4401,62 @@ constant-vs-varying character of the maximum can.
 
 That is the first time the bone-collapse hide has been exercised end-to-end
 without freezing, which is what `DrawScale3D` could never do.
+
+## Session 65 (2026-08-23) - the world FOV is overridden BELOW CalcView
+
+### The bathysphere renders 80 deg while CalcView reports 100
+
+The "black square" on a bathysphere was never the cinematic quad. Falsified
+directly: `vrcine off` kills `g_cineActive` outright and the box survived it.
+
+What actually happens, measured on the frame the player presses A:
+
+```
+19:48:40.950  scripted: forced move BEGAN  (ctl+0x9E0 = 1)
+19:48:40.957  fov watch: WORLD tanH=0.839100 (hfov 80.00 deg, 12/12 votes)
+19:48:40.966  rendered-fov mismatch ON (rendered 80.0 deg vs option 100.0)
+19:48:40.969  xr: claim substituted from the live WORLD lens (hfov 80.00 deg)
+```
+
+**CalcView reports `fov=100.0` for the entire ride** - every sample, boarding to
+landing. The narrowing therefore happens DOWNSTREAM of CalcView, which is why
+nothing in the camera path could see it and why the fov watch is the only
+instrument that catches it.
+
+The mod's response was correct and was itself the visible defect: it re-claims
+the OpenXR layer at the measured 80 deg, so the image fills 80 deg of a wider
+headset - a correct, full-resolution picture sitting in a box with black around
+it. Reported as "renders in a square, but the resolution is the same".
+
+### The two fields, and they were already in this file
+
+`PC+0x45C` is the world lens and `PC+0x648` its mirror. **Both were already
+derived here for another purpose**: the foreground scene-node ctor is passed
+`float PC+0x45C` (default 75.0) beside `PC+0x460`, and the note on `PC+0x65C`
+records the "75/75/60 fov floats" at `PC+0x648..0x650`. Session 65 only needed
+to WRITE them.
+
+BRVR reached the same two fields independently (`ClampWorldFov`, its
+`WorldFovOffset`/`WorldFovOffset2`) and measured the narrow side as 75.0 -> 60.0.
+**The numbers do not transfer** - this build reads 100 -> 80 - but the offsets
+agreeing with a derivation already in this tree is the corroboration that
+matters.
+
+### Why the guard is gated, and why the gate is not `bathysphere()`
+
+The window is `forced_move() || bathysphere()`. The narrowing lands **1.2 s
+before** the ride flag, on the forced-move frame, so gating on the ride alone
+misses the start - which is precisely the moment the player sees the box appear.
+
+Two things depend on the guard staying narrow:
+
+1. **It would blind the cutscene detector.** One leg of `wantCine` fires when the
+   game renders a different fov than it claims. Clamping globally deletes exactly
+   that evidence - BRVR's own `CONSOLIDATION.md` names this as integration hazard
+   number one for this port.
+2. **Weapon zoom uses the same field.** `Hands::FadeFOV` drives it downward when
+   you scope. A global floor would fight it; you cannot scope on a bathysphere,
+   so the gate removes the conflict rather than special-casing it.
+
+The restored value is SAMPLED, not hardcoded: whatever the lens read while no
+scene owned the camera. That accounts for the user's own FOV option for free.

--- a/docs/bioshock1/ENGINE_NOTES.md
+++ b/docs/bioshock1/ENGINE_NOTES.md
@@ -4460,3 +4460,137 @@ Two things depend on the guard staying narrow:
 
 The restored value is SAMPLED, not hardcoded: whatever the lens read while no
 scene owned the camera. That accounts for the user's own FOV option for free.
+
+## Session 65 (2026-08-23) - the turn jitter, and the wall that looks like a pause menu
+
+### The turn jitter: measured, NOT solved, and the attempt is reverted
+
+Reported as: walking a circle is smooth while the turn stick is barely over, and
+past an exact repeatable threshold it goes jittery. Predates every turn change
+this repo has made. **Six headset runs. The anomaly is real and located; whether
+it is what the player FEELS was never established, and the fix was reverted.**
+
+What is measured and can be relied on:
+
+- **It is not our input.** The composed pad the game actually consumed reads flat
+  to three decimals (`composedRx -0.428..-0.428`) across whole windows in which
+  the engine's yaw rate swings from 5 to 349 deg/s.
+- **It is not the body transfer.** `resid` stayed at 0.00-0.02 deg throughout,
+  the 180 deg/s slew cap never engaged, and the movement stick was never rotated
+  (0 STRADDLE events in 570 samples).
+- **It never stalls.** Zero frames where the yaw failed to advance, in any run.
+- **The engine advances its own yaw unevenly**: about seven normal steps then one
+  of ~2.5x, repeating every **125 ms (8 Hz)**. Confirmed across two different
+  clocks and two frame rates - 8 counted frames at 64/s and 15 at 120/s are both
+  125 ms - so it is time-periodic, not frame-counted.
+- **Frame time amplifies it**, at a fixed stick: 1.98x at 8 ms/frame, 2.11x at 9,
+  2.57x at 10, 3.67x at 12, **5.29x at 13**. So the lag spikes and the turn
+  jitter are the same subject; fixing pacing would reduce the jitter.
+- **There is a separate, real deadzone cliff**: mean turn rate jumps ~5x from
+  3.5 to 16.7 deg/s across |rx| 0.20 -> 0.25, straddling the game's 0.225
+  per-axis deadzone, and the response is nearly flat above it (16.7 at 0.25 to
+  24.6 at 0.45). Worth fixing on its own merits.
+
+**THREE PROBE REVISIONS WERE SPENT MEASURING THE INSTRUMENT.** Recorded because
+the next person will reach for the same clock:
+
+1. `GetTickCount64` has **15.625 ms** resolution and this path runs at ~245/s, so
+   most calls read `dt == 0`. Worse, the sampler updated `prevYaw` before the
+   `dt > 0` guard, so those frames' yaw was DISCARDED. The residue produced a
+   convincing "double step every 8 frames" - which is exactly 8 x 15.625 ms.
+   **Use QueryPerformanceCounter for anything sub-frame.**
+2. A 20 Hz sampler against a ~120 Hz frame cadence aliases: `dt` alternated
+   59/68 ms with the rate alternating against it, which is indistinguishable
+   from a real oscillation. **Accumulate every call; throttle only the summary.**
+3. A summary that resets its accumulators before reading them logs nothing. One
+   whole run produced 38 windows and zero sequences.
+
+**The attempted fix, and why it was abandoned rather than turned off.** A
+view-only spike clipper: clamp the excess of a step over its local average out of
+the yaw CalcView returns (through `yaw_adjust_units()`), and bleed it back over
+the next few frames. Deliberately NOT a field write, which is what kept
+graveyard entries 12, 13 and 16 out of scope entirely rather than merely handled.
+It built and shipped behind an F10 toggle; the player still felt the jitter, and
+the session ended before establishing whether the yaw anomaly is the percept at
+all. **The turn probe could never have answered that** - it reads the engine's
+yaw FIELD, and a view-only correction only changes CalcView's out-parameter, so
+the probe is blind to it by construction.
+
+**The open question, and it is the first thing to settle before any more work:**
+is the jitter the VIEW rotating unevenly, or the DIRECTION OF TRAVEL stepping?
+Everything above measures the view. Graveyard entry 14 is the movement-side
+candidate and is untested for this symptom.
+
+### Walking into a wall drops the view to the cinematic quad
+
+**The bug**: walk into a wall and the world renders in an anchored square exactly
+like the pause menu; the hand renders but cannot be moved; the game keeps
+running. It toggles on and off as the player walks into and away from the wall,
+and it persists if they quit while it is active. Several walls in one area.
+
+**The cause is a hard-coded draw-count threshold**, `hud_capture.cpp`:
+
+```
+ID3D11Resource* scene_leader() {
+    ...
+    // A handful of DSV-bound draws is not a scene (the fg rig pass has ~14);
+    // the world pass has hundreds. 32 is comfortably between.
+    return (best && best->n >= 32) ? best->res : nullptr;
+}
+```
+
+A view filled by one near wall draws too little geometry, the winning render
+target falls under 32 DSV-bound draws, `scene_leader()` returns null, and the
+screen-only verdict trips:
+
+```
+screenOnly = scene_leader() == nullptr && g_swfDrawsThisInterval >= 20
+```
+
+`screenOnly` is an unconditional term in core's `wantCine`, so the projection
+layer drops to the M2 quad - the same path menus use, which is why it looks like
+the pause menu and why the anchored placement is identical.
+
+**Measured 2026-08-23, 19 transitions in one run:**
+
+```
+22:19:19.661 screen-only interval off (swf draws 145, world pass present)
+22:19:19.710 screen-only interval ON  (swf draws 145, world pass absent)
+22:19:19.723 xr: cinematic quad ON (strict=1 stale=0 fovMismatch=0 screenOnly=1 uiPaused=0)
+```
+
+**THE SWF HALF OF THE PREDICATE IS DEAD.** `swf draws 145` is identical on both
+sides of every transition - ordinary gameplay is always far above the 20-draw
+floor, so the guard that was meant to stop single stray draws tripping the
+verdict contributes nothing. In practice `screenOnly == (scene_leader() == null)`.
+
+**`strict=1` throughout**, which is the useful discriminator: the strict gameplay
+verdict held the whole time the quad was up. A momentary world-pass loss while
+the gameplay verdict is TRUE is not a loading screen, and gating on that looks
+more promising than tuning 32 - a threshold has no correct value here, because
+"how much geometry is on screen" is a property of the level, not of the mode.
+
+The 3-interval hysteresis already present (`g_screenOnlyStreak >= 3`) is not
+enough: a wall is not momentary, it lasts as long as the player faces it.
+
+### NOT A BUG: the interact prompt aims with the HEAD, not the controller
+
+Reported 2026-08-23 as a soft lock - the flying turret wedged in the first
+Medical Pavilion door offered no hack prompt while vending machines, lootables
+and money on the ground all did. It was aim, not a defect: the player was not
+looking down far enough at it.
+
+Worth writing down because the false alarm is a good one. The use/interact trace
+is the ENGINE's, so it aims along the engine's view pitch - and in VR that value
+is driven only indirectly, by the session-30 pitch servo steering it toward the
+head through the game's own input path. **Pointing a controller at something
+does nothing for the prompt; you have to physically look at it.** Objects with
+generous use volumes (money, loot, a vending machine you walk into) hide this;
+a small device low in a doorway does not.
+
+If a prompt ever genuinely will not appear, the F10 input section's "Kill
+right-stick pitch under VR" is the A/B: unchecked, the right stick's Y goes back
+to the game as an ordinary look axis and can pitch the engine's view directly.
+If the prompt appears that way and not otherwise, the servo has stalled - it
+fails open to the plain kill, and a frozen engine pitch is invisible until
+something the engine owns aims with it.

--- a/src/core/gfx/hud_capture.cpp
+++ b/src/core/gfx/hud_capture.cpp
@@ -65,6 +65,11 @@ DXGI_FORMAT g_curFmt = DXGI_FORMAT_UNKNOWN;
 // Scene-RT vote: the resource hosting the most DSV-bound DrawIndexed calls.
 struct Vote { ID3D11Resource* res; unsigned n; };
 Vote g_votes[4] = {};
+// s65: the render target we were CONFIDENT about, latched by identity. See the
+// banner on scene_leader() - default off in core, BioShock 1 opts in.
+ID3D11Resource* g_worldRtLatched = nullptr;
+std::atomic<bool> g_sceneLeaderLatch{false};
+std::atomic<uint32_t> g_leaderRescues{0};
 ID3D11Resource* g_hudTarget = nullptr; // set when the tonemap is identified
 bool g_hudThisInterval = false;
 bool g_hadHudLastInterval = false;
@@ -854,14 +859,48 @@ void fov_watch_on_present(ID3D11DeviceContext* ctx) {
     }
 }
 
+// A COUNT CANNOT TELL A THIN WORLD FROM A MENU. IDENTITY CAN.
+//
+// The >= 32 rule asks "did some render target take enough DSV-bound draws to be
+// a scene", and it is right about menus - a hack screen, a loading screen or an
+// FMV draws no world at all. It is WRONG about a wall. Walk into one and the
+// view is a single near surface: the world is still rendered, it is just cheap,
+// and the count falls under the bar. screen_only() then trips and wantCine drops
+// the projection to the M2 quad, so the player gets the pause menu's anchored
+// square mid-gameplay with the hand frozen, toggling as they face the wall.
+//
+// MEASURED 2026-08-23, 19 transitions in one run, "swf draws 145" IDENTICAL on
+// both sides of every one - so the >= 20 swf floor contributes nothing here and
+// the verdict is scene_leader() == nullptr alone.
+//
+// No threshold fixes this: "how much geometry is on screen" is a property of the
+// LEVEL, not the mode, so every number has a wall behind it somewhere. The latch
+// does not lower the bar - it remembers WHICH target was the world while we were
+// confident and keeps calling that target the world while it still draws at all.
+// A menu is still caught, because on a menu that target draws NOTHING.
+//
+// Default off so BS2 and Infinite keep the pre-s65 rule exactly.
 ID3D11Resource* scene_leader() {
     Vote* best = nullptr;
     for (Vote& v : g_votes)
         if (v.res && (!best || v.n > best->n)) best = &v;
     // A handful of DSV-bound draws is not a scene (the fg rig pass has ~14);
     // the world pass has hundreds. 32 is comfortably between.
-    return (best && best->n >= 32) ? best->res : nullptr;
+    if (best && best->n >= 32) {
+        g_worldRtLatched = best->res; // confident: this IS the world target
+        return best->res;
+    }
+    if (g_sceneLeaderLatch.load(std::memory_order_relaxed) && g_worldRtLatched) {
+        for (Vote& v : g_votes) {
+            if (v.res != g_worldRtLatched || v.n == 0) continue;
+            // Same target, still drawing - a thin world, not a menu.
+            g_leaderRescues.fetch_add(1, std::memory_order_relaxed);
+            return v.res;
+        }
+    }
+    return nullptr;
 }
+
 
 bool ensure_rt(ID3D11DeviceContext* ctx, UINT w, UINT h, DXGI_FORMAT fmt) {
     if (g_tex && g_texW == w && g_texH == h) return true;
@@ -1658,6 +1697,21 @@ bool fov_mismatch() {
     return g_fovMismatchOn.load(std::memory_order_relaxed);
 }
 
+void set_scene_leader_latch(bool on) {
+    if (g_sceneLeaderLatch.exchange(on, std::memory_order_relaxed) == on) return;
+    if (!on) g_worldRtLatched = nullptr;
+    BVR_LOG("[hud] scene-leader identity latch %s - a target that was the world "
+            "stays the world while it still draws (stops a near wall reading as a "
+            "menu); rescues so far %u",
+            on ? "ON" : "off", g_leaderRescues.load(std::memory_order_relaxed));
+}
+
+bool scene_leader_latch() { return g_sceneLeaderLatch.load(std::memory_order_relaxed); }
+
+unsigned scene_leader_rescues() {
+    return g_leaderRescues.load(std::memory_order_relaxed);
+}
+
 bool screen_only() {
     return g_screenOnlyOn.load(std::memory_order_relaxed);
 }
@@ -1803,6 +1857,9 @@ void fix_blend_alpha(ID3D11DeviceContext* ctx) {
 }
 
 void release_resources() {
+    // The latch is a bare pointer used ONLY for comparison, never dereferenced -
+    // but a freed address can be reused by another target, so drop it here.
+    g_worldRtLatched = nullptr;
     if (g_srv) { g_srv->Release(); g_srv = nullptr; }
     if (g_rtv) { g_rtv->Release(); g_rtv = nullptr; }
     if (g_tex) { g_tex->Release(); g_tex = nullptr; }

--- a/src/core/gfx/hud_capture.h
+++ b/src/core/gfx/hud_capture.h
@@ -328,6 +328,17 @@ bool backbuffer_dims(unsigned* w, unsigned* h);
 //   postfx_count  lifetime count of post-tonemap draws left IN-FRAME because
 //                 they sample a backbuffer-sized texture (alcohol blur etc.).
 bool screen_only();
+
+// s65: keep calling a render target "the world" while it still draws anything,
+// once it has been confidently identified as the world pass. Without it a near
+// wall draws too little geometry, screen_only() trips, and wantCine drops
+// gameplay to the M2 quad - the pause menu's anchored square, mid-walk.
+//
+// DEFAULT OFF: BS2 and Infinite keep the pre-s65 count-only rule untouched.
+// BioShock 1 opts in from its adapter.
+void set_scene_leader_latch(bool on);
+bool scene_leader_latch();
+unsigned scene_leader_rescues();
 unsigned postfx_count();
 
 // Session 22 round 2: engine-cinematic letterbox (plasmid FMV sequences

--- a/src/game/bioshock1r/bioshock1r_adapter.cpp
+++ b/src/game/bioshock1r/bioshock1r_adapter.cpp
@@ -1,5 +1,6 @@
 #include "game/bioshock1r/bioshock1r_adapter.h"
 
+#include "core/gfx/hud_capture.h"
 #include "core/ui/overlay.h"
 #include "core/util/log.h"
 #include "core/vr/openxr_runtime.h"
@@ -80,12 +81,27 @@ bool Bioshock1RAdapter::init(const bvr::pattern_scan::ProcessImage& image) {
     // the core defaults and delete the block from all three adapters.
     //
     // What each one is, and what off means, is on the declarations in
-    // core/input/xinput_bridge.h and core/ui/overlay.h.
+    // core/input/xinput_bridge.h and core/ui/overlay.h. The scene-leader latch
+    // just below is the same pattern and travels with this block.
     bvr::input::set_flick_fourth_direction(true);   // right flick + the held hint bit
     bvr::input::set_menu_modifier_context_help(true); // modifier + menu -> BACK, held
     bvr::input::set_chord_tap_opens_panel(true);    // both-sticks TAP opens F10
     bvr::input::set_flick_press_threshold(0.5f);    // was 0.65 with no dominance test
     bvr::overlay::set_pad_drive(true);              // ray as cursor, RT as click
+
+    // Walking into a wall must not look like the pause menu (s65). The world
+    // pass is identified by a DSV-bound draw COUNT >= 32, and a view filled by
+    // one near surface draws less than that - so screen_only() tripped, core's
+    // wantCine dropped the projection to the M2 quad, and the player got an
+    // anchored square with a frozen hand, toggling as they faced the wall.
+    // Measured 2026-08-23: 19 transitions in one run, "swf draws 145" identical
+    // on both sides, so the count was the whole verdict.
+    //
+    // The latch keeps calling a target the world while it still draws anything,
+    // once it has been confidently identified as one. BS1 ONLY: BS2 and
+    // Infinite keep the count-only rule until somebody puts a headset on for
+    // them, and then they opt in on this same line.
+    bvr::hud::set_scene_leader_latch(true);
 
     // ---- BioshockVR.ini [VR] keys this adapter owns -------------------------
     // PRECEDENCE, and it is not the obvious one: init() runs BEFORE

--- a/src/game/bioshock1r/camera.cpp
+++ b/src/game/bioshock1r/camera.cpp
@@ -907,6 +907,7 @@ void save_vr_preset() {
     fprintf(f, "scriptedRecentre=%d\n", scripted::scripted_recentre_mode());
     fprintf(f, "scriptedFreezeHands=%d\n", scripted::freeze_hands_in_scenes() ? 1 : 0);
     fprintf(f, "scriptedHideRig=%d\n", scripted::hide_rig_in_scenes() ? 1 : 0);
+    fprintf(f, "scriptedWorldFov=%d\n", scripted::world_fov_guard() ? 1 : 0);
     fprintf(f, "scriptedArmMotion=%.4f\n", scripted::arm_motion_threshold());
     fprintf(f, "scriptedArmHoldMs=%d\n", scripted::arm_hold_ms());
     fprintf(f, "effectsInFrame=%d\n", bvr::hud::effects_in_frame() ? 1 : 0);
@@ -1071,6 +1072,8 @@ void load_vr_preset_values() {
             scripted::set_freeze_hands_in_scenes(v != 0.0f);
         else if (strcmp(key, "scriptedHideRig") == 0)
             scripted::set_hide_rig_in_scenes(v != 0.0f);
+        else if (strcmp(key, "scriptedWorldFov") == 0)
+            scripted::set_world_fov_guard(v != 0.0f);
         else if (strcmp(key, "scriptedArmMotion") == 0)
             scripted::set_arm_motion_threshold(v);
         else if (strcmp(key, "scriptedArmHoldMs") == 0)

--- a/src/game/bioshock1r/patterns.h
+++ b/src/game/bioshock1r/patterns.h
@@ -547,6 +547,28 @@ inline constexpr uint32_t kPawnForegroundFovOffset = 0x558; // research; not a r
 // address (the pawn's eye height). The session-13 "+0x558 non-lever" verdict
 // stands; this is its correction.
 inline constexpr uint32_t kPcForegroundFovOffset = 0x460;
+// THE WORLD FOV, and its mirror. Both floats on the PLAYERCONTROLLER, both
+// already derived in this tree for another purpose: the foreground scene-node
+// ctor below is passed `float PC+0x45C` (the world lens, default 75.0) beside
+// PC+0x460 (the foreground one), and the note on PC+0x65C records the
+// "75/75/60 fov floats" sitting at PC+0x648..0x650. Named here because s65
+// needs to WRITE them, not merely read them.
+//
+// A SCRIPTED CAMERA NARROWS THESE AND CalcView NEVER SAYS SO. Measured
+// 2026-08-23 on the bathysphere: CalcView keeps reporting fov=100.0 for the
+// whole ride while the renderer switches to 80 deg on the frame the forced
+// move begins (`rendered tanH 0.8391 = 80.0 deg vs option 100.0`). Rendering
+// narrower than we claim to OpenXR is what puts the picture in a small box
+// with black all round it - the image is correct and full-resolution, it just
+// occupies less of the headset than the layer says it does.
+//
+// BRVR reached the same two fields independently (`ClampWorldFov`,
+// `BioshockVR/Game/GameState.cpp`, its `WorldFovOffset`/`WorldFovOffset2`) and
+// measured the narrow side as 75.0 -> 60.0 there. THE NUMBERS DO NOT TRANSFER
+// - this build reads 100 -> 80 - but the OFFSETS agree with the derivation
+// already in this file, which is the corroboration that matters.
+inline constexpr uint32_t kPcWorldFovOffset = 0x45C;
+inline constexpr uint32_t kPcWorldFovMirrorOffset = 0x648;
 // cb0 fingerprint: floats 12..18 of every foreground draw hold the constant
 // screen-ray block (2*tanH, 0, -tanH, 0, 0, -2*tanV, tanV) of the fixed
 // projection; the capture spans floats 36..59 (viewport block, then the

--- a/src/game/bioshock1r/scripted.cpp
+++ b/src/game/bioshock1r/scripted.cpp
@@ -92,6 +92,28 @@ bool read_u32(const void* obj, uint32_t off, uint32_t* out) {
     }
 }
 
+bool read_f32(const void* obj, uint32_t off, float* out) {
+    if (!obj) return false;
+    const uint8_t* p = static_cast<const uint8_t*>(obj) + off;
+    __try {
+        *out = *reinterpret_cast<const float*>(p);
+        return true;
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        return false;
+    }
+}
+
+bool write_f32(void* obj, uint32_t off, float v) {
+    if (!obj) return false;
+    uint8_t* p = static_cast<uint8_t*>(obj) + off;
+    __try {
+        *reinterpret_cast<float*>(p) = v;
+        return true;
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        return false;
+    }
+}
+
 bool read_ptr_at(const void* obj, uint32_t off, void** out) {
     if (!obj) return false;
     const uint8_t* p = static_cast<const uint8_t*>(obj) + off;
@@ -104,6 +126,12 @@ bool read_ptr_at(const void* obj, uint32_t off, void** out) {
 }
 
 // ---- published state (game thread writes, overlay thread reads) ------------
+// The world FOV guard. Game thread owns g_worldFovGameplay; the switch and the
+// counter are read by the F10 overlay thread.
+std::atomic<int> g_worldFovGuard{1};
+std::atomic<uint32_t> g_worldFovSnaps{0};
+float g_worldFovGameplay = 0.0f;
+
 
 // Master switch. Exists so the entire module can be taken out of the frame in
 // the headset without a rebuild - which is the cheapest possible answer to "did
@@ -526,6 +554,80 @@ void set_enabled(bool on) {
             on ? "signals live" : "use this to A/B whether this module causes a symptom");
 }
 
+// ---- THE WORLD FOV GUARD ---------------------------------------------------
+//
+// A scripted camera narrows the world lens and CalcView never mentions it.
+// MEASURED 2026-08-23, boarding a bathysphere: CalcView reports fov=100.0 for
+// the whole ride, and on the frame the forced move begins the renderer switches
+// to 80 deg (`rendered tanH 0.8391 = 80.0 deg vs option 100.0`). The mod does
+// the honest thing with that - it re-claims the layer at the measured 80 - and
+// the honest thing is what the player sees as a bug: the picture is correct and
+// still full-resolution, but it only fills 80 deg of a wider headset, so it sits
+// in a small box with black all round.
+//
+// So the fix is not on the claim side. It is to stop the narrowing.
+//
+// PORTED FROM BRVR's ClampWorldFov, with its shape and NOT its numbers: two
+// fields written together, snapped only when they move the wrong way, never a
+// fixed per-frame write. BRVR measured 75 -> 60; this build reads 100 -> 80.
+//
+// SELF-CALIBRATING, because there is no good constant to hardcode. The value to
+// restore is whatever the lens read during ordinary gameplay, which already
+// accounts for the user's FOV option, so it is sampled continuously while no
+// scene owns the camera and only replayed while one does.
+//
+// GATED, and the gate is the load-bearing part. BRVR's own CONSOLIDATION.md
+// names the hazard: this mod's cutscene detector has a leg that fires when the
+// game renders a different fov than it claims, and clamping deletes exactly
+// that evidence. Restricting the guard to the boarding-plus-ride window keeps
+// the leg intact everywhere else, and it is also why weapon zoom is safe -
+// Hands::FadeFOV drives the same field down when you scope, and you cannot
+// scope on a bathysphere.
+//
+// The window is `forced_move() || bathysphere()` and not `bathysphere()` alone:
+// the narrowing lands 1.2 s BEFORE the ride flag, on the frame the forced move
+// begins, which is the moment the player presses A.
+constexpr float kWorldFovEpsilon = 0.5f;
+
+void clamp_world_fov(void* pc) {
+    if (!pc || !g_worldFovGuard.load(std::memory_order_relaxed)) return;
+
+    float live = 0.0f;
+    if (!read_f32(pc, patterns::kPcWorldFovOffset, &live)) return;
+    if (!(live > 1.0f) || !(live < 170.0f)) return; // not a lens; leave it alone
+
+    const bool sceneOwnsLens = forced_move() || bathysphere();
+
+    if (!sceneOwnsLens) {
+        // Ordinary gameplay: this IS the value to restore. Remembered rather
+        // than derived, so the user's own FOV option needs no separate read.
+        g_worldFovGameplay = live;
+        return;
+    }
+    const float want = g_worldFovGameplay;
+    if (!(want > 1.0f)) return; // never seen gameplay yet - nothing to restore
+
+    // ONLY THE NARROW SIDE. A scene that opens the lens WIDER than gameplay is
+    // not the defect being fixed here, and snapping that back would be an
+    // unrequested content change.
+    if (live >= want - kWorldFovEpsilon) return;
+
+    const bool a = write_f32(pc, patterns::kPcWorldFovOffset, want);
+    const bool b = write_f32(pc, patterns::kPcWorldFovMirrorOffset, want);
+    g_worldFovSnaps.fetch_add(1, std::memory_order_relaxed);
+
+    static unsigned long long lastLog = 0;
+    const unsigned long long now = GetTickCount64();
+    if (now - lastLog >= 2000) {
+        lastLog = now;
+        BVR_LOG("[b1r] worldfov: scene narrowed the lens to %.1f - snapping both fields "
+                "back to %.1f (+0x%03X %s, +0x%03X %s, %s)",
+                live, want, patterns::kPcWorldFovOffset, a ? "ok" : "FAILED",
+                patterns::kPcWorldFovMirrorOffset, b ? "ok" : "FAILED",
+                bathysphere() ? "bathysphere ride" : "forced move");
+    }
+}
+
 void observe(void* playerController, int gameYawUnits, float turnStickX) {
     if (!enabled()) {
         // Say so ONCE. The switch exists to take this module out of the frame
@@ -540,6 +642,11 @@ void observe(void* playerController, int gameYawUnits, float turnStickX) {
         }
         return;
     }
+    // The lens guard runs before anything can early-return: a scripted camera
+    // narrows it on the same frame the forced move begins, and a frame missed
+    // there is a frame the player sees boxed.
+    clamp_world_fov(playerController);
+
     // The comfort accumulators advance HERE, before any early return, because
     // observe() is the one thing in this module that runs on every single
     // CalcView. The first version drove them from inside the head-drive block
@@ -773,6 +880,21 @@ int yaw_adjust_units() {
 
 float freeze_offset_deg() { return g_freezeOffsetUnits / kRotUnitsPerDegree; }
 float scripted_turn_deg() { return g_scriptedTurnUnits / kRotUnitsPerDegree; }
+
+bool world_fov_guard() { return g_worldFovGuard.load(std::memory_order_relaxed) != 0; }
+
+void set_world_fov_guard(bool on) {
+    if (g_worldFovGuard.exchange(on ? 1 : 0, std::memory_order_relaxed) != (on ? 1 : 0))
+        BVR_LOG("[b1r] worldfov guard %s (a scripted camera %s narrow the world lens "
+                "below its gameplay value; snaps so far %u)",
+                on ? "ON" : "off", on ? "may not" : "may",
+                g_worldFovSnaps.load(std::memory_order_relaxed));
+}
+
+void world_fov_readout(float* gameplay, unsigned* snaps) {
+    if (gameplay) *gameplay = g_worldFovGameplay;
+    if (snaps) *snaps = g_worldFovSnaps.load(std::memory_order_relaxed);
+}
 
 bool hide_rig_in_scenes() { return g_hideRig.load(std::memory_order_relaxed) != 0; }
 
@@ -1038,6 +1160,30 @@ void draw_debug_ui() {
 
     ImGui::Separator();
     ImGui::TextDisabled("DURING A SCRIPTED SCENE");
+
+    bool fovGuard = world_fov_guard();
+    if (ImGui::Checkbox("Keep the world lens at its gameplay width", &fovGuard))
+        set_world_fov_guard(fovGuard);
+    if (ImGui::IsItemHovered())
+        ImGui::SetTooltip(
+            "A scripted camera can narrow the world FOV without CalcView ever\n"
+            "reporting it - measured on the bathysphere as 100 -> 80 degrees on the\n"
+            "frame you press A. The mod then honestly re-claims the layer at the\n"
+            "narrower value, and you see the picture in a small box with black all\n"
+            "round it: correct image, full resolution, just not filling the headset.\n\n"
+            "This snaps the lens back instead. It only ever WIDENS a narrowed lens\n"
+            "back to what gameplay was using, and only while boarding or riding, so\n"
+            "weapon zoom is untouched."
+            );
+    {
+        float gameplayFov = 0.0f;
+        unsigned snaps = 0;
+        world_fov_readout(&gameplayFov, &snaps);
+        if (gameplayFov > 1.0f)
+            ImGui::Text("lens      gameplay %.1f deg   snaps %u", gameplayFov, snaps);
+        else
+            ImGui::TextDisabled("lens      no gameplay sample yet");
+    }
 
     bool freezeHands = freeze_hands_in_scenes();
     if (ImGui::Checkbox("The engine owns your hands", &freezeHands))

--- a/src/game/bioshock1r/scripted.h
+++ b/src/game/bioshock1r/scripted.h
@@ -202,6 +202,23 @@ int yaw_adjust_units();
 // walking you into position and your hands have nothing to do - then show them
 // the moment an animation starts, because that animation is what you are meant
 // to be watching. Collapses every bone; see bones::collapse_rig.
+// THE WORLD FOV GUARD (s65). A scripted camera narrows the world lens without
+// CalcView ever reporting it - measured on the bathysphere as 100 -> 80 deg on
+// the frame the forced move begins. The mod then honestly re-claims the layer
+// at the narrower value, and the player sees the picture in a small box with
+// black all round. This stops the narrowing instead.
+//
+// Deliberately scoped to `forced_move() || bathysphere()`: clamping everywhere
+// would delete the fov-mismatch leg of the cutscene detector (BRVR's
+// CONSOLIDATION.md names that hazard), and it is also what keeps weapon zoom
+// working, since Hands::FadeFOV drives the same field down when you scope.
+//
+// Self-calibrating: the value restored is whatever the lens read during
+// ordinary gameplay, so the user's own FOV option needs no separate read.
+bool world_fov_guard();
+void set_world_fov_guard(bool on);
+void world_fov_readout(float* gameplay, unsigned* snaps);
+
 bool hide_rig_in_scenes();
 void set_hide_rig_in_scenes(bool on);
 


### PR DESCRIPTION
Two BS1 view fixes, both headset-confirmed. **Merge this one first** — the other two BS1 PRs are later cuts of the same line of work and contain these commits.

## What it fixes

**The world lens narrowed during a bathysphere.** The ride is a scripted sequence, and the scripted path was pulling the world FOV to its cutscene width — so the whole descent rendered through a lens that did not match the rest of the game. Held at gameplay width for the duration instead.

**A near wall read as a menu and dropped the view to the anchored quad.** The panel decision keyed on something a wall satisfies at close range, so walking into one flipped the renderer to the flat quad mid-gameplay. The tell was in the log line, which reported the decision it *used to* make rather than the one it did.

## Scope

- `src/game/bioshock1r/` only. `git diff staging...HEAD -- src/core/` is empty.
- 2 commits.

## Testing

Headset, by the tester: ride the bathysphere and confirm the lens does not narrow; walk into a wall and confirm the view stays in stereo.