### PR TITLE
BS2 issue #31: left-eye flicker fixed (pass-1 skeleton update hook) + diagnosis instruments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,7 @@ the parts that are actually fixed.
 | `CONTRIBUTING.md` | **Branch, commit and PR rules.** Read before your first commit of a session |
 | `docs/ORG-PRACTICES.md` | Repo and `VR-Stereo-Hub` settings that enforce the above (admin) |
 | `docs/STATUS.md` | **Session handoff**: current state, next steps, blockers, session log |
+| `docs/KNOWN-ISSUES.md` | **Known issues + review findings** per game: what is open, what was fixed and in which session, cleanup deferred to the healing session |
 | `docs/ROADMAP.md` | BS1/BS2 milestones M0–M10 with acceptance criteria and checkboxes |
 | `docs/ARCHITECTURE.md` | Module design, core/adapter contract, stereo strategy, decision log |
 | `docs/RESEARCH.md` | All research findings with sources (engine, prior art, VR runtimes, legal) |

--- a/docs/KNOWN-ISSUES.md
+++ b/docs/KNOWN-ISSUES.md
@@ -1,0 +1,90 @@
+# Known issues and review findings
+
+Living list. Each entry says which game it touches, where it came from, and its
+state. Fixed entries stay for one release so a tester log can be matched to the
+build that closed them; then prune.
+
+## BioShock 2
+
+### Left-eye flicker (issue #31) - FIXED in s74, headset-confirmed
+
+The hand/weapon "snap" in the left eye was the engine's dirty-flagged skeleton
+update re-evaluating the hands inside pass 1 (never pass 2), after every repaint
+site and before the mesh was drawn. Fixed by hooking that update and repainting
+the driven pose the moment it returns (`vrbones wfix`, ships ON, F10 checkbox
+"LEFT-EYE FLICKER FIX (s74)" is the in-headset A/B). Mechanism, evidence and
+derivation: `docs/bioshock2/ENGINE_NOTES.md` session 74.
+
+Review findings on the fix, all closed in the same PR (s74 code review):
+
+| # | Finding | State |
+|---|---|---|
+| 1 | Hook thread id latched once at install; 0 if the rig resolved before the first Draw (fix silently inert, still reported hooked) | fixed: refreshed at every Draw entry |
+| 2 | Saved-return slot never self-healed after a swallowed exception (fix silently dead for the session) | fixed: cleared at Draw entry and on world change |
+| 3 | Hook installed from inside a hooked Draw / from the F10 render thread; one enable failure stuck forever | fixed: rig resolve and the checkbox POST; the game thread's poll lane installs; ALREADY_CREATED retries the enable |
+| 4 | Six-point race probe ran unconditionally (~18 syscalls per stereo pair) | fixed: off unless `vrbones race on` / `diag31 on` |
+| 5 | `pe_repaint` paid a VirtualQuery before the 48-byte sentinel compare on every ProcessEvent | fixed: compare first, validate on a hit |
+| 6 | `vrbones status` invariant always read BROKEN (new repaint phases not summed) | fixed: all 8 phases summed; phase 4-7 window max drained |
+| 7 | Engine numbers (update slot 0xA4, call site) lived in `bones.cpp`; log printed the call site off by one | fixed: `patterns.h` (`kSkelInstUpdateSlot`, `kSkelInstDirtyOffset`, `kSkelInstUpdateCallSiteRva`) |
+| 8 | `[hudgate]` logged a false burn on re-arm and flooded with stereo off; `[pairEdge] unheld-right` flooded with pair pacing off | fixed: unconditional delta tracking, eye-tagged presents only, transition latch |
+
+### Weapon scale flicker (big/small) - OPEN, not reproduced
+
+Reported once on the flat window with the hand drive off (s74). A 74-frame
+weapon-region sweep on a fresh boot was flat in both eyes. Suspects: foreground
+FOV write cadence, weapon-profile / `wscale` writes, or long-uptime state.
+Needs a long soak with `hash every 1` + the weapon-region metric.
+
+### Game FOV option baked by a hard kill - OPEN
+
+While the mod's game-FOV write is live, a crash or power loss leaves the written
+value in `Shared.ini` as if it were the user's option (seen twice in s74:
+`saved option 138`, real option 100). The restore only runs on a clean exit.
+Candidate fix: write the restore value to a sidecar at write time and repair
+on the next boot.
+
+### Menu-transition HUD burn - REAL BUT NOT PERCEIVED, parked
+
+Every pause open/close draws the HUD into both eyes' world images for ~3 pairs
+(`[hudgate]` witnesses it 5/5). The user does not perceive it in the headset,
+so it is parked; the instrument stays.
+
+## Cross-game (core)
+
+### F10 panel swallow of the right trigger and stick - FIXED in s74 for BS2
+
+The s63 controller-driven panel zeroed RT and the right stick for the game while
+the overlay was visible. On BS2 the panel cannot be closed from inside the
+headset (no F10 key), so one F10 visit killed fire and turning for the session.
+Now gated to pad-drive mode (BS1 opt-in), the only mode where the swallow has a
+purpose; the overlay logs SHOWN/hidden.
+
+Left as-is, noted:
+- BS1, pad drive on, right hand untracked, panel open via keyboard: RT and the
+  right stick are still swallowed although nothing can click. Pre-existing s63
+  behaviour; a `wants_pad_input()` predicate on the overlay would be the right
+  home if it ever matters.
+- With the panel open on the desktop, a BS2 wrench-swing pulse can still fire
+  (the swing pulse was only ever swallowed by the same gate). Design question
+  for the controller-navigation work, not a regression anyone hit.
+
+## Simulator and tools (diagnostic-only)
+
+- `hash every 1` copies each eye's full source texture and Maps it synchronously
+  on the present thread every frame - a GPU drain that perturbs the pacing it
+  measures. Nothing in s74 rests on it (the fix was A-B-A'd by counters and
+  captures), but treat hash-mode timing numbers as approximate. Cheaper form if
+  it ever matters: double-buffered staging (Map the previous frame) or a GPU
+  downsample.
+- `tools/eye-seq-diff.ps1` builds its line array with `+=` (quadratic); fine for
+  minutes, slow for a multi-hour TSV. Stream the rows if a long soak needs it.
+- Cleanup deferred to the healing session: `module_range()` in `bones.cpp`
+  duplicates the image-range lookup that `capture_main_module` already returns;
+  ad-hoc `eip - g_gameBase` RVA math could share a range-checked `to_rva()`;
+  the two staging-copy paths in `xrsim_compositor.cpp` could share a helper.
+
+## Repository hygiene (s74)
+
+- Three s74 commit subjects run 73-75 characters (limit 72); the fix commit
+  bundles the diagnosis levers with the fix. Left in history (rewriting a
+  pushed draft branch was not worth it); split and shorten on the next one.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -21,6 +21,17 @@ session and was measured, photographed and A-B'd. Full mechanism write-up:
   counters show one repaint per pass-1 writer return; rest pose untouched;
   user: "now there's no snapping". Correction to the earlier read: the RIGHT
   eye was always correct - the LEFT eye rendered the raw restamp.
+- **HEADSET-CONFIRMED (Quest 3 / VDXR): "the flicker went away".** F10 checkbox
+  "LEFT-EYE FLICKER FIX (s74)" under HANDS + AIM is the in-headset A/B.
+- **The menu flicker is NOT a BS2 bug** - the user was thinking of another
+  game. The [hudgate] burn train is real but nobody perceives it; parked.
+- **Staging input regression found in the headset test and fixed:** the s63
+  "F10 panel clicks with the right trigger" swallow (xinput_bridge.cpp) zeroed
+  RT + right stick for the game whenever the overlay was visible - on BS2 the
+  panel cannot be closed from inside the headset (no F10 there), so one F10
+  visit killed fire and turning for the session. Now gated to pad-drive mode
+  (BS1 opt-in), which is the only mode where the swallow has a purpose; the
+  overlay logs SHOWN/hidden transitions.
 - **The "left eye flicker" is THREE artifacts, now separated:**
   1. **Hand/weapon pose snap** - FIXED above. ([pair] + per-eye source hashes
      were CLEAN throughout -> s62's pairing-layer hypotheses exonerated.)

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,6 +2,53 @@
 
 > Handoff file. Rewrite "Current state" and "Next steps" every session; append to the session log.
 
+## Session 2026-09-01 - s74: BS2 issue #31 diagnosed LIVE - the flicker decomposed
+
+Branch `claude/bioshock2-left-eye-flicker-3ca08e` (off `staging`), diagnosis-only
+per the evidence-first gate. The flicker reproduced CONSTANTLY in a flat xrsim
+session and was measured, photographed and A-B'd. Full mechanism write-up:
+`docs/bioshock2/ENGINE_NOTES.md` session 74.
+
+### Current state
+
+- **The "left eye flicker" is THREE artifacts, now separated:**
+  1. **Hand/weapon pose snap** (the constant one): pass 2 / RIGHT eye always
+     renders the engine's authored pose (drive never re-applied - the
+     camera.cpp:2319 TODO); pass 1 / LEFT eye intermittently loses the
+     restamp race. Photographed per-eye (evidence dir below). [pair] + per-eye
+     source hashes CLEAN throughout -> s62's pairing-layer hypotheses
+     exonerated for this symptom.
+  2. **Menu-transition burn** (tester report 3): 5/5 reproducible witness
+     train - 3 leaderMiss intervals on open, ~145 HUD draws burned into 3
+     pairs (both eyes) on close, one unheld-right generation split per
+     transition. Photographed (pause menu warped into the left eye image).
+  3. **Weapon scale flicker** (open): seen by the user with the drive off;
+     not yet reproduced on a fresh boot; suspects fgfov cadence / profile
+     writes / long-uptime state.
+- New instruments landed (all opt-in, BS1 untouched): `vrbones diag31`,
+  [pairEdge] + [hudgate] event-edge witnesses, [pair] `deep=` field, xrsim
+  `hash every N` per-eye source hashing + `tools/eye-seq-diff.ps1`.
+- Bug found in the s62 probe premise (lone-left parks the RIGHT eye, not the
+  left) - comments corrected, fix-session scope.
+- Crash-persistence bug found: a hard kill leaves the mod's written game FOV
+  baked in Shared.ini (this boot: option 138, user's real option 100). The
+  user's ini is CURRENTLY polluted - restore before their next flat session.
+- Evidence archive: `%LOCALAPPDATA%\BioshockVR\bs2\evidence-s74-flicker\`
+  (605 files: per-eye PNG pairs, eyehash.tsv). NOT in git (game-derived).
+
+### Next steps
+
+1. Fix session for artifact 1 (the big one): re-apply/verify the bone drive
+   for pass 2 and close the pass-1 restamp window (design against the s41
+   retarget architecture; A-B-A with the s74 capture protocol).
+2. Fix session for artifact 2: raise the HUD gate on the same present it is
+   decided (or arm hud redirect during the transition window), and suppress
+   the unheld-right by keeping the hold across the cine boundary.
+3. Reproduce artifact 3 (scale): long soak with `hash every 1` + weapon-region
+   metric, fgfov/profile write logging if it shows.
+4. Restore the user's FOV option (100) and decide the crash-restore guard.
+5. Testers: ship a diag31 build + one-line arm instruction once 1-2 land.
+
 ## Session 2026-08-30 - s72/s73: the off hand's ARM, decoupled and rotating
 
 **TWO branches and two draft PRs**, split at the point the arm work began:

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -11,13 +11,19 @@ session and was measured, photographed and A-B'd. Full mechanism write-up:
 
 ### Current state
 
+- **ARTIFACT 1 IS FIXED (the constant left-eye hand/weapon snap).** The
+  write-watch named the writer: the engine's dirty-flagged SkeletonInstance
+  update (vtable slot 0xA4) re-runs INSIDE PASS 1 only, after every repaint
+  site and before the hands mesh is drawn. `vrbones wfix` (auto-installed at
+  rig resolve, ships ON) hooks that virtual with a naked ret-hook and repaints
+  the driven pose the moment it returns. Three-state A-B-A in the sim: per-eye
+  temporal gap <=2.6 with the fix vs left-only spikes of 16-19 without;
+  counters show one repaint per pass-1 writer return; rest pose untouched;
+  user: "now there's no snapping". Correction to the earlier read: the RIGHT
+  eye was always correct - the LEFT eye rendered the raw restamp.
 - **The "left eye flicker" is THREE artifacts, now separated:**
-  1. **Hand/weapon pose snap** (the constant one): pass 2 / RIGHT eye always
-     renders the engine's authored pose (drive never re-applied - the
-     camera.cpp:2319 TODO); pass 1 / LEFT eye intermittently loses the
-     restamp race. Photographed per-eye (evidence dir below). [pair] + per-eye
-     source hashes CLEAN throughout -> s62's pairing-layer hypotheses
-     exonerated for this symptom.
+  1. **Hand/weapon pose snap** - FIXED above. ([pair] + per-eye source hashes
+     were CLEAN throughout -> s62's pairing-layer hypotheses exonerated.)
   2. **Menu-transition burn** (tester report 3): 5/5 reproducible witness
      train - 3 leaderMiss intervals on open, ~145 HUD draws burned into 3
      pairs (both eyes) on close, one unheld-right generation split per
@@ -38,9 +44,10 @@ session and was measured, photographed and A-B'd. Full mechanism write-up:
 
 ### Next steps
 
-1. Fix session for artifact 1 (the big one): re-apply/verify the bone drive
-   for pass 2 and close the pass-1 restamp window (design against the s41
-   retarget architecture; A-B-A with the s74 capture protocol).
+1. **Headset confirmation of the artifact-1 fix** (Quest 3 + VDXR, then
+   SteamVR): play 10+ min, fire a lot, confirm no left-eye snap; `vrbones
+   wfix off` is the in-session A/B. Then a diag31 build to the issue-#31
+   reporters.
 2. Fix session for artifact 2: raise the HUD gate on the same present it is
    decided (or arm hud redirect during the transition window), and suppress
    the unheld-right by keeping the hold across the cine boundary.

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -406,7 +406,28 @@ compare against rather than a guess:
   lone-left pair breaks (a pass-2 skip after the left tag - see `skip`
   silent/stall/foreign for WHY); `reb>0` marks the mid-session resolution
   change the reporter performed. `mirror` prints the vrmirror pin state so a
-  `vrmirror off` A/B is legible in the same log line.
+  `vrmirror off` A/B is legible in the same log line. s74 correction: a
+  lone-left break parks the RIGHT eye, not the left - read `stale` BOTH ways.
+  s74 adds `deep=` (tag-ring pops that found a full pair queued - a sustained
+  nonzero is the phase-offset tell no other counter sees).
+- **`vrbones diag31 on` -> `[pairEdge]` / `[hudgate]` event-edge lines** (BS2,
+  s74): timestamped one-shots at each pairing break (lone-left,
+  untagged-close, untag-capture, acquire/wait-fail, hold-expired,
+  unheld-right) and at each per-eye HUD-burn interval (`burn eye=... `,
+  `leaderMiss eye=...`). A tester's "I saw it at 12:03" is answered by
+  grepping the minute around 12:03 for these. Known good signal: every BS2
+  pause open/close fires 3 leaderMiss + 6 burn + 1 unheld-right (the menu
+  flicker mechanism, 5/5 in sim).
+- **xrsim `hash every <n>` + `tools\eye-seq-diff.ps1`** (s74): the temporal
+  per-eye oracle. One TSV row per Nth submitted frame with an FNV hash of
+  each eye's SOURCE projection texture, per-eye release age and luma
+  (`capture\eyehash.tsv`, latest row mirrored in state.json `eyeHash`). The
+  differ flags left-stale / right-stale / eye-swap / age-spike / one-eye
+  luma-pop; exit 0 clean, 2 anomalies. Trap it exists to close: eye-check
+  legs 1-5 pass with identical eye images, and the PNG capture path cannot
+  see a repeated frame. Sim baseline at the save: 1651 projection rows, zero
+  anomalies - while the pose-snap flicker was VISIBLY firing, which is the
+  proof that artifact lives in frame content, not frame identity.
 - **BS2 pause menu**: seam commands and the pad are BOTH dead while paused (the
   PE-tail service lane starves - ENGINE_NOTES s42 #4); an unfocused-paused game
   writes nothing and false-positives log-age wedge checks. `game-key Space` wakes

--- a/docs/bioshock2/ENGINE_NOTES.md
+++ b/docs/bioshock2/ENGINE_NOTES.md
@@ -2545,3 +2545,13 @@ while"). Needs a longer soak or the user's live confirmation window.
   right-stale, eye-swap, age-spike, one-eye luma-pop. Baseline: 1651
   projection frames, zero anomalies, while the pose snap was visibly firing -
   the class-A artifact lives in frame CONTENT, not frame identity.
+
+**s74 addendum - artifact A causally CONFIRMED live (three-state A-B-A, user
+witnessed on the flat window):** (1) `vrhands off` -> snap gone; (2) drive on
+but a fresh idle boot -> snap gone AND [flick] pe1 ~0/min (no ambient
+restamps); (3) drive on + rapid fire -> snap visible, ~4 pe1 catches per shot.
+The snap therefore requires BOTH the drive and an engine restamp - the race is
+the cause, and the restamp PRESSURE is state-dependent: ~0/min on a fresh
+idle boot vs ~1600/min after sustained play (the testers' "after playing for a
+while", and s41's ~10-minute onset). Shots are the reliable on-demand restamp
+source (the s62b fire-snap and this artifact are one mechanism).

--- a/docs/bioshock2/ENGINE_NOTES.md
+++ b/docs/bioshock2/ENGINE_NOTES.md
@@ -2555,3 +2555,57 @@ the cause, and the restamp PRESSURE is state-dependent: ~0/min on a fresh
 idle boot vs ~1600/min after sustained play (the testers' "after playing for a
 while", and s41's ~10-minute onset). Shots are the reliable on-demand restamp
 source (the s62b fire-snap and this artifact are one mechanism).
+
+### Session 74 (cont.) - the left-eye flicker FIXED: the writer named and hooked
+
+**Why every earlier rung missed it.** A six-point sentinel probe (pass 1
+entry/flush/post-drain, pass 2 the same; `vrbones race`) read the hands bank
+as OURS at every point of the pair - even with the full mask scanned - while
+the left eye demonstrably rendered the engine's pose. The repaint sites were
+all correct and all too late: the bank was clean everywhere we could look, and
+the image was still wrong. Inference had run out; the writer had to be caught.
+
+**The write-watch (`vrbones watch on`).** Three debug registers on the first
+driven weapon-hand bone, a vectored handler recording writer EIP + EBP chain +
+pair context. Result, one salvo: ONE engine routine writes the pose (RVA
+0xEF751D..31, the three 16-byte groups), reached from
+- the game tick (x1324; chain 0x5FB816 <- 0x57798D <- 0x578270) - the normal
+  animation update the PE-lane repaint already absorbs, and
+- INSIDE PASS 1 ONLY (x33, ~2 per shot; chain 0x5FB816 <- 0x5E65D7 <-
+  0x3816C0) - never in pass 2.
+
+The shared call site 0x5FB810 is `mov eax,[esi]; call [eax+0xA4]` guarded by
+`cmp byte [esi+0xA0],0` and followed by `mov byte [esi+0xA0],0`: a
+DIRTY-FLAGGED virtual update on the SkeletonInstance (vtable slot 0xA4/4 = 41,
+vtable = patterns::kSkeletonInstanceVtableRva, resolved at runtime to RVA
+0x3398D, an ILT jump thunk). The pass-1 caller enters through another virtual
+(`call [vtbl+0x100]` at 0x5E65D5) - the render-side per-view update of the
+hands. Pass 2 is clean because the flag is already clear by then. That is the
+whole "left eye only" story: pass 1 re-evaluates the skeleton after every
+repaint site and before the mesh is drawn; pass 2 does not.
+
+**The fix (`vrbones wfix`, ships ON, auto-installed at rig resolve).** MinHook
+on that vtable-slot function with a convention-agnostic NAKED detour: filter
+`this` to g_skel / g_wSkel (every other skeletal mesh passes through
+untouched), game thread only, swap the caller's return address for a stub,
+jump to the original with the stack intact; the stub saves all registers +
+x87 state, runs `pe_repaint(3)` (site 3 -> catch phases 6/7) when pass 1 is
+in flight, restores, returns to the real caller. The repaint therefore lands
+between the writer and the mesh draw - the one window no earlier rung could
+reach.
+
+**Verification (sim, three-state A-B-A, same boot):**
+- counters: fix ON - every pass-1 writer return is followed by a catch (34
+  returns -> 66 hand catches; +24 -> +48); fix OFF - returns continue, catches
+  frozen; ON again - resumes 2 catches per return.
+- images: per-eye frame-to-frame diffs in the hands region track within ~2
+  with the fix ON; with it OFF the LEFT eye spikes alone (f002926 L25.4 vs
+  R9.3, f002972 L28.2 vs R17.0) - the raw recoil pose in the left eye with the
+  driven pose in the right, frozen on camera (evidence dir, `f002926_sbs.png`).
+- rest pose fix ON vs OFF: mean-abs-diff 0.14, 0.5% pixels - the fix moves
+  nothing at rest.
+- user, flat window: "now there's no snapping".
+- game stable across three hooked boots; the hook is inert for NPC skeletons.
+
+**Still open:** the menu-transition burn (artifact B, [hudgate]) and the
+weapon scale flicker (artifact C, not yet reproduced on a fresh boot).

--- a/docs/bioshock2/ENGINE_NOTES.md
+++ b/docs/bioshock2/ENGINE_NOTES.md
@@ -2476,3 +2476,72 @@ revisit only if the user reports them.
   `drive=authored+look`.
 - v0.7.0 (CMakeLists), packaged with tools/package.ps1 - ONE zip serves both
   games (the adapter registry picks by host exe).
+
+### Session 74 (2026-09-01) - issue #31 diagnosed live: the "left eye flicker" decomposed
+
+The flicker reproduced CONSTANTLY in a flat xrsim session (user watching the
+desktop window, which pins to the LEFT eye), which turned issue #31 from a
+headset-only report into a measured, photographed defect. Three separate
+artifacts were untangled; per-eye source hashes and the [pair] counters were
+CLEAN throughout, so the XR pairing/submission layer (s62's H1-H6 candidates)
+is EXONERATED for the visible symptom.
+
+**A. The hand/weapon pose snap (the constant "left eye flicker").**
+Per-eye captures (evidence: `%LOCALAPPDATA%\BioshockVR\bs2\evidence-s74-flicker\`,
+frames f116157/f116166 vs f116187/f116205) show, within ONE clean pair:
+- pass 2 / RIGHT eye renders the engine's AUTHORED viewmodel pose every tick
+  (`second_pass_replay` never re-applies the bone drive - the known TODO at
+  camera.cpp:2319-2322);
+- pass 1 / LEFT eye usually renders the DRIVEN pose but intermittently loses
+  the race to an engine restamp and renders authored for a frame - the flip
+  the user sees (and the desktop mirror shows), at the [flick] pe1 cadence
+  (~27 catches/s, dmax 16 ms exposure).
+So the headset percept is constant inter-eye pose rivalry plus a temporal flip
+in the left eye. fl1/fl2 stay 0 while wrong poses render, so the flush-point
+sentinel is NOT what the renderer consumes - the pass's mesh data is built
+earlier in the traversal. A-B: `vrhands off` removes the driven pose and the
+snap (partially confirmed live; blackout interrupted the controlled A-B-A).
+
+**B. The menu-transition burn (tester report "flickers when navigating menus").
+5/5 reproducible; witnessed and photographed.** Every pause-menu OPEN logs 3
+`[hudgate] leaderMiss` intervals (2 LEFT, 1 RIGHT: menu swf draws with no world
+pass, inside the 3-interval screen-only hysteresis window) and every CLOSE logs
+~145 unarmed swf draws burned into SIX consecutive presents (3 pairs, both
+eyes) before the gate rises - plus ONE `[pairEdge] unheld-right` (pose
+generations split across the resync pair) at every transition. Photographic
+evidence: f030038_left = the PAUSE MENU warped into the left projection eye.
+The s62 H1 hypothesis (gate one draw late, one left frame) was directionally
+right but understated: the cine-quad hysteresis holds the gate down for ~3
+pairs and hits BOTH eyes.
+
+**C. The weapon SCALE flicker (open).** With the drive off the user still saw
+the weapon flip big/small on the window. Not yet reproduced on a fresh boot
+(74-frame weapon-region sweep flat in both eyes); candidates: fgfov lens-write
+cadence, weapon-profile/wscale writes, or long-uptime state ("after playing a
+while"). Needs a longer soak or the user's live confirmation window.
+
+**Corrections and traps recorded this session:**
+- The s62 [pair] premise "any pair break leaves the LEFT eye stale" is wrong
+  for lone-left breaks (pass-2 skip): those park the RIGHT eye. Probe comments
+  amended (openxr_runtime.cpp/.h); watch staleL AND staleR.
+- Crash persistence: a hard kill (blackout) while the game fov write is live
+  leaves the written FOV baked in Shared.ini - this boot read back
+  `saved option 138` where the user's real option is 100. Any tester crash
+  does the same; the next boot then runs with a polluted option. NOT yet
+  fixed; restore the user's option and consider a startup sanity note.
+- xrsim `capture every` had a sticky captureTag (one `shot` poisoned all later
+  sequences into one filename) - fixed: arming a sequence clears the tag.
+
+**New instruments (all opt-in / sim-side, no frame-behavior change):**
+- `vrbones diag31 on|off` - umbrella: [flick]+[pair] minute lines,
+  `[pairEdge]` event-edge lines (lone-left, untagged-close, untag-capture,
+  acquire/wait-fail, hold-expired, unheld-right), `[hudgate]` witnesses (gate
+  transitions, per-eye burn and leaderMiss intervals).
+- `[pair]` minute line grew `deep=` (pops that found a full pair queued - the
+  H3 phase-offset tell; 0 all session).
+- xrsim `hash every <n>` - per-frame FNV hash + release-age + luma of each
+  eye's SOURCE projection texture into `capture\eyehash.tsv`; surfaced in
+  state.json (`eyeHash`); `tools/eye-seq-diff.ps1` flags left-stale,
+  right-stale, eye-swap, age-spike, one-eye luma-pop. Baseline: 1651
+  projection frames, zero anomalies, while the pose snap was visibly firing -
+  the class-A artifact lives in frame CONTENT, not frame identity.

--- a/docs/bioshock2/TESTING.md
+++ b/docs/bioshock2/TESTING.md
@@ -80,7 +80,14 @@ leader-miss intervals - the menu-transition flicker fires a 5/5-reproducible
 train of these on every pause open/close). Sim side, `xrsim-cmd "hash every 1"`
 fingerprints every submitted frame's per-eye SOURCE texture into
 `capture\eyehash.tsv`, and `tools\eye-seq-diff.ps1` turns that into a
-left-stale / right-stale / eye-swap / age-spike / luma-pop verdict. `exec` stays
+left-stale / right-stale / eye-swap / age-spike / luma-pop verdict. The s74 fix
+and its probes: `vrbones wfix on|off|status|install` (the post-writer repaint -
+ships ON, auto-installed at rig resolve; `off` is the flat A/B), `vrbones race`
+(+ the `[race]` minute line: sentinel state at six points of the pair),
+`vrbones watch on|off` (hardware write-watch on the sentinel bone - lists engine
+writer RVAs + pair context; debug only), `vrbones fullmask on|off` (repaint
+decision scans every masked bone), `vrbones p1fix|p2fix on|off` (pass-entry
+repaints - superseded by wfix, kept as levers). `exec` stays
 BS1-only by design - BS2 engine-state writes go through script setters via
 FindFunctionChecked + ProcessEvent (the vrxhair precedent, ENGINE_NOTES s42).
 

--- a/docs/bioshock2/TESTING.md
+++ b/docs/bioshock2/TESTING.md
@@ -72,7 +72,15 @@ without live SR stereo, the flat A/B; status = counters + per-reason routes),
 edge), `menukey on|off|force on|force off|status` (pad A -> scancode Enter in menu
 contexts; inert while vrinput is off), `vrxhair on|off|status` (the game's own
 crosshair - DEFAULT HIDDEN, PE-by-name DisableReticle), and `vrbones flick on|off`
-(the [flick] per-minute flicker-diagnosis line; counters always count). `exec` stays
+(the [flick] per-minute flicker-diagnosis line; counters always count). Session 74
+adds `vrbones diag31 on|off` - the issue-#31 umbrella: it arms the minute lines
+PLUS the `[pairEdge]` event-edge witnesses (each pairing break named with a
+timestamp) and the `[hudgate]` witnesses (gate transitions; per-eye HUD-burn and
+leader-miss intervals - the menu-transition flicker fires a 5/5-reproducible
+train of these on every pause open/close). Sim side, `xrsim-cmd "hash every 1"`
+fingerprints every submitted frame's per-eye SOURCE texture into
+`capture\eyehash.tsv`, and `tools\eye-seq-diff.ps1` turns that into a
+left-stale / right-stale / eye-swap / age-spike / luma-pop verdict. `exec` stays
 BS1-only by design - BS2 engine-state writes go through script setters via
 FindFunctionChecked + ProcessEvent (the vrxhair precedent, ENGINE_NOTES s42).
 

--- a/src/core/gfx/hud_capture.cpp
+++ b/src/core/gfx/hud_capture.cpp
@@ -1443,24 +1443,25 @@ void on_present(ID3D11DeviceContext* ctx, IDXGISwapChain* swapchain) {
     //               a declared screen-only span - the whole HUD rendered into
     //               this eye's world image (the muzzle-flash H4 window); the
     //               3-interval hysteresis swallows exactly these blips.
+    // The unarmed-route delta is tracked on EVERY present (one relaxed load),
+    // so arming the witness later never sees the pre-arm cumulative count as
+    // a burn - the first live run, and the first re-arm, were both fooled by
+    // an inside-the-gate delta.
+    static unsigned s_prevUnarmed = 0; // present thread only
+    const unsigned unarmed = g_cPass[kRouteUnarmed].load(std::memory_order_relaxed);
+    const unsigned unarmedDelta = unarmed - s_prevUnarmed;
+    s_prevUnarmed = unarmed;
     if (g_gateLog.load(std::memory_order_relaxed)) {
-        // present thread only; primed==false on the first armed interval so
-        // the pre-arm cumulative count is swallowed instead of logged as a
-        // burn (it fooled the first live run of this witness).
-        static unsigned s_prevUnarmed = 0;
-        static bool s_primed = false;
-        const unsigned unarmed = g_cPass[kRouteUnarmed].load(std::memory_order_relaxed);
-        const unsigned unarmedDelta = s_primed ? unarmed - s_prevUnarmed : 0;
-        s_prevUnarmed = unarmed;
-        s_primed = true;
         const bool world = scene_leader() != nullptr;
         const int eye = bvr::vr::sr_last_pop_sign();
         const char* eyeName = eye < 0 ? "LEFT" : (eye > 0 ? "RIGHT" : "untagged");
-        if (unarmedDelta > 0 && world)
+        // Only eye-TAGGED presents can burn: with stereo off the gate is down
+        // by design on every present, and that is not the menu-exit window.
+        if (unarmedDelta > 0 && world && eye != 0)
             BVR_LOG("[hudgate] burn eye=%s unarmedSwfDraws=%u swf=%d (gate was "
                     "DOWN while a world pass ran - HUD burned into this eye)",
                     eyeName, unarmedDelta, g_swfDrawsThisInterval);
-        if (!world && g_swfDrawsThisInterval >= 20 &&
+        if (!world && g_swfDrawsThisInterval >= 20 && eye != 0 &&
             !g_screenOnlyOn.load(std::memory_order_relaxed))
             BVR_LOG("[hudgate] leaderMiss eye=%s swf=%d (no scene leader this "
                     "interval outside a screen-only span - HUD went into this "

--- a/src/core/gfx/hud_capture.cpp
+++ b/src/core/gfx/hud_capture.cpp
@@ -20,6 +20,7 @@ namespace {
 std::atomic<bool> g_enabled{true};
 std::atomic<bool> g_force{false};
 std::atomic<bool> g_gate{false};
+std::atomic<bool> g_gateLog{false}; // [hudgate] issue #31 witness, opt-in
 // Session 42 (BS2): the game composites gameswf directly on the BACKBUFFER
 // (bind = RENDER_TARGET only) and its tonemap is an INDEXED quad - both fail
 // BS1's fingerprints. Per-game opt-in; default off keeps BS1 bit-identical.
@@ -1433,6 +1434,40 @@ void on_present(ID3D11DeviceContext* ctx, IDXGISwapChain* swapchain) {
     (void)swapchain; // letterbox sampling moved to letterbox_sample (detour HEAD)
     fov_watch_on_present(ctx); // session 22: map last interval's cb0 copy
 
+    // [hudgate] (issue #31, opt-in): the two one-eye HUD-burn signatures, read
+    // at interval end BEFORE the counters roll. Runs after vr::on_present_end
+    // popped this present's eye tag, so the interval is eye-attributable.
+    //   burn:       gameswf draws hit the unarmed route while a world pass ran
+    //               (the gate was still down - the menu-exit H1 window).
+    //   leaderMiss: >=20 swf draws but NO scene leader this interval, outside
+    //               a declared screen-only span - the whole HUD rendered into
+    //               this eye's world image (the muzzle-flash H4 window); the
+    //               3-interval hysteresis swallows exactly these blips.
+    if (g_gateLog.load(std::memory_order_relaxed)) {
+        // present thread only; primed==false on the first armed interval so
+        // the pre-arm cumulative count is swallowed instead of logged as a
+        // burn (it fooled the first live run of this witness).
+        static unsigned s_prevUnarmed = 0;
+        static bool s_primed = false;
+        const unsigned unarmed = g_cPass[kRouteUnarmed].load(std::memory_order_relaxed);
+        const unsigned unarmedDelta = s_primed ? unarmed - s_prevUnarmed : 0;
+        s_prevUnarmed = unarmed;
+        s_primed = true;
+        const bool world = scene_leader() != nullptr;
+        const int eye = bvr::vr::sr_last_pop_sign();
+        const char* eyeName = eye < 0 ? "LEFT" : (eye > 0 ? "RIGHT" : "untagged");
+        if (unarmedDelta > 0 && world)
+            BVR_LOG("[hudgate] burn eye=%s unarmedSwfDraws=%u swf=%d (gate was "
+                    "DOWN while a world pass ran - HUD burned into this eye)",
+                    eyeName, unarmedDelta, g_swfDrawsThisInterval);
+        if (!world && g_swfDrawsThisInterval >= 20 &&
+            !g_screenOnlyOn.load(std::memory_order_relaxed))
+            BVR_LOG("[hudgate] leaderMiss eye=%s swf=%d (no scene leader this "
+                    "interval outside a screen-only span - HUD went into this "
+                    "eye's image)",
+                    eyeName, g_swfDrawsThisInterval);
+    }
+
     // Session 22 kind (a): screen-only interval verdict (hysteresis over
     // present intervals, transitions logged - the flat instrument). Computed
     // BEFORE the vote reset below. The 20-draw floor keeps single stray swf
@@ -1527,8 +1562,27 @@ void set_enabled(bool on) {
 bool enabled() { return g_enabled.load(std::memory_order_relaxed); }
 
 void set_gate(bool stereoActive) {
+    // [hudgate] (issue #31, opt-in): the gate is set at present TAIL but
+    // consumed by the NEXT draw, so a rising edge always lands one pass late -
+    // and the first tagged pass after a menu is the LEFT one. Transition lines
+    // make that window visible in a tester log.
+    if (g_gateLog.load(std::memory_order_relaxed)) {
+        bool was = g_gate.load(std::memory_order_relaxed);
+        if (was != stereoActive)
+            BVR_LOG("[hudgate] gate %s (consumed by the NEXT draw pass; eye "
+                    "this present popped: %d)",
+                    stereoActive ? "RAISED" : "dropped", bvr::vr::sr_last_pop_sign());
+    }
     g_gate.store(stereoActive, std::memory_order_relaxed);
 }
+
+void set_gate_log(bool on) {
+    g_gateLog.store(on, std::memory_order_relaxed);
+    BVR_LOG("[hudgate] witness %s", on ? "ARMED (gate transitions + one-eye "
+                                         "HUD-burn intervals will log)"
+                                       : "off");
+}
+bool gate_log() { return g_gateLog.load(std::memory_order_relaxed); }
 
 void set_force(bool on) {
     g_force.store(on, std::memory_order_relaxed);

--- a/src/core/gfx/hud_capture.h
+++ b/src/core/gfx/hud_capture.h
@@ -91,6 +91,11 @@ bool enabled();
 // override arms the redirect with no XR session - REQUIRED for flat testing
 // (projectionReady can never be true without a headset).
 void set_gate(bool stereoActive);
+// [hudgate] issue #31 witness (opt-in, default off; BS2 arms it): logs gate
+// transitions and one-eye HUD-burn intervals (unarmed swf draws over a world
+// pass; leader-miss blips outside screen-only spans).
+void set_gate_log(bool on);
+bool gate_log();
 void set_force(bool on);
 bool force();
 

--- a/src/core/input/xinput_bridge.cpp
+++ b/src/core/input/xinput_bridge.cpp
@@ -351,7 +351,14 @@ Gamepad compose_synthetic(uint64_t now) {
     // would leave the panel with nothing to click with. This is the last point
     // before the game sees anything, and it also catches the swing pulse above
     // - a wrench swing should not fire while you are aiming at a checkbox.
-    if (bvr::overlay::visible()) {
+    //
+    // Session 74: ONLY under the controller-driven panel (BS1 opt-in). Without
+    // pad drive the trigger cannot click the panel anyway, and a panel that
+    // cannot be closed from inside the headset (no F10 there) would otherwise
+    // take fire and turning with it for the rest of the session - which is
+    // exactly what BS2 shipped into: right trigger and right stick dead after
+    // one F10 visit, everything else alive.
+    if (bvr::overlay::visible() && bvr::overlay::pad_drive()) {
         out.rt = 0;
         // ...and the right stick, which now scrolls the panel. Turning while
         // reading a menu is not something anyone asked for, and leaving it

--- a/src/core/ui/overlay.cpp
+++ b/src/core/ui/overlay.cpp
@@ -519,6 +519,13 @@ void on_present(IDXGISwapChain* swapchain) {
         g_visible = req != 0;
         ImGui::GetIO().MouseDrawCursor = g_visible;
     }
+    // Transition log (s74): a panel left open in the headset is invisible in
+    // the log otherwise, and under pad drive it swallows fire and turning.
+    static bool s_loggedVisible = false;
+    if (g_visible != s_loggedVisible) {
+        BVR_LOG("overlay: %s", g_visible ? "SHOWN" : "hidden");
+        s_loggedVisible = g_visible;
+    }
     g_visibleApplied.store(g_visible, std::memory_order_relaxed);
 
     if (!g_visible) return;

--- a/src/core/vr/openxr_runtime.cpp
+++ b/src/core/vr/openxr_runtime.cpp
@@ -439,6 +439,7 @@ constexpr uint32_t kPmStaleAgeMs = 50; // > any healthy cadence (SR ~14ms, AER ~
 std::atomic<bool> g_pairEdgeLog{false};
 std::atomic<int> g_srLastPop{0};      // what THIS present popped; hud interval attribution
 std::atomic<uint32_t> g_pmPopDeep{0}; // pops that found a full pair queued (phase-offset tell)
+bool g_unheldRight = false;           // present thread: unheld-right transition latch
 
 // Session 42 (Infinite I6 judder): pair-CADENCE statistics. The judder question
 // is not "how many pairs per second" but "how EVENLY are they spaced" - a mean
@@ -3683,6 +3684,11 @@ void on_present_end(IDXGISwapChain* swapchain) {
     if (pairSecond) {
         if (srSign == +1) {
             g_srPairs.fetch_add(1, std::memory_order_relaxed);
+            if (g_unheldRight) {
+                if (g_pairEdgeLog.load(std::memory_order_relaxed))
+                    BVR_LOG("[pairEdge] unheld-right ended (pairs hold again)");
+                g_unheldRight = false;
+            }
             // Pair-cadence sample (session 42): stamp the CLOSE of the pair -
             // the one moment per pair that exists exactly once on exactly one
             // thread. g_qpcFreq is initialized by the PhaseScope wrapping this
@@ -3739,18 +3745,20 @@ void on_present_end(IDXGISwapChain* swapchain) {
                         srSign < 0 ? "next LEFT" : "untagged",
                         srSign < 0 ? "LEFT" : "index 0");
         }
-    } else if (srSign == +1 && srFrame &&
-               g_pairEdgeLog.load(std::memory_order_relaxed)) {
+    } else if (srSign == +1 && srFrame) {
         // Issue #31 (H2): a RIGHT-tagged present with no hold open ran its own
         // xrWaitFrame + xrLocateViews, so the two eyes of this pair are tagged
         // from DIFFERENT locate generations - the left eye's pose is one
         // display period behind, which reprojection turns into a left-only
-        // lateral double under head motion.
-        BVR_LOG("[pairEdge] unheld-right (right present without a pair hold - "
-                "pose generations split across this pair; shouldRender=%d "
-                "pacing=%d)",
-                g_frameState.shouldRender ? 1 : 0,
-                g_srPairPacing.load(std::memory_order_relaxed) ? 1 : 0);
+        // lateral double under head motion. Transition-logged: with pair
+        // pacing off every tick lands here, and that is a state, not an event.
+        if (!g_unheldRight && g_pairEdgeLog.load(std::memory_order_relaxed))
+            BVR_LOG("[pairEdge] unheld-right BEGAN (right present without a pair "
+                    "hold - pose generations split across the pair; shouldRender=%d "
+                    "pacing=%d)",
+                    g_frameState.shouldRender ? 1 : 0,
+                    g_srPairPacing.load(std::memory_order_relaxed) ? 1 : 0);
+        g_unheldRight = true;
     }
     bool pairHold = srFrame && srSign < 0 && !pairSecond &&
                     g_srPairPacing.load(std::memory_order_relaxed) &&

--- a/src/core/vr/openxr_runtime.cpp
+++ b/src/core/vr/openxr_runtime.cpp
@@ -428,6 +428,18 @@ std::atomic<uint32_t> g_pmAgeMax[2] = {};    // worst capture age at submit, ms
 std::atomic<uint64_t> g_pmLastCapMs[2] = {}; // tick of last SR capture per eye
 constexpr uint32_t kPmStaleAgeMs = 50; // > any healthy cadence (SR ~14ms, AER ~28ms)
 
+// Issue #31 hunt, this session: event-edge witnesses over the same mechanisms
+// the minute counters aggregate. A tester says "I saw the flicker at 12:03";
+// a minute-window counter cannot answer that, a timestamped line can. Off by
+// default and armed only by the BS2 adapter, so BS1/BSI logs are untouched.
+// NOTE the s62 premise above ("any pair break leaves the LEFT eye stale") is
+// only true for breaks on the RIGHT present; a lone-left break (pass 2
+// skipped) captures a fresh LEFT and submits with the RIGHT eye old - so the
+// probe must watch BOTH eyes, and staleR is as interesting as staleL.
+std::atomic<bool> g_pairEdgeLog{false};
+std::atomic<int> g_srLastPop{0};      // what THIS present popped; hud interval attribution
+std::atomic<uint32_t> g_pmPopDeep{0}; // pops that found a full pair queued (phase-offset tell)
+
 // Session 42 (Infinite I6 judder): pair-CADENCE statistics. The judder question
 // is not "how many pairs per second" but "how EVENLY are they spaced" - a mean
 // of 13.9 ms with 5 ms of swing reprojects differently every frame while both
@@ -940,18 +952,40 @@ std::atomic<bool> g_loggedFirstMirror{false};
 int sr_pop_eye() {
     uint32_t tail = g_srTail.load(std::memory_order_relaxed);
     uint32_t head = g_srHead.load(std::memory_order_acquire);
-    if (tail == head) return 0;
+    if (tail == head) {
+        g_srLastPop.store(0, std::memory_order_relaxed);
+        return 0;
+    }
     if (head - tail > 2) {
         // More than a pair in flight: submit/present pairing skewed (mode
         // boundary). Drop everything and resync from mono.
         g_srTail.store(head, std::memory_order_relaxed);
         g_srCleared.fetch_add(1, std::memory_order_relaxed);
         BVR_LOG("xr: sr tag ring skewed (depth %u) - cleared", head - tail);
+        g_srLastPop.store(0, std::memory_order_relaxed);
         return 0;
+    }
+    // Issue #31 (H3): in the healthy 1t loop a tag is popped by the Present
+    // inside the same engine Draw that pushed it, so depth at pop is 1. A pop
+    // that finds a FULL PAIR queued means push/present phase slipped by one -
+    // the offset the depth>2 self-heal above can never see. Counted always,
+    // transition-logged when the edge witness is armed. Present thread only.
+    static bool s_wasDeep = false;
+    if (head - tail == 2) {
+        g_pmPopDeep.fetch_add(1, std::memory_order_relaxed);
+        if (!s_wasDeep && g_pairEdgeLog.load(std::memory_order_relaxed))
+            BVR_LOG("[pairEdge] popDeep BEGAN (a full pair was queued at pop - "
+                    "eye tags now trail their presents by one)");
+        s_wasDeep = true;
+    } else if (s_wasDeep) {
+        if (g_pairEdgeLog.load(std::memory_order_relaxed))
+            BVR_LOG("[pairEdge] popDeep ended (pop depth back to 1)");
+        s_wasDeep = false;
     }
     int sign = g_srRing[tail & (kSrRingSize - 1)].load(std::memory_order_relaxed);
     g_srTail.store(tail + 1, std::memory_order_release);
     g_srPopped.fetch_add(1, std::memory_order_relaxed);
+    g_srLastPop.store(sign, std::memory_order_relaxed);
     return sign;
 }
 
@@ -2797,6 +2831,9 @@ void on_present_begin(IDXGISwapChain* swapchain) {
         BVR_LOG("xr: pair hold outlived %u ms with no right-eye present - "
                 "aborting it (presents stopped mid-pair? alt-tab/level load)",
                 kPairHoldMaxMs);
+        if (g_pairEdgeLog.load(std::memory_order_relaxed))
+            BVR_LOG("[pairEdge] hold-expired (left was captured, its right "
+                    "sibling never presented)");
         g_srPairOpen = false;
         g_srPairAborts.fetch_add(1, std::memory_order_relaxed);
         g_pmAbortExpired.fetch_add(1, std::memory_order_relaxed);
@@ -3694,7 +3731,26 @@ void on_present_end(IDXGISwapChain* swapchain) {
                 g_pmAbortLeft.fetch_add(1, std::memory_order_relaxed);
             else
                 g_pmAbortUntag.fetch_add(1, std::memory_order_relaxed);
+            if (g_pairEdgeLog.load(std::memory_order_relaxed))
+                BVR_LOG("[pairEdge] %s (pair broke on the %s present; this "
+                        "submit captures fresh %s and the OTHER eye rides its "
+                        "old image)",
+                        srSign < 0 ? "lone-left" : "untagged-close",
+                        srSign < 0 ? "next LEFT" : "untagged",
+                        srSign < 0 ? "LEFT" : "index 0");
         }
+    } else if (srSign == +1 && srFrame &&
+               g_pairEdgeLog.load(std::memory_order_relaxed)) {
+        // Issue #31 (H2): a RIGHT-tagged present with no hold open ran its own
+        // xrWaitFrame + xrLocateViews, so the two eyes of this pair are tagged
+        // from DIFFERENT locate generations - the left eye's pose is one
+        // display period behind, which reprojection turns into a left-only
+        // lateral double under head motion.
+        BVR_LOG("[pairEdge] unheld-right (right present without a pair hold - "
+                "pose generations split across this pair; shouldRender=%d "
+                "pacing=%d)",
+                g_frameState.shouldRender ? 1 : 0,
+                g_srPairPacing.load(std::memory_order_relaxed) ? 1 : 0);
     }
     bool pairHold = srFrame && srSign < 0 && !pairSecond &&
                     g_srPairPacing.load(std::memory_order_relaxed) &&
@@ -3723,14 +3779,23 @@ void on_present_end(IDXGISwapChain* swapchain) {
             // [pair] probe: an untagged present in projection mode captures
             // into the LEFT swapchain (index 0) - candidate mechanism for a
             // wrong-content left eye.
-            if (projectionMode && !srFrame && !aerActive)
+            if (projectionMode && !srFrame && !aerActive) {
                 g_pmUntaggedProj.fetch_add(1, std::memory_order_relaxed);
+                if (g_pairEdgeLog.load(std::memory_order_relaxed))
+                    BVR_LOG("[pairEdge] untag-capture (untagged present wrote "
+                            "the LEFT swapchain, index 0)");
+            }
             uint32_t index = 0;
             int64_t tAcq = phase_now();
             XrSwapchainImageAcquireInfo ai{XR_TYPE_SWAPCHAIN_IMAGE_ACQUIRE_INFO};
             XrResult acqRes = xrAcquireSwapchainImage(g_swapchains[target], &ai, &index);
-            if (XR_FAILED(acqRes))
+            if (XR_FAILED(acqRes)) {
                 g_pmAcqFail.fetch_add(1, std::memory_order_relaxed);
+                if (g_pairEdgeLog.load(std::memory_order_relaxed))
+                    BVR_LOG("[pairEdge] acquire-fail eye=%d (%s) - this eye "
+                            "keeps its previous released image",
+                            target, res_str(acqRes));
+            }
             if (XR_SUCCEEDED(acqRes)) {
                 XrSwapchainImageWaitInfo wi{XR_TYPE_SWAPCHAIN_IMAGE_WAIT_INFO};
                 wi.timeout = XR_INFINITE_DURATION;
@@ -3740,12 +3805,17 @@ void on_present_end(IDXGISwapChain* swapchain) {
                     imageReady = XR_SUCCEEDED(xrWaitSwapchainImage(g_swapchains[target], &wi));
                 }
                 phase_record(kPhAcquire, tAcq);
-                if (!imageReady)
+                if (!imageReady) {
                     // The release below still runs (spec requires it), which
                     // makes an UNDEFINED-content image the eye's most recently
                     // released one - counted, because that is one of the
                     // stale-left candidate mechanisms.
                     g_pmWaitFail.fetch_add(1, std::memory_order_relaxed);
+                    if (g_pairEdgeLog.load(std::memory_order_relaxed))
+                        BVR_LOG("[pairEdge] wait-fail eye=%d (an UNDEFINED "
+                                "image becomes this eye's released one)",
+                                target);
+                }
                 if (imageReady) {
                     // Same size + same typeless family (guaranteed at creation),
                     // so a straight GPU copy carries the frame - overlay
@@ -5400,8 +5470,18 @@ void pair_probe(PairProbe* out) {
     out->ringPopped = g_srPopped.load(std::memory_order_relaxed);
     out->ringDropped = g_srDropped.load(std::memory_order_relaxed);
     out->ringCleared = g_srCleared.load(std::memory_order_relaxed);
+    out->popDeep = g_pmPopDeep.load(std::memory_order_relaxed);
     out->mirrorOn = g_mirror.load(std::memory_order_relaxed);
 }
+
+void set_pair_edge_log(bool on) {
+    g_pairEdgeLog.store(on, std::memory_order_relaxed);
+    BVR_LOG("[pairEdge] witness %s", on ? "ARMED (event-edge lines will name "
+                                          "each pairing break as it happens)"
+                                        : "off");
+}
+bool pair_edge_log() { return g_pairEdgeLog.load(std::memory_order_relaxed); }
+int sr_last_pop_sign() { return g_srLastPop.load(std::memory_order_relaxed); }
 
 } // namespace bvr::vr
 
@@ -5487,6 +5567,9 @@ const char* cine_drive_name(CineDrive) { return "authored"; }
 float rendered_hfov_deg() { return 0.0f; }
 int current_eye_sign() { return 0; }
 void sr_push_eye(int) {}
+void set_pair_edge_log(bool) {}
+bool pair_edge_log() { return false; }
+int sr_last_pop_sign() { return 0; }
 void set_laser(const LaserConfig&) {}
 void set_aim_dot(const AimDotConfig&) {}
 void set_hud_quad(float, float, float) {}

--- a/src/core/vr/openxr_runtime.h
+++ b/src/core/vr/openxr_runtime.h
@@ -435,11 +435,14 @@ void sr_push_eye(int eyeSign); // game thread, at submit; -1 left, +1 right
 // --- s62: the [pair] probe (issue #31, BS2 left-eye double image) -----------
 // Cumulative counters over the per-eye present pairing layer - the quantity
 // the bone-restamp [flick] instrument does NOT measure. The right-tagged
-// present submits BOTH eyes' most-recently-released images, so any pair break
-// leaves the LEFT eye stale while the right stays fresh; `staleL` counts
-// stereo submits whose left capture was older than 50 ms, and ageMax tracks
-// the worst observed capture age at submit. Read by the BS2 adapter's minute
-// line; purely additive (nothing in core prints, BS1/BSI behavior unchanged).
+// present submits BOTH eyes' most-recently-released images, so a pair break
+// parks ONE eye on an old image - WHICH eye depends on the break: a break on
+// the right present leaves the LEFT stale, but a lone-left break (pass 2
+// skipped) captures a fresh left and submits with the RIGHT old. The s62
+// premise that every break lands on the left was wrong (found this session);
+// watch staleL AND staleR. ageMax tracks the worst observed capture age at
+// submit. Read by the BS2 adapter's minute line; purely additive (nothing in
+// core prints, BS1/BSI behavior unchanged).
 struct PairProbe {
     uint32_t pairs = 0;          // completed L->R pairs
     uint32_t aborts = 0;         // total pair aborts (all kinds)
@@ -457,9 +460,20 @@ struct PairProbe {
     uint32_t ageMaxL = 0;        // worst capture age at submit, ms - DRAINED on read
     uint32_t ageMaxR = 0;        //   (window = the caller's own read cadence)
     uint32_t ringPushed = 0, ringPopped = 0, ringDropped = 0, ringCleared = 0;
+    uint32_t popDeep = 0;        // pops that found a full pair queued (H3 phase-offset tell)
     bool mirrorOn = false;       // desktop mirror pin state (vrmirror)
 };
 void pair_probe(PairProbe* out);
+
+// Issue #31 event-edge witness (this session): timestamped one-shot log lines
+// at each pairing-break site, so a reported sighting can be matched to a
+// mechanism by wall clock. Off by default; only the BS2 adapter arms it.
+void set_pair_edge_log(bool on);
+bool pair_edge_log();
+// The eye sign the CURRENT present popped (-1 left, +1 right, 0 none) - lets
+// per-present consumers running after the pop (hud interval roll) attribute
+// their interval to an eye.
+int sr_last_pop_sign();
 
 // --- M7: the aim laser ------------------------------------------------------
 // A row of soft dots along the hand's aim ray, submitted as extra XR quad

--- a/src/game/bioshock2r/bones.cpp
+++ b/src/game/bioshock2r/bones.cpp
@@ -10,6 +10,7 @@
 #include "game/bioshock2r/scenedraw.h"
 
 #include <windows.h>
+#include <MinHook.h>
 
 #include <atomic>
 #include <cmath>
@@ -142,15 +143,36 @@ std::atomic<uint32_t> g_peRepaints{0}; // restamps caught mid-draw (flicker fix)
 // BASELINE, not a survivor count. The survivor signal is the late-window
 // catches (fl*) and a large write->catch latency (g_catchDeltaMaxMs): a
 // restamp that sat unrepainted for most of the pass plausibly rendered.
-std::atomic<uint32_t> g_catch[4][2] = {};
-std::atomic<uint32_t> g_catchDeltaMaxMs[4] = {}; // window max, drained on snapshot
+// Session 74 widens the phase table: 4/5 = the pass-ENTRY repaint (site 2),
+// the fix candidate armed by `vrbones p1fix|p2fix`.
+// 6/7 = the post-WRITER repaint (site 3, the s74 fix: right after the engine's
+// pose writer returns inside pass 1).
+std::atomic<uint32_t> g_catch[8][2] = {};
+std::atomic<uint32_t> g_catchDeltaMaxMs[8] = {}; // window max, drained on snapshot
 std::atomic<uint32_t> g_driveAdoptEvents[2] = {}; // [0] hand drives, [1] wskel drives
 std::atomic<uint32_t> g_worldChanges{0};
 std::atomic<uint32_t> g_wRescans{0};
 std::atomic<bool> g_flickLog{true}; // [flick] minute line (counters always count)
 
+// --- Session 74: the pose-RACE probe ----------------------------------------
+// The per-eye captures proved the RIGHT eye renders the engine's authored pose
+// every tick while fl2 stayed 0 - so the bank is ours at pass-2 flush yet the
+// image is not. This probe samples the same sentinel at six points of the
+// pair (pass 1 entry / flush / post-drain, pass 2 entry / flush / post-drain)
+// and counts "foreign at this point", which says WHERE the bank flips instead
+// of arguing it from counters that only see the repaint sites.
+std::atomic<uint32_t> g_probeCalls[6] = {};
+std::atomic<uint32_t> g_probeForeign[6][2] = {}; // [point][0 hands, 1 weapon]
+std::atomic<int> g_probeFirstDiff[6] = {};       // last first-differing bone index seen
+std::atomic<bool> g_entryFix[2] = {}; // repaint at pass 1 / pass 2 ENTRY
+// The s41 sentinel compares ONE bone (the first masked) - a restamp that
+// leaves that bone alone and moves the elbow/wrist/gun bones is invisible to
+// it. fullmask makes the repaint decision (and the probe, always) scan every
+// masked bone: `vrbones fullmask on|off`.
+std::atomic<bool> g_fullMask{false};
+
 void note_catch(int phase, int kind, uint32_t latMs) {
-    if (phase < 0 || phase > 3) return;
+    if (phase < 0 || phase > 7) return;
     g_catch[phase][kind].fetch_add(1, std::memory_order_relaxed);
     // Torn max under the dev-only threaded substrate is an accepted diagnostic
     // hazard (matches pe_repaint's existing exposure); shipping config is 1t.
@@ -252,6 +274,13 @@ bool resolve_rig() {
     g_refValid = false;
     BVR_LOG("[b2r] bones: rig resolved - AHands %p skel %p pose %p x%d bones", g_hands,
             g_skel, g_pose, g_boneCount);
+    // Session 74: the left-eye flicker fix rides the rig. The engine's
+    // dirty-flagged skeleton update re-evaluates the hands INSIDE pass 1 (never
+    // pass 2), after every repaint site and before the mesh is drawn; hooking
+    // it here means the driven pose is repainted the moment it returns. The
+    // hook is a static vtable slot, so installing once is enough; the
+    // this-filter in the detour follows g_skel/g_wSkel across re-resolves.
+    wfix_install();
     return true;
 }
 
@@ -861,26 +890,41 @@ void release(const char* why, int hand) {
     }
 }
 
+// First masked bone of hand h whose 48-byte pose differs from our last write,
+// or -1. scanAll=false reproduces the s41 sentinel (first masked bone only);
+// true scans the whole mask (session 74: the sentinel missed restamps that
+// leave the first bone alone and move the elbow/wrist/gun bones).
+int first_foreign_bone(int h, bool scanAll) {
+    for (int i = 0; i < g_boneCount; ++i) {
+        if (!g_writtenMask[h][i]) continue;
+        if (memcmp(g_pose + i * patterns::kSkelPoseStride, g_written[i], 48) != 0)
+            return i;
+        if (!scanAll) return -1;
+    }
+    return -1;
+}
+int first_foreign_wbone(bool scanAll) {
+    for (int i = 0; i < g_wBoneCount; ++i) {
+        if (!g_wWrittenValid[i]) continue;
+        if (memcmp(g_wPose + i * patterns::kSkelPoseStride, g_wWritten[i], 48) != 0)
+            return i;
+        if (!scanAll) return -1;
+    }
+    return -1;
+}
+
 void pe_repaint(int site) {
     if (!g_pose || !g_refValid) return;
     uint64_t now = GetTickCount64();
     // Session 42: catch phase for the flicker instrumentation (site 0 = the
     // PE lane, 1 = the flush point; odd = pass 2).
     int phase = site * 2 + (scenedraw::in_second_draw() ? 1 : 0);
+    const bool scanAll = g_fullMask.load(std::memory_order_relaxed);
     for (int h = 0; h < 2; ++h) {
         if (now - g_writeStampMs[h] > 100) continue; // not driving, nothing to defend
-        // Sentinel: the first masked bone. Animation restamps translation and
-        // rotation, so a 48-byte compare catches it the moment it lands.
-        int s = -1;
-        for (int i = 0; i < g_boneCount; ++i)
-            if (g_writtenMask[h][i]) {
-                s = i;
-                break;
-            }
-        if (s < 0) continue;
-        if (memcmp(g_pose + s * patterns::kSkelPoseStride, g_written[s], 48) == 0)
-            continue;
         if (!is_memory_valid(g_pose, g_boneCount * patterns::kSkelPoseStride)) return;
+        // Sentinel (s41): the first masked bone; fullmask (s74): any masked bone.
+        if (first_foreign_bone(h, scanAll) < 0) continue;
         // Session 41, absorb-then-recompose: the restamp is INPUT, not an
         // enemy - adopt it into g_anim first, then rewrite this frame
         // composed on the fresh pose. Pass 1 only: the second pass must
@@ -901,14 +945,7 @@ void pe_repaint(int site) {
     // Weapon skeleton (session 41): same sentinel, same absorb-then-recompose
     // on pass 1 / verbatim on pass 2.
     if (g_wPose && g_wStampMs && now - g_wStampMs <= 100 && wskel_intact()) {
-        int s = -1;
-        for (int i = 0; i < g_wBoneCount; ++i)
-            if (g_wWrittenValid[i]) {
-                s = i;
-                break;
-            }
-        if (s >= 0 &&
-            memcmp(g_wPose + s * patterns::kSkelPoseStride, g_wWritten[s], 48) != 0) {
+        if (first_foreign_wbone(scanAll) >= 0) {
             if (!scenedraw::in_second_draw()) {
                 float ws = g_wScale.load(std::memory_order_relaxed);
                 if (!(ws > 0.05f && ws < 20.0f)) ws = 1.0f;
@@ -923,6 +960,393 @@ void pe_repaint(int site) {
             note_catch(phase, 1, static_cast<uint32_t>(now - g_wStampMs));
         }
     }
+}
+
+void probe_point(int p) {
+    if (p < 0 || p > 5 || !g_pose || !g_refValid) return;
+    g_probeCalls[p].fetch_add(1, std::memory_order_relaxed);
+    uint64_t now = GetTickCount64();
+    if (!is_memory_valid(g_pose, g_boneCount * patterns::kSkelPoseStride)) return;
+    // The probe always scans the FULL mask - it exists to see what the
+    // sentinel cannot.
+    int firstDiff = -1;
+    for (int h = 0; h < 2; ++h) {
+        if (now - g_writeStampMs[h] > 100) continue;
+        int b = first_foreign_bone(h, true);
+        if (b >= 0 && (firstDiff < 0 || b < firstDiff)) firstDiff = b;
+    }
+    if (firstDiff >= 0) {
+        g_probeForeign[p][0].fetch_add(1, std::memory_order_relaxed);
+        g_probeFirstDiff[p].store(firstDiff, std::memory_order_relaxed);
+    }
+    if (g_wPose && g_wStampMs && now - g_wStampMs <= 100 && wskel_intact()) {
+        if (first_foreign_wbone(true) >= 0)
+            g_probeForeign[p][1].fetch_add(1, std::memory_order_relaxed);
+    }
+}
+
+void set_full_mask(bool on) { g_fullMask.store(on, std::memory_order_relaxed); }
+bool full_mask() { return g_fullMask.load(std::memory_order_relaxed); }
+
+// --- Session 74: hardware write-watch on the sentinel bone -----------------
+// Every probe says the bank is ours at every point we can look, yet pass 1's
+// image carries the restamp. So: stop inferring the writer, CATCH it. Three
+// debug registers cover the first masked weapon-hand bone (bytes 0-3, 16-19,
+// 32-35 of its 48-byte pose), a vectored handler records the writer's EIP
+// plus a short EBP return chain and WHERE in the pair it fired (tick / pass 1
+// / pass 2 / flush), and our own module's writes are filtered out. Armed on
+// the game thread only (`vrbones watch on`); the registers are cleared on
+// `off`. Debug-only instrument - never ships armed.
+namespace {
+struct WatchHit {
+    uint32_t eip = 0;      // RVA in the game exe (or raw address if foreign)
+    uint32_t ret[3] = {};  // EBP-chain return RVAs
+    uint8_t ctx = 0;       // 0 tick, 1 pass1, 2 pass2, +4 = inside flush
+    uint32_t count = 0;
+};
+std::atomic<bool> g_watchOn{false};
+std::atomic<uint32_t> g_watchOurs{0}, g_watchEngine{0}, g_watchForeign{0};
+PVOID g_watchVeh = nullptr;
+uint8_t* g_watchAddr = nullptr;
+uint32_t g_watchTid = 0;
+WatchHit g_watchHits[12];
+std::atomic<int> g_watchHitN{0};
+uintptr_t g_selfBase = 0, g_selfEnd = 0, g_gameBase = 0, g_gameEnd = 0;
+
+void module_range(void* addrInModule, uintptr_t* base, uintptr_t* end) {
+    HMODULE m = nullptr;
+    GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                           GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                       static_cast<LPCWSTR>(addrInModule), &m);
+    if (!m) { *base = *end = 0; return; }
+    auto* dos = reinterpret_cast<IMAGE_DOS_HEADER*>(m);
+    auto* nt = reinterpret_cast<IMAGE_NT_HEADERS*>(reinterpret_cast<uint8_t*>(m) + dos->e_lfanew);
+    *base = reinterpret_cast<uintptr_t>(m);
+    *end = *base + nt->OptionalHeader.SizeOfImage;
+}
+
+LONG CALLBACK watch_veh(EXCEPTION_POINTERS* ep) {
+    if (ep->ExceptionRecord->ExceptionCode != EXCEPTION_SINGLE_STEP)
+        return EXCEPTION_CONTINUE_SEARCH;
+    CONTEXT* c = ep->ContextRecord;
+    if ((c->Dr6 & 0x7) == 0) return EXCEPTION_CONTINUE_SEARCH; // not our DR0-2
+    c->Dr6 = 0;
+    const uintptr_t eip = c->Eip;
+    if (eip >= g_selfBase && eip < g_selfEnd) {
+        g_watchOurs.fetch_add(1, std::memory_order_relaxed);
+        return EXCEPTION_CONTINUE_EXECUTION;
+    }
+    uint8_t ctx = 0;
+    if (scenedraw::draw_depth() > 0) ctx = scenedraw::in_second_draw() ? 2 : 1;
+    if (scenedraw::in_flush()) ctx |= 4;
+    uint32_t rva = (eip >= g_gameBase && eip < g_gameEnd)
+                       ? static_cast<uint32_t>(eip - g_gameBase) : static_cast<uint32_t>(eip);
+    if (eip >= g_gameBase && eip < g_gameEnd)
+        g_watchEngine.fetch_add(1, std::memory_order_relaxed);
+    else
+        g_watchForeign.fetch_add(1, std::memory_order_relaxed);
+    // Dedupe on (eip, ctx); keep the first 12 distinct sites.
+    int n = g_watchHitN.load(std::memory_order_relaxed);
+    for (int i = 0; i < n; ++i) {
+        if (g_watchHits[i].eip == rva && g_watchHits[i].ctx == ctx) {
+            ++g_watchHits[i].count;
+            return EXCEPTION_CONTINUE_EXECUTION;
+        }
+    }
+    if (n < 12) {
+        WatchHit& h = g_watchHits[n];
+        h.eip = rva;
+        h.ctx = ctx;
+        h.count = 1;
+        uintptr_t ebp = c->Ebp;
+        for (int k = 0; k < 3; ++k) {
+            if (!is_memory_valid(reinterpret_cast<void*>(ebp), 8)) break;
+            uintptr_t ret = *reinterpret_cast<uintptr_t*>(ebp + 4);
+            h.ret[k] = (ret >= g_gameBase && ret < g_gameEnd)
+                           ? static_cast<uint32_t>(ret - g_gameBase) : static_cast<uint32_t>(ret);
+            ebp = *reinterpret_cast<uintptr_t*>(ebp);
+        }
+        g_watchHitN.store(n + 1, std::memory_order_relaxed);
+    }
+    return EXCEPTION_CONTINUE_EXECUTION;
+}
+
+// Debug registers are per thread and must be set from OUTSIDE the target:
+// a helper thread suspends the game thread, edits DR0-2/DR7, resumes.
+void watch_apply(uint32_t tid, uint8_t* addr, bool arm) {
+    HANDLE th = OpenThread(THREAD_ALL_ACCESS, FALSE, tid);
+    if (!th) {
+        BVR_LOG("[b2r] watch: OpenThread(%u) failed (%lu)", tid, GetLastError());
+        return;
+    }
+    if (SuspendThread(th) == static_cast<DWORD>(-1)) {
+        BVR_LOG("[b2r] watch: SuspendThread failed (%lu)", GetLastError());
+        CloseHandle(th);
+        return;
+    }
+    CONTEXT ctx{};
+    ctx.ContextFlags = CONTEXT_DEBUG_REGISTERS;
+    if (GetThreadContext(th, &ctx)) {
+        if (arm) {
+            ctx.Dr0 = reinterpret_cast<uintptr_t>(addr);
+            ctx.Dr1 = reinterpret_cast<uintptr_t>(addr + 16);
+            ctx.Dr2 = reinterpret_cast<uintptr_t>(addr + 32);
+            // L0-L2 enable; RW=01 (write), LEN=11 (4 bytes) for each.
+            ctx.Dr7 = 0x1 | 0x4 | 0x10 | (0x1u << 16) | (0x3u << 18) | (0x1u << 20) |
+                      (0x3u << 22) | (0x1u << 24) | (0x3u << 26);
+        } else {
+            ctx.Dr0 = ctx.Dr1 = ctx.Dr2 = 0;
+            ctx.Dr7 = 0;
+        }
+        ctx.Dr6 = 0;
+        if (!SetThreadContext(th, &ctx))
+            BVR_LOG("[b2r] watch: SetThreadContext failed (%lu)", GetLastError());
+    } else {
+        BVR_LOG("[b2r] watch: GetThreadContext failed (%lu)", GetLastError());
+    }
+    ResumeThread(th);
+    CloseHandle(th);
+}
+} // namespace
+
+void watch_set(bool on) {
+    if (on) {
+        if (g_watchOn.load(std::memory_order_relaxed)) return;
+        if (!g_pose || !g_refValid) {
+            BVR_LOG("[b2r] watch: no live pose bank - resolve the rig first");
+            return;
+        }
+        int s = -1;
+        for (int i = 0; i < g_boneCount && s < 0; ++i)
+            if (g_writtenMask[1][i]) s = i;
+        if (s < 0)
+            for (int i = 0; i < g_boneCount && s < 0; ++i)
+                if (g_writtenMask[0][i]) s = i;
+        if (s < 0) {
+            BVR_LOG("[b2r] watch: no driven bone yet (vrhands on and wait a tick)");
+            return;
+        }
+        uint32_t tid = scenedraw::draw_tid();
+        if (!tid) {
+            BVR_LOG("[b2r] watch: no draw thread seen yet");
+            return;
+        }
+        module_range(reinterpret_cast<void*>(&watch_set), &g_selfBase, &g_selfEnd);
+        module_range(GetModuleHandleW(nullptr), &g_gameBase, &g_gameEnd);
+        g_watchAddr = g_pose + s * patterns::kSkelPoseStride;
+        g_watchTid = tid;
+        g_watchHitN.store(0, std::memory_order_relaxed);
+        g_watchOurs.store(0); g_watchEngine.store(0); g_watchForeign.store(0);
+        if (!g_watchVeh) g_watchVeh = AddVectoredExceptionHandler(1, watch_veh);
+        uint32_t t = tid;
+        uint8_t* a = g_watchAddr;
+        HANDLE h = CreateThread(nullptr, 0,
+                                [](LPVOID p) -> DWORD {
+                                    auto* args = static_cast<uintptr_t*>(p);
+                                    watch_apply(static_cast<uint32_t>(args[0]),
+                                                reinterpret_cast<uint8_t*>(args[1]), true);
+                                    delete[] args;
+                                    return 0;
+                                },
+                                new uintptr_t[2]{t, reinterpret_cast<uintptr_t>(a)}, 0, nullptr);
+        if (h) CloseHandle(h);
+        g_watchOn.store(true, std::memory_order_relaxed);
+        BVR_LOG("[b2r] watch ARMED on bone %d @ %p (thread %u) - engine writers will be "
+                "logged by `vrbones watch status`", s, g_watchAddr, tid);
+    } else {
+        if (!g_watchOn.load(std::memory_order_relaxed)) return;
+        uint32_t t = g_watchTid;
+        HANDLE h = CreateThread(nullptr, 0,
+                                [](LPVOID p) -> DWORD {
+                                    watch_apply(static_cast<uint32_t>(reinterpret_cast<uintptr_t>(p)),
+                                                nullptr, false);
+                                    return 0;
+                                },
+                                reinterpret_cast<LPVOID>(static_cast<uintptr_t>(t)), 0, nullptr);
+        if (h) { WaitForSingleObject(h, 2000); CloseHandle(h); }
+        g_watchOn.store(false, std::memory_order_relaxed);
+        BVR_LOG("[b2r] watch off");
+    }
+}
+
+// --- Session 74: the post-writer repaint (the fix) ---------------------------
+// The write-watch named ONE engine routine as the pose writer, reached from
+// the game tick (handled by the PE-lane repaint) and, ~2x per shot, from a
+// render-side path INSIDE pass 1 only - after every repaint site and before
+// the hands mesh is drawn, so the LEFT eye renders the raw restamp. The fix is
+// to repaint the driven pose the moment that writer RETURNS while pass 1 is
+// in flight. The routine's signature is unknown, so the detour is naked and
+// convention-agnostic: on entry it swaps the caller's return address for a
+// stub and jumps to the original untouched; the stub runs the repaint with
+// every register (and the x87 state) preserved and returns to the real
+// caller. Game thread only (TEB tid check); nested calls pass through.
+namespace {
+void* g_wTarget = nullptr;
+void* g_wOrig = nullptr;
+uintptr_t g_wRetSaved = 0; // the hooked call's real return address (game thread)
+uint32_t g_wTid = 0;
+bool g_wCreated = false;
+std::atomic<bool> g_wPostFix{true}; // the fix ships ON; `vrbones wfix off` is the A/B
+std::atomic<uint32_t> g_wPost{0}, g_wPostPass1{0}, g_wPostPass2{0}, g_wPostTick{0};
+
+void __cdecl w_post() {
+    g_wPost.fetch_add(1, std::memory_order_relaxed);
+    if (scenedraw::draw_depth() <= 0) {
+        g_wPostTick.fetch_add(1, std::memory_order_relaxed);
+        return;
+    }
+    if (scenedraw::in_second_draw()) {
+        g_wPostPass2.fetch_add(1, std::memory_order_relaxed);
+        return;
+    }
+    g_wPostPass1.fetch_add(1, std::memory_order_relaxed);
+    if (g_wPostFix.load(std::memory_order_relaxed)) pe_repaint(3);
+}
+
+__declspec(naked) void w_ret_stub() {
+    __asm {
+        pushad
+        pushfd
+        sub esp, 108
+        fnsave [esp]
+        call w_post
+        frstor [esp]
+        add esp, 108
+        popfd
+        popad
+        push dword ptr [g_wRetSaved]
+        mov dword ptr [g_wRetSaved], 0
+        ret
+    }
+}
+
+__declspec(naked) void w_detour() {
+    __asm {
+        push eax
+        ; only OUR two skeleton instances (ecx = this): every other skeletal
+        ; mesh in the level passes straight through untouched
+        cmp ecx, [g_skel]
+        je ours
+        cmp ecx, [g_wSkel]
+        jne passthrough
+      ours:
+        mov eax, fs:[0x24]           ; current thread id (TEB)
+        cmp eax, [g_wTid]
+        jne passthrough
+        cmp dword ptr [g_wRetSaved], 0
+        jne passthrough              ; nested call - leave it alone
+        mov eax, [esp + 4]           ; the caller's return address
+        mov [g_wRetSaved], eax
+        mov eax, offset w_ret_stub
+        mov [esp + 4], eax
+      passthrough:
+        pop eax
+        jmp dword ptr [g_wOrig]
+    }
+}
+} // namespace
+
+// The writer's call site (RVA 0x5FB810, named by the watch's EBP chain) is
+// `mov eax,[esi]; call [eax+0xA4]` guarded by `cmp byte [esi+0xA0],0` - a
+// dirty-flagged virtual update on the skeleton instance (slot 0xA4/4 = 41 of
+// the SkeletonInstance vtable the rig scan already identifies), which is also
+// why pass 2 never restamps: the flag is clear by then.
+constexpr uint32_t kSkelInstUpdateSlot = 0xA4;
+
+bool wfix_install() {
+    if (g_wCreated) return true;
+    if (!g_imageBase) {
+        BVR_LOG("[b2r] wfix: image base unknown - resolve the rig first");
+        return false;
+    }
+    if (!g_gameBase) module_range(GetModuleHandleW(nullptr), &g_gameBase, &g_gameEnd);
+    const uint8_t* vt = g_imageBase + patterns::kSkeletonInstanceVtableRva;
+    if (!is_memory_valid(vt + kSkelInstUpdateSlot, sizeof(void*))) {
+        BVR_LOG("[b2r] wfix: SkeletonInstance vtable slot unreadable");
+        return false;
+    }
+    uint8_t* target = *reinterpret_cast<uint8_t* const*>(vt + kSkelInstUpdateSlot);
+    if (!is_memory_valid(target, 16)) {
+        BVR_LOG("[b2r] wfix: resolved target %p is not readable", target);
+        return false;
+    }
+    const uint32_t retRva = 0x5FB816;
+    g_wTid = scenedraw::draw_tid();
+    g_wTarget = target;
+    MH_STATUS st = MH_CreateHook(g_wTarget, reinterpret_cast<void*>(&w_detour), &g_wOrig);
+    if (st != MH_OK) {
+        BVR_LOG("[b2r] wfix: MH_CreateHook(0x%X) failed: %s",
+                static_cast<uint32_t>(reinterpret_cast<uintptr_t>(target) - g_gameBase),
+                MH_StatusToString(st));
+        return false;
+    }
+    st = MH_EnableHook(g_wTarget);
+    if (st != MH_OK) {
+        BVR_LOG("[b2r] wfix: MH_EnableHook failed: %s", MH_StatusToString(st));
+        return false;
+    }
+    g_wCreated = true;
+    BVR_LOG("[b2r] wfix: writer HOOKED at RVA 0x%X (from call site 0x%X; bytes %02X %02X %02X "
+            "%02X %02X %02X %02X %02X) - `vrbones wfix on` arms the post-writer repaint",
+            static_cast<uint32_t>(reinterpret_cast<uintptr_t>(target) - g_gameBase), retRva - 5,
+            target[0], target[1], target[2], target[3], target[4], target[5], target[6],
+            target[7]);
+    return true;
+}
+
+void wfix_set(bool on) {
+    if (on && !g_wCreated && !wfix_install()) return;
+    g_wPostFix.store(on, std::memory_order_relaxed);
+    BVR_LOG("[b2r] command: vrbones wfix %s (post-writer repaint in pass 1)", on ? "on" : "off");
+}
+
+void wfix_status() {
+    BVR_LOG("[b2r] wfix %s hooked=%d: writer returns seen %u (tick %u, pass1 %u, pass2 %u); "
+            "post-writer catches hands/weapon = %u/%u",
+            g_wPostFix.load() ? "ON" : "off", g_wCreated ? 1 : 0, g_wPost.load(),
+            g_wPostTick.load(), g_wPostPass1.load(), g_wPostPass2.load(),
+            g_catch[6][0].load(), g_catch[6][1].load());
+}
+
+void watch_status() {
+    BVR_LOG("[b2r] watch %s: hits ours=%u engine=%u foreign=%u, %d distinct sites",
+            g_watchOn.load() ? "ON" : "off", g_watchOurs.load(), g_watchEngine.load(),
+            g_watchForeign.load(), g_watchHitN.load());
+    int n = g_watchHitN.load(std::memory_order_relaxed);
+    static const char* kCtx[8] = {"tick", "pass1", "pass2", "?", "tick+flush",
+                                  "pass1+flush", "pass2+flush", "?"};
+    for (int i = 0; i < n; ++i) {
+        const WatchHit& h = g_watchHits[i];
+        BVR_LOG("[b2r]   writer RVA 0x%X x%u in %s <- 0x%X <- 0x%X <- 0x%X", h.eip, h.count,
+                kCtx[h.ctx & 7], h.ret[0], h.ret[1], h.ret[2]);
+    }
+}
+
+void race_snapshot(RaceStats* out) {
+    if (!out) return;
+    for (int p = 0; p < 6; ++p) {
+        out->calls[p] = g_probeCalls[p].load(std::memory_order_relaxed);
+        for (int k = 0; k < 2; ++k)
+            out->foreign[p][k] = g_probeForeign[p][k].load(std::memory_order_relaxed);
+    }
+    for (int k = 0; k < 2; ++k) {
+        out->entryCatch[0][k] = g_catch[4][k].load(std::memory_order_relaxed);
+        out->entryCatch[1][k] = g_catch[5][k].load(std::memory_order_relaxed);
+    }
+    for (int p = 0; p < 6; ++p)
+        out->firstDiff[p] = g_probeFirstDiff[p].load(std::memory_order_relaxed);
+    out->entryFix[0] = g_entryFix[0].load(std::memory_order_relaxed);
+    out->entryFix[1] = g_entryFix[1].load(std::memory_order_relaxed);
+    out->fullMask = g_fullMask.load(std::memory_order_relaxed);
+}
+
+void set_entry_fix(int pass, bool on) {
+    if (pass < 0 || pass > 1) return;
+    g_entryFix[pass].store(on, std::memory_order_relaxed);
+}
+
+bool entry_fix(int pass) {
+    return (pass < 0 || pass > 1) ? false : g_entryFix[pass].load(std::memory_order_relaxed);
 }
 
 void set_anim_mode(bool on) {
@@ -1171,6 +1595,56 @@ bool handle_command(const char* args) {
             g_flickLog.store(false, std::memory_order_relaxed);
         BVR_LOG("[b2r] command: vrbones flick %s (counters always count)",
                 g_flickLog.load(std::memory_order_relaxed) ? "on" : "off");
+        return true;
+    }
+    if (strncmp(args, "p1fix", 5) == 0 || strncmp(args, "p2fix", 5) == 0) {
+        // p1fix|p2fix on|off - repaint the driven pose at that pass's ENTRY
+        // (the session-74 fix candidate; the [race] line grades it).
+        int pass = args[1] == '2' ? 1 : 0;
+        if (strstr(args + 5, "on")) set_entry_fix(pass, true);
+        else if (strstr(args + 5, "off")) set_entry_fix(pass, false);
+        BVR_LOG("[b2r] command: vrbones p%dfix %s (entry repaint pass 1=%d pass 2=%d)",
+                pass + 1, entry_fix(pass) ? "on" : "off", entry_fix(0) ? 1 : 0,
+                entry_fix(1) ? 1 : 0);
+        return true;
+    }
+    if (strncmp(args, "race", 4) == 0) {
+        RaceStats rs;
+        race_snapshot(&rs);
+        BVR_LOG("[b2r] race totals: p1 entry=%u/%u flush=%u/%u drained=%u/%u | "
+                "p2 entry=%u/%u flush=%u/%u drained=%u/%u | calls %u/%u/%u/%u/%u/%u "
+                "| firstDiff %d/%d/%d/%d/%d/%d | entry catches p1=%u/%u p2=%u/%u | "
+                "fix p1=%d p2=%d fullmask=%d (hands/weapon)",
+                rs.foreign[0][0], rs.foreign[0][1], rs.foreign[1][0], rs.foreign[1][1],
+                rs.foreign[2][0], rs.foreign[2][1], rs.foreign[3][0], rs.foreign[3][1],
+                rs.foreign[4][0], rs.foreign[4][1], rs.foreign[5][0], rs.foreign[5][1],
+                rs.calls[0], rs.calls[1], rs.calls[2], rs.calls[3], rs.calls[4],
+                rs.calls[5], rs.firstDiff[0], rs.firstDiff[1], rs.firstDiff[2],
+                rs.firstDiff[3], rs.firstDiff[4], rs.firstDiff[5],
+                rs.entryCatch[0][0], rs.entryCatch[0][1], rs.entryCatch[1][0],
+                rs.entryCatch[1][1], rs.entryFix[0] ? 1 : 0, rs.entryFix[1] ? 1 : 0,
+                rs.fullMask ? 1 : 0);
+        return true;
+    }
+    if (strncmp(args, "wfix", 4) == 0) {
+        if (strstr(args + 4, "on")) wfix_set(true);
+        else if (strstr(args + 4, "off")) wfix_set(false);
+        else if (strstr(args + 4, "install")) wfix_install();
+        wfix_status();
+        return true;
+    }
+    if (strncmp(args, "watch", 5) == 0) {
+        if (strstr(args + 5, "on")) watch_set(true);
+        else if (strstr(args + 5, "off")) watch_set(false);
+        watch_status();
+        return true;
+    }
+    if (strncmp(args, "fullmask", 8) == 0) {
+        if (strstr(args + 8, "on")) set_full_mask(true);
+        else if (strstr(args + 8, "off")) set_full_mask(false);
+        BVR_LOG("[b2r] command: vrbones fullmask %s (repaint decision scans %s)",
+                full_mask() ? "on" : "off",
+                full_mask() ? "every masked bone" : "the first masked bone only");
         return true;
     }
     if (strncmp(args, "diag31", 6) == 0) {

--- a/src/game/bioshock2r/bones.cpp
+++ b/src/game/bioshock2r/bones.cpp
@@ -1300,6 +1300,9 @@ void wfix_set(bool on) {
     BVR_LOG("[b2r] command: vrbones wfix %s (post-writer repaint in pass 1)", on ? "on" : "off");
 }
 
+bool wfix_enabled() { return g_wPostFix.load(std::memory_order_relaxed); }
+bool wfix_hooked() { return g_wCreated; }
+
 void wfix_status() {
     BVR_LOG("[b2r] wfix %s hooked=%d: writer returns seen %u (tick %u, pass1 %u, pass2 %u); "
             "post-writer catches hands/weapon = %u/%u",

--- a/src/game/bioshock2r/bones.cpp
+++ b/src/game/bioshock2r/bones.cpp
@@ -170,6 +170,14 @@ std::atomic<bool> g_entryFix[2] = {}; // repaint at pass 1 / pass 2 ENTRY
 // it. fullmask makes the repaint decision (and the probe, always) scan every
 // masked bone: `vrbones fullmask on|off`.
 std::atomic<bool> g_fullMask{false};
+// The race probe is a diagnostic (its answer is in ENGINE_NOTES s74); it costs
+// syscalls at six points per pair, so it is OFF unless armed (`vrbones race
+// on`, or diag31).
+std::atomic<bool> g_raceProbe{false};
+// The writer hook installs from the game thread's poll lane (outside hooked
+// calls), never from inside a Draw or the overlay: rig resolve and the F10
+// checkbox only POST the request here.
+std::atomic<bool> g_wfixPending{false};
 
 void note_catch(int phase, int kind, uint32_t latMs) {
     if (phase < 0 || phase > 7) return;
@@ -280,7 +288,9 @@ bool resolve_rig() {
     // it here means the driven pose is repainted the moment it returns. The
     // hook is a static vtable slot, so installing once is enough; the
     // this-filter in the detour follows g_skel/g_wSkel across re-resolves.
-    wfix_install();
+    // POSTED, not installed: this runs inside the CalcView dispatch of a
+    // hooked Draw, and hooks install only from the poll lane (apply_pending_wfix).
+    g_wfixPending.store(true, std::memory_order_relaxed);
     return true;
 }
 
@@ -922,9 +932,11 @@ void pe_repaint(int site) {
     const bool scanAll = g_fullMask.load(std::memory_order_relaxed);
     for (int h = 0; h < 2; ++h) {
         if (now - g_writeStampMs[h] > 100) continue; // not driving, nothing to defend
-        if (!is_memory_valid(g_pose, g_boneCount * patterns::kSkelPoseStride)) return;
         // Sentinel (s41): the first masked bone; fullmask (s74): any masked bone.
+        // Compare FIRST: this runs on every ProcessEvent dispatch, and the
+        // VirtualQuery below is only worth paying once a restamp is in hand.
         if (first_foreign_bone(h, scanAll) < 0) continue;
+        if (!is_memory_valid(g_pose, g_boneCount * patterns::kSkelPoseStride)) return;
         // Session 41, absorb-then-recompose: the restamp is INPUT, not an
         // enemy - adopt it into g_anim first, then rewrite this frame
         // composed on the fresh pose. Pass 1 only: the second pass must
@@ -963,6 +975,7 @@ void pe_repaint(int site) {
 }
 
 void probe_point(int p) {
+    if (!g_raceProbe.load(std::memory_order_relaxed)) return;
     if (p < 0 || p > 5 || !g_pose || !g_refValid) return;
     g_probeCalls[p].fetch_add(1, std::memory_order_relaxed);
     uint64_t now = GetTickCount64();
@@ -987,6 +1000,8 @@ void probe_point(int p) {
 
 void set_full_mask(bool on) { g_fullMask.store(on, std::memory_order_relaxed); }
 bool full_mask() { return g_fullMask.load(std::memory_order_relaxed); }
+void set_race_probe(bool on) { g_raceProbe.store(on, std::memory_order_relaxed); }
+bool race_probe() { return g_raceProbe.load(std::memory_order_relaxed); }
 
 // --- Session 74: hardware write-watch on the sentinel bone -----------------
 // Every probe says the bank is ours at every point we can look, yet pass 1's
@@ -1246,12 +1261,12 @@ __declspec(naked) void w_detour() {
 }
 } // namespace
 
-// The writer's call site (RVA 0x5FB810, named by the watch's EBP chain) is
-// `mov eax,[esi]; call [eax+0xA4]` guarded by `cmp byte [esi+0xA0],0` - a
-// dirty-flagged virtual update on the skeleton instance (slot 0xA4/4 = 41 of
-// the SkeletonInstance vtable the rig scan already identifies), which is also
-// why pass 2 never restamps: the flag is clear by then.
-constexpr uint32_t kSkelInstUpdateSlot = 0xA4;
+// The writer's call site (patterns::kSkelInstUpdateCallSiteRva, named by the
+// watch's EBP chain) is `mov eax,[esi]; call [eax+0xA4]` guarded by
+// `cmp byte [esi+0xA0],0` - a dirty-flagged virtual update on the skeleton
+// instance (patterns::kSkelInstUpdateSlot of the SkeletonInstance vtable the
+// rig scan already identifies), which is also why pass 2 never restamps: the
+// flag is clear by then.
 
 bool wfix_install() {
     if (g_wCreated) return true;
@@ -1261,43 +1276,61 @@ bool wfix_install() {
     }
     if (!g_gameBase) module_range(GetModuleHandleW(nullptr), &g_gameBase, &g_gameEnd);
     const uint8_t* vt = g_imageBase + patterns::kSkeletonInstanceVtableRva;
-    if (!is_memory_valid(vt + kSkelInstUpdateSlot, sizeof(void*))) {
+    if (!is_memory_valid(vt + patterns::kSkelInstUpdateSlot, sizeof(void*))) {
         BVR_LOG("[b2r] wfix: SkeletonInstance vtable slot unreadable");
         return false;
     }
-    uint8_t* target = *reinterpret_cast<uint8_t* const*>(vt + kSkelInstUpdateSlot);
+    uint8_t* target = *reinterpret_cast<uint8_t* const*>(vt + patterns::kSkelInstUpdateSlot);
     if (!is_memory_valid(target, 16)) {
         BVR_LOG("[b2r] wfix: resolved target %p is not readable", target);
         return false;
     }
-    const uint32_t retRva = 0x5FB816;
+    // The tid is refreshed at every Draw entry (wfix_on_draw_entry); this is
+    // only the value until the next Draw.
     g_wTid = scenedraw::draw_tid();
     g_wTarget = target;
     MH_STATUS st = MH_CreateHook(g_wTarget, reinterpret_cast<void*>(&w_detour), &g_wOrig);
-    if (st != MH_OK) {
+    // A hook that was created but failed to enable last time is still there:
+    // retry the enable rather than failing forever on ALREADY_CREATED.
+    if (st != MH_OK && st != MH_ERROR_ALREADY_CREATED) {
         BVR_LOG("[b2r] wfix: MH_CreateHook(0x%X) failed: %s",
                 static_cast<uint32_t>(reinterpret_cast<uintptr_t>(target) - g_gameBase),
                 MH_StatusToString(st));
         return false;
     }
     st = MH_EnableHook(g_wTarget);
-    if (st != MH_OK) {
+    if (st != MH_OK && st != MH_ERROR_ENABLED) {
         BVR_LOG("[b2r] wfix: MH_EnableHook failed: %s", MH_StatusToString(st));
         return false;
     }
     g_wCreated = true;
-    BVR_LOG("[b2r] wfix: writer HOOKED at RVA 0x%X (from call site 0x%X; bytes %02X %02X %02X "
-            "%02X %02X %02X %02X %02X) - `vrbones wfix on` arms the post-writer repaint",
-            static_cast<uint32_t>(reinterpret_cast<uintptr_t>(target) - g_gameBase), retRva - 5,
-            target[0], target[1], target[2], target[3], target[4], target[5], target[6],
-            target[7]);
+    BVR_LOG("[b2r] wfix: writer HOOKED at RVA 0x%X (slot 0x%X, call site 0x%X; bytes %02X "
+            "%02X %02X %02X %02X %02X %02X %02X) - `vrbones wfix off` is the A/B",
+            static_cast<uint32_t>(reinterpret_cast<uintptr_t>(target) - g_gameBase),
+            patterns::kSkelInstUpdateSlot, patterns::kSkelInstUpdateCallSiteRva, target[0],
+            target[1], target[2], target[3], target[4], target[5], target[6], target[7]);
     return true;
 }
 
+void apply_pending_wfix() {
+    if (!g_wfixPending.load(std::memory_order_relaxed)) return;
+    if (g_wCreated || wfix_install()) g_wfixPending.store(false, std::memory_order_relaxed);
+}
+
+void wfix_on_draw_entry(uint32_t tid) {
+    // Every Draw entry on the game thread: refresh the thread the detour
+    // accepts (it was 0 if the rig resolved before the first hooked Draw) and
+    // clear the saved-return slot - nothing of ours is on the stack here, so a
+    // slot left set by an unwind that skipped the ret stub is stale.
+    g_wTid = tid;
+    g_wRetSaved = 0;
+}
+
 void wfix_set(bool on) {
-    if (on && !g_wCreated && !wfix_install()) return;
+    if (on && !g_wCreated) g_wfixPending.store(true, std::memory_order_relaxed); // poll lane installs
     g_wPostFix.store(on, std::memory_order_relaxed);
-    BVR_LOG("[b2r] command: vrbones wfix %s (post-writer repaint in pass 1)", on ? "on" : "off");
+    BVR_LOG("[b2r] command: vrbones wfix %s (post-writer repaint in pass 1%s)", on ? "on" : "off",
+            (on && !g_wCreated) ? "; hook install posted to the poll lane" : "");
 }
 
 bool wfix_enabled() { return g_wPostFix.load(std::memory_order_relaxed); }
@@ -1384,6 +1417,9 @@ void flicker_snapshot(FlickerStats* out) {
         // semantics without a second clear pass racing a concurrent catch.
         out->dmaxMs[p] = g_catchDeltaMaxMs[p].exchange(0, std::memory_order_relaxed);
     }
+    // Phases 4-7 (s74 entry / post-writer sites) are read by the [race] and
+    // wfix reports; drain their window max here too so it does not pin.
+    for (int p = 4; p < 8; ++p) g_catchDeltaMaxMs[p].exchange(0, std::memory_order_relaxed);
     out->driveAdoptEvents[0] = g_driveAdoptEvents[0].load(std::memory_order_relaxed);
     out->driveAdoptEvents[1] = g_driveAdoptEvents[1].load(std::memory_order_relaxed);
     out->adopts[0] = g_adopts[0].load(std::memory_order_relaxed);
@@ -1436,6 +1472,7 @@ void on_world_change(const char* why) {
     g_scanDormant = false;
     g_scanMisses = 0;
     g_worldChanges.fetch_add(1, std::memory_order_relaxed); // flicker correlate
+    g_wRetSaved = 0; // a world change can unwind past the writer ret-stub
 }
 
 void* hands_actor() {
@@ -1566,7 +1603,7 @@ bool handle_command(const char* args) {
         {
             // Session 42: cumulative flicker catches + the printed invariant.
             uint32_t sum = 0;
-            for (int p = 0; p < 4; ++p)
+            for (int p = 0; p < 8; ++p) // s74: phases 4-7 (entry / post-writer) count too
                 for (int k = 0; k < 2; ++k)
                     sum += g_catch[p][k].load(std::memory_order_relaxed);
             uint32_t pe = g_peRepaints.load(std::memory_order_relaxed);
@@ -1612,6 +1649,10 @@ bool handle_command(const char* args) {
         return true;
     }
     if (strncmp(args, "race", 4) == 0) {
+        // race [on|off] - arm/disarm the six-point probe (off by default: it
+        // costs syscalls per pair), then print the totals either way.
+        if (strstr(args + 4, "on")) set_race_probe(true);
+        else if (strstr(args + 4, "off")) set_race_probe(false);
         RaceStats rs;
         race_snapshot(&rs);
         BVR_LOG("[b2r] race totals: p1 entry=%u/%u flush=%u/%u drained=%u/%u | "
@@ -1659,9 +1700,11 @@ bool handle_command(const char* args) {
             g_flickLog.store(true, std::memory_order_relaxed);
             bvr::vr::set_pair_edge_log(true);
             bvr::hud::set_gate_log(true);
+            set_race_probe(true);
         } else if (strstr(args + 6, "off")) {
             bvr::vr::set_pair_edge_log(false);
             bvr::hud::set_gate_log(false);
+            set_race_probe(false);
         }
         BVR_LOG("[b2r] command: vrbones diag31 %s (minute lines %s, pairEdge "
                 "%s, hudgate %s)",

--- a/src/game/bioshock2r/bones.cpp
+++ b/src/game/bioshock2r/bones.cpp
@@ -1173,6 +1173,27 @@ bool handle_command(const char* args) {
                 g_flickLog.load(std::memory_order_relaxed) ? "on" : "off");
         return true;
     }
+    if (strncmp(args, "diag31", 6) == 0) {
+        // diag31 on|off|status - the issue-#31 umbrella: minute lines
+        // ([flick]+[pair]) plus the event-edge witnesses ([pairEdge] pairing
+        // breaks in core, [hudgate] one-eye HUD-burn intervals). One verb so a
+        // tester arms everything the hunt needs in one line.
+        if (strstr(args + 6, "on")) {
+            g_flickLog.store(true, std::memory_order_relaxed);
+            bvr::vr::set_pair_edge_log(true);
+            bvr::hud::set_gate_log(true);
+        } else if (strstr(args + 6, "off")) {
+            bvr::vr::set_pair_edge_log(false);
+            bvr::hud::set_gate_log(false);
+        }
+        BVR_LOG("[b2r] command: vrbones diag31 %s (minute lines %s, pairEdge "
+                "%s, hudgate %s)",
+                bvr::vr::pair_edge_log() ? "on" : "off",
+                g_flickLog.load(std::memory_order_relaxed) ? "on" : "off",
+                bvr::vr::pair_edge_log() ? "on" : "off",
+                bvr::hud::gate_log() ? "on" : "off");
+        return true;
+    }
     // cluster l|r <lo> <hi> <anchor> [extra]
     if (sscanf_s(args, "cluster %7s %d %d %d %d", side, (unsigned)sizeof side, &lo, &hi,
                  &anchor, &extra) >= 4) {

--- a/src/game/bioshock2r/bones.h
+++ b/src/game/bioshock2r/bones.h
@@ -148,6 +148,8 @@ void watch_status();
 bool wfix_install();
 void wfix_set(bool on);
 void wfix_status();
+bool wfix_enabled(); // the post-writer repaint is armed (F10 A/B checkbox)
+bool wfix_hooked();  // the writer hook is installed (rig resolved at least once)
 // `vrbones flick on|off` gates only the [flick] minute log line; the counters
 // always count (they are a handful of relaxed atomics on actual catches).
 bool flicker_log();

--- a/src/game/bioshock2r/bones.h
+++ b/src/game/bioshock2r/bones.h
@@ -117,6 +117,37 @@ struct FlickerStats {
     uint32_t wRescans;
 };
 void flicker_snapshot(FlickerStats* out);
+
+// Session 74: the pose-RACE probe. Samples the drive's sentinel bones at six
+// points of the stereo pair - 0 pass-1 entry, 1 pass-1 flush (before the
+// repaint), 2 pass-1 post-drain, 3 pass-2 entry, 4 pass-2 flush, 5 pass-2
+// post-drain - and counts "bank is foreign here", per hands bank / weapon
+// skeleton. pe_repaint(2) is the pass-ENTRY repaint (phases 4/5 in the catch
+// table), armed per pass by set_entry_fix (`vrbones p1fix|p2fix`).
+struct RaceStats {
+    uint32_t calls[6] = {};
+    uint32_t foreign[6][2] = {};
+    int firstDiff[6] = {};          // last first-differing hand bone at that point
+    uint32_t entryCatch[2][2] = {}; // [pass][hands/weapon]
+    bool entryFix[2] = {};
+    bool fullMask = false;
+};
+void probe_point(int p);
+void race_snapshot(RaceStats* out);
+void set_entry_fix(int pass, bool on);
+bool entry_fix(int pass);
+// s74: repaint decision scans every masked bone instead of the first one.
+void set_full_mask(bool on);
+bool full_mask();
+// s74: hardware write-watch on the sentinel bone (`vrbones watch on|off`);
+// status lists the engine writer RVAs and where in the pair they fired.
+void watch_set(bool on);
+void watch_status();
+// s74 fix: hook the writer the watch named and repaint the driven pose right
+// after it returns inside pass 1 (`vrbones wfix install|on|off|status`).
+bool wfix_install();
+void wfix_set(bool on);
+void wfix_status();
 // `vrbones flick on|off` gates only the [flick] minute log line; the counters
 // always count (they are a handful of relaxed atomics on actual catches).
 bool flicker_log();

--- a/src/game/bioshock2r/bones.h
+++ b/src/game/bioshock2r/bones.h
@@ -145,9 +145,14 @@ void watch_set(bool on);
 void watch_status();
 // s74 fix: hook the writer the watch named and repaint the driven pose right
 // after it returns inside pass 1 (`vrbones wfix install|on|off|status`).
-bool wfix_install();
+bool wfix_install();       // installs NOW - call only from the game thread's poll lane
+void apply_pending_wfix(); // poll lane: installs a posted request (rig resolve / F10)
+void wfix_on_draw_entry(uint32_t tid); // DrawDetour depth 0: refresh tid, clear the ret slot
 void wfix_set(bool on);
 void wfix_status();
+// s74: the six-point race probe is off unless armed (it costs syscalls per pair).
+void set_race_probe(bool on);
+bool race_probe();
 bool wfix_enabled(); // the post-writer repaint is armed (F10 A/B checkbox)
 bool wfix_hooked();  // the writer hook is installed (rig resolved at least once)
 // `vrbones flick on|off` gates only the [flick] minute log line; the counters

--- a/src/game/bioshock2r/camera.cpp
+++ b/src/game/bioshock2r/camera.cpp
@@ -3052,6 +3052,16 @@ void draw_debug_ui() {
             if (ImGui::SliderFloat("anim wrist travel (0 = glued)", &at, 0.0f, 1.0f))
                 bones::set_anim_trans(at);
         }
+
+        // Session 74: the left-eye flicker fix, exposed for an in-headset A/B
+        // (untick = the pre-fix behaviour: the engine's pass-1 skeleton update
+        // renders raw in the LEFT eye; tick = repainted the moment it returns).
+        ImGui::Separator();
+        bool wfix = bones::wfix_enabled();
+        if (ImGui::Checkbox("LEFT-EYE FLICKER FIX (s74)  <-- untick to compare", &wfix))
+            bones::wfix_set(wfix);
+        ImGui::SameLine();
+        ImGui::TextDisabled(bones::wfix_hooked() ? "(hooked)" : "(arms when the rig resolves)");
     }
 
     if (ImGui::CollapsingHeader("Camera debug")) {

--- a/src/game/bioshock2r/camera.cpp
+++ b/src/game/bioshock2r/camera.cpp
@@ -2403,6 +2403,9 @@ void __fastcall ProcessEventDetour(void* self, void* edx, void* fn, void* parms,
                 // game thread outside hooked calls. Also the MENU-arming
                 // path - BS2's menu never runs PlayerCalcView.
                 scenedraw::apply_pending_vrstereo();
+                // s74: the left-eye flicker writer hook installs from this
+                // same lane (rig resolve and the F10 checkbox only post it).
+                bones::apply_pending_wfix();
                 // Overlay/command-posted resolution apply (session 37): live
                 // window resize + ini persistence, on the game thread, and it
                 // works from the main menu for the same reason vrstereo

--- a/src/game/bioshock2r/patterns.h
+++ b/src/game/bioshock2r/patterns.h
@@ -476,6 +476,12 @@ constexpr uint32_t kSkelSharedDataOffset = 0x8;        // -> SharedSkeletonData
 // {fname_text-resolvable name, index in range} pairs; ambiguity or zero
 // candidates logs and falls back to the raw `vrbones map` dword dump.
 constexpr uint32_t kSkelPoseArrayOffset = 0x44;        // {data, count, max}
+// Session 74 (the left-eye flicker writer, ENGINE_NOTES s74): the dirty-flagged
+// pose update. `cmp byte [inst+0xA0],0; call [vtbl+0xA4]; mov byte [inst+0xA0],0`
+// at the call site below; the slot is what the wfix hook resolves at runtime.
+constexpr uint32_t kSkelInstDirtyOffset = 0xA0;        // byte: update pending
+constexpr uint32_t kSkelInstUpdateSlot = 0xA4;         // vtable byte offset (slot 41)
+constexpr uint32_t kSkelInstUpdateCallSiteRva = 0x5FB810; // FF 90 A4 00 00 00 (6 bytes)
 constexpr uint32_t kSkelPoseStride = 0x30;             // hkQsTransform
 constexpr uint32_t kSkelPoseTransOffset = 0x0;         // vec4
 constexpr uint32_t kSkelPoseQuatOffset = 0x10;         // xyzw

--- a/src/game/bioshock2r/scenedraw.cpp
+++ b/src/game/bioshock2r/scenedraw.cpp
@@ -999,7 +999,7 @@ void heartbeat(uint64_t now) {
         uint32_t skipForeign = g_foreignCallerSkips.load(std::memory_order_relaxed);
         BVR_LOG("[pair] min=%llu pairs=%u ab=%u(exp=%u lft=%u unt=%u) "
                 "cap=%u/%u stale=%u/%u age<=%u/%u ms acqF=%u waitF=%u untag=%u "
-                "skip=%u/%u/%u ring=%u/%u/%u skew=%u reb=%u mirror=%d",
+                "skip=%u/%u/%u ring=%u/%u/%u skew=%u reb=%u mirror=%d deep=%u",
                 static_cast<unsigned long long>((now - s_flickStartMs) / 60000),
                 pp.pairs - s_prevPair.pairs, pp.aborts - s_prevPair.aborts,
                 pp.abortExpired - s_prevPair.abortExpired,
@@ -1017,7 +1017,8 @@ void heartbeat(uint64_t now) {
                 pp.ringPopped - s_prevPair.ringPopped,
                 pp.ringDropped - s_prevPair.ringDropped,
                 pp.ringCleared - s_prevPair.ringCleared,
-                pp.rebuilds - s_prevPair.rebuilds, pp.mirrorOn ? 1 : 0);
+                pp.rebuilds - s_prevPair.rebuilds, pp.mirrorOn ? 1 : 0,
+                pp.popDeep - s_prevPair.popDeep);
         s_prevPair = pp;
         s_prevSkipSilent = skipSilent;
         s_prevSkipStall = skipStall;

--- a/src/game/bioshock2r/scenedraw.cpp
+++ b/src/game/bioshock2r/scenedraw.cpp
@@ -710,7 +710,15 @@ int force_inline_flush(void* scene, void* group) {
 //    [gate+8] -> latch) nanoseconds before the engine's own `cmp [esi+8],0`:
 //    latch clear = the Wait(INFINITE) will be entered. Under 1t wait2/s
 //    reads 0 - correctly, the freeze window is gone.
+std::atomic<int> g_inFlush; // defined with the s74 accessors below
+
+struct FlushScope {
+    FlushScope() { g_inFlush.fetch_add(1, std::memory_order_relaxed); }
+    ~FlushScope() { g_inFlush.fetch_sub(1, std::memory_order_relaxed); }
+};
+
 void __fastcall FlushPointDetour(void* ecx, void* edx, void* scene, void* group) {
+    FlushScope flushScope;
     g_flushPointEntries.fetch_add(1, std::memory_order_relaxed);
     // Session 41 round 2 (the residual left-eye flicker): this is the LAST
     // game-thread point before the inline drain submits the pass. A skeleton
@@ -719,6 +727,10 @@ void __fastcall FlushPointDetour(void* ecx, void* edx, void* scene, void* group)
     // it here. Self-gating (one 48-byte sentinel per driven hand when fresh,
     // no-op otherwise), pass-2 verbatim semantics live inside pe_repaint.
     // Session 42: site 1 = flush point, for the flicker catch-phase split.
+    // Session 74: race probe points 1/4 (flush, BEFORE the repaint) and 2/5
+    // (after the inline drain returned - did the drain itself write the bank?).
+    const bool inPass2 = g_inSecondDraw.load(std::memory_order_relaxed);
+    bvr::b2r::bones::probe_point(inPass2 ? 4 : 1);
     bvr::b2r::bones::pe_repaint(1);
     // Session 38: forcing the inline branch KEEPS RUNNING through teardown, on
     // purpose. The first version of this gate stopped forcing once a close
@@ -732,6 +744,7 @@ void __fastcall FlushPointDetour(void* ecx, void* edx, void* scene, void* group)
         int r = force_inline_flush(scene, group);
         if (r > 0) {
             g_forcedInline.fetch_add(1, std::memory_order_relaxed);
+            bvr::b2r::bones::probe_point(inPass2 ? 5 : 2);
             return;
         }
         if (r < 0) {
@@ -839,6 +852,10 @@ void maybe_second_draw(void* ecx, void* edx, void* a1, void* a2, void* a3, void*
     // trace say whether the game is sitting inside the RE-ENTERED scene draw.
     bvr::vr::set_draw_stage("secondDraw");
     g_inSecondDraw.store(true, std::memory_order_relaxed);
+    // Session 74: race probe point 3 (pass-2 entry) + the optional entry
+    // repaint (`vrbones p2fix on`) - pass 2 gets the verbatim driven pose.
+    bvr::b2r::bones::probe_point(3);
+    if (bvr::b2r::bones::entry_fix(1)) bvr::b2r::bones::pe_repaint(2);
     bool ok = call_draw_guarded(reinterpret_cast<DrawFn>(g_draw.original), ecx, edx, a1,
                                 a2, a3, a4);
     g_inSecondDraw.store(false, std::memory_order_relaxed);
@@ -1023,6 +1040,36 @@ void heartbeat(uint64_t now) {
         s_prevSkipSilent = skipSilent;
         s_prevSkipStall = skipStall;
         s_prevSkipForeign = skipForeign;
+
+        // Session 74: the pose-race probe, per-minute deltas. Each field is
+        // foreign-hands/foreign-weapon at that point of the pair; a nonzero
+        // column names WHERE the authored pose enters the frame.
+        static bones::RaceStats s_prevRace;
+        bones::RaceStats rs;
+        bones::race_snapshot(&rs);
+        BVR_LOG("[race] min=%llu p1 entry=%u/%u flush=%u/%u drained=%u/%u | "
+                "p2 entry=%u/%u flush=%u/%u drained=%u/%u | calls=%u/%u | "
+                "entryCatch p1=%u/%u p2=%u/%u | fix=%d/%d",
+                static_cast<unsigned long long>((now - s_flickStartMs) / 60000),
+                rs.foreign[0][0] - s_prevRace.foreign[0][0],
+                rs.foreign[0][1] - s_prevRace.foreign[0][1],
+                rs.foreign[1][0] - s_prevRace.foreign[1][0],
+                rs.foreign[1][1] - s_prevRace.foreign[1][1],
+                rs.foreign[2][0] - s_prevRace.foreign[2][0],
+                rs.foreign[2][1] - s_prevRace.foreign[2][1],
+                rs.foreign[3][0] - s_prevRace.foreign[3][0],
+                rs.foreign[3][1] - s_prevRace.foreign[3][1],
+                rs.foreign[4][0] - s_prevRace.foreign[4][0],
+                rs.foreign[4][1] - s_prevRace.foreign[4][1],
+                rs.foreign[5][0] - s_prevRace.foreign[5][0],
+                rs.foreign[5][1] - s_prevRace.foreign[5][1],
+                rs.calls[0] - s_prevRace.calls[0], rs.calls[3] - s_prevRace.calls[3],
+                rs.entryCatch[0][0] - s_prevRace.entryCatch[0][0],
+                rs.entryCatch[0][1] - s_prevRace.entryCatch[0][1],
+                rs.entryCatch[1][0] - s_prevRace.entryCatch[1][0],
+                rs.entryCatch[1][1] - s_prevRace.entryCatch[1][1],
+                rs.entryFix[0] ? 1 : 0, rs.entryFix[1] ? 1 : 0);
+        s_prevRace = rs;
     }
     s_prev = cur;
     s_prevStreams = streams;
@@ -1048,8 +1095,13 @@ void __fastcall DrawDetour(void* ecx, void* edx, void* a1, void* a2, void* a3, v
         // lone tag; core's tag ring self-heals at depth > 2.
         if (g_stereo.load(std::memory_order_relaxed) &&
             !g_poisoned.load(std::memory_order_relaxed) &&
-            callerRva == patterns::kSceneBuildGameplayRetRva)
+            callerRva == patterns::kSceneBuildGameplayRetRva) {
             bvr::vr::sr_push_eye(-1);
+            // Session 74: race probe point 0 (pass-1 entry) + the optional
+            // entry repaint (fix candidate, `vrbones p1fix on`).
+            bvr::b2r::bones::probe_point(0);
+            if (bvr::b2r::bones::entry_fix(0)) bvr::b2r::bones::pe_repaint(2);
+        }
     }
 
     LARGE_INTEGER t0, t1, freq;
@@ -1471,6 +1523,10 @@ bool in_second_draw() {
     uint32_t t = g_secondPassTid.load(std::memory_order_relaxed);
     return t != 0 && t == GetCurrentThreadId();
 }
+
+int draw_depth() { return g_activeDepth.load(std::memory_order_relaxed); }
+bool in_flush() { return g_inFlush.load(std::memory_order_relaxed) != 0; }
+uint32_t draw_tid() { return g_lastDrawTid.load(std::memory_order_relaxed); }
 
 void request_vrstereo(bool on) {
     g_vrstereoPending.store(on ? 1 : 0, std::memory_order_relaxed);

--- a/src/game/bioshock2r/scenedraw.cpp
+++ b/src/game/bioshock2r/scenedraw.cpp
@@ -1047,6 +1047,7 @@ void heartbeat(uint64_t now) {
         static bones::RaceStats s_prevRace;
         bones::RaceStats rs;
         bones::race_snapshot(&rs);
+        if (bones::race_probe())
         BVR_LOG("[race] min=%llu p1 entry=%u/%u flush=%u/%u drained=%u/%u | "
                 "p2 entry=%u/%u flush=%u/%u drained=%u/%u | calls=%u/%u | "
                 "entryCatch p1=%u/%u p2=%u/%u | fix=%d/%d",
@@ -1088,6 +1089,7 @@ void __fastcall DrawDetour(void* ecx, void* edx, void* a1, void* a2, void* a3, v
     uint32_t presentLowAtEntry = static_cast<uint32_t>(bvr::d3d11_hook::present_count());
     if (depth == 0) {
         g_activeTid.store(tid, std::memory_order_relaxed);
+        bvr::b2r::bones::wfix_on_draw_entry(tid); // s74: writer hook tid refresh + ret-slot reset
         probe_cam_actor(a1);
         // Pass-1 eye tag: this Draw's present captures as the LEFT eye. The
         // camera side caches the driven base and applies -IPD/2 on the

--- a/src/game/bioshock2r/scenedraw.h
+++ b/src/game/bioshock2r/scenedraw.h
@@ -65,6 +65,15 @@ bool second_pass_for_current_thread(float* yawDegOut);
 // dispatch accounting.
 bool in_second_draw();
 
+// Session 74 (the write-watch): where in the pair the current thread is.
+// draw_depth 0 = outside any hooked Draw (the game tick), 1 = inside pass 1
+// (or pass 2 - combine with in_second_draw), in_flush = inside the flush
+// point detour (traversal done, drain pending/done). draw_tid = the thread
+// that last entered Draw (the game thread under 1t).
+int draw_depth();
+bool in_flush();
+uint32_t draw_tid();
+
 // One-toggle "VR stereo" request: posts the on/off intent; the game thread
 // applies camera mode + stereo outside any hooked call (the overlay checkbox
 // draws on the render thread and must never install hooks itself).

--- a/src/tools/xrsim/xrsim_compositor.cpp
+++ b/src/tools/xrsim/xrsim_compositor.cpp
@@ -451,7 +451,10 @@ void compositor_init(ID3D11Device* device, ID3D11DeviceContext* context) {
     XRSIM_LOG("xrsim: compositor ready");
 }
 
+void compositor_hash_cleanup(); // defined with the hash-log statics below
+
 void compositor_shutdown() {
+    compositor_hash_cleanup();
     if (g_encodeRunning.exchange(false)) {
         g_qCv.notify_all();
         if (g_encodeThread.joinable()) g_encodeThread.join();
@@ -895,6 +898,155 @@ void compositor_on_end_frame(const SimSubmission& sub, bool capture) {
         g_queue.push_back(std::move(job));
     }
     g_qCv.notify_one();
+}
+
+// ---------------------------------------------------------------------------
+// Per-eye source-hash log (the BS2 left-eye flicker hunt, issue #31)
+// ---------------------------------------------------------------------------
+// Fingerprints the PROJECTION layer's two source textures - the exact images
+// the game released for each eye - NOT the composited RT: quad layers (laser,
+// HUD) move with the head, so a frozen eye image would still change the
+// composite and mask itself. A repeated hashL while hashR advances is the
+// stale-left signature; hashL matching the previous hashR is the eye-swap
+// signature. relAge counts submitted frames since that eye's swapchain was
+// last released into - the runtime-side witness of "this eye held an old
+// image", independent of the mod's own [pair] bookkeeping.
+// Runs on the present thread inside xrEndFrame (same thread as the capture
+// path), so the statics below need no lock.
+
+namespace {
+
+ID3D11Texture2D* g_hashStaging[2] = {};
+uint32_t g_hashW[2] = {}, g_hashH[2] = {};
+DXGI_FORMAT g_hashFmt[2] = {DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_UNKNOWN};
+FILE* g_hashFile = nullptr;
+bool g_hashFileFailed = false;
+
+bool hash_source_tex(int eye, ID3D11Texture2D* tex, uint64_t* outHash, double* outLuma) {
+    if (!tex || !g_device || !g_ctx) return false;
+    D3D11_TEXTURE2D_DESC d{};
+    tex->GetDesc(&d);
+    if (g_hashStaging[eye] &&
+        (g_hashW[eye] != d.Width || g_hashH[eye] != d.Height || g_hashFmt[eye] != d.Format)) {
+        g_hashStaging[eye]->Release();
+        g_hashStaging[eye] = nullptr;
+    }
+    if (!g_hashStaging[eye]) {
+        D3D11_TEXTURE2D_DESC sd = d;
+        sd.Usage = D3D11_USAGE_STAGING;
+        sd.BindFlags = 0;
+        sd.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+        sd.MiscFlags = 0;
+        sd.MipLevels = 1;
+        sd.ArraySize = 1;
+        sd.SampleDesc = {1, 0};
+        if (FAILED(g_device->CreateTexture2D(&sd, nullptr, &g_hashStaging[eye]))) return false;
+        g_hashW[eye] = d.Width;
+        g_hashH[eye] = d.Height;
+        g_hashFmt[eye] = d.Format;
+    }
+    g_ctx->CopyResource(g_hashStaging[eye], tex);
+    D3D11_MAPPED_SUBRESOURCE m{};
+    if (FAILED(g_ctx->Map(g_hashStaging[eye], 0, D3D11_MAP_READ, 0, &m))) return false;
+    // FNV-1a over a fixed subsample (every 8th row, every 4th texel): the grid
+    // is deterministic, so identical images always agree, and any real frame
+    // change lands on it. 2560x2560 -> ~205k texels, well under a millisecond.
+    uint64_t hsh = 1469598103934665603ull;
+    uint64_t lumaSum = 0, samples = 0;
+    const auto* base = static_cast<const uint8_t*>(m.pData);
+    for (uint32_t y = 0; y < d.Height; y += 8) {
+        const uint8_t* row = base + static_cast<size_t>(y) * m.RowPitch;
+        for (uint32_t x = 0; x < d.Width; x += 4) {
+            uint32_t px;
+            memcpy(&px, row + static_cast<size_t>(x) * 4, 4);
+            hsh ^= px;
+            hsh *= 1099511628211ull;
+            const uint32_t rr = px & 0xFF, gg = (px >> 8) & 0xFF, bb = (px >> 16) & 0xFF;
+            lumaSum += (rr * 77 + gg * 151 + bb * 28) >> 8;
+            ++samples;
+        }
+    }
+    g_ctx->Unmap(g_hashStaging[eye], 0);
+    *outHash = hsh;
+    *outLuma = samples ? static_cast<double>(lumaSum) / samples : 0.0;
+    return true;
+}
+
+} // namespace
+
+void compositor_hash_cleanup() {
+    for (int e = 0; e < 2; ++e) {
+        if (g_hashStaging[e]) {
+            g_hashStaging[e]->Release();
+            g_hashStaging[e] = nullptr;
+        }
+        g_hashW[e] = g_hashH[e] = 0;
+        g_hashFmt[e] = DXGI_FORMAT_UNKNOWN;
+    }
+    if (g_hashFile) {
+        fclose(g_hashFile);
+        g_hashFile = nullptr;
+    }
+    g_hashFileFailed = false;
+}
+
+void compositor_hash_frame(const SimSubmission& sub) {
+    if (!g_device || !g_ctx) return;
+
+    const SimLayer* proj = nullptr;
+    for (uint32_t i = 0; i < sub.layerCount; ++i) {
+        if (sub.layers[i].type == XR_TYPE_COMPOSITION_LAYER_PROJECTION) {
+            proj = &sub.layers[i];
+            break;
+        }
+    }
+
+    uint64_t hsh[2] = {};
+    double luma[2] = {};
+    uint32_t idx[2] = {}, relFrame[2] = {}, relAge[2] = {};
+    if (proj) {
+        for (int e = 0; e < 2 && e < static_cast<int>(proj->viewCount); ++e) {
+            const XrSwapchain swp = proj->views[e].subImage.swapchain;
+            if (!swapchain_release_info(swp, &idx[e], &relFrame[e])) continue;
+            relAge[e] = (sub.frameIndex >= relFrame[e])
+                            ? static_cast<uint32_t>(sub.frameIndex - relFrame[e])
+                            : 0;
+            hash_source_tex(e, swapchain_last_image(swp, nullptr, nullptr), &hsh[e], &luma[e]);
+        }
+    }
+
+    for (int e = 0; e < 2; ++e) {
+        g.lastEyeHash[e].store(hsh[e]);
+        g.lastEyeRelAge[e].store(relAge[e]);
+    }
+    g.lastEyeHashFrame.store(sub.frameIndex);
+
+    if (!g_hashFile && !g_hashFileFailed) {
+        wchar_t p[MAX_PATH];
+        swprintf_s(p, L"%s\\capture\\eyehash.tsv", log::dir());
+        g_hashFile = _wfsopen(p, L"w", _SH_DENYNO);
+        if (!g_hashFile) {
+            g_hashFileFailed = true;
+            XRSIM_LOG_ONCE("xrsim: eyehash.tsv could not be opened - hash log disabled");
+            return;
+        }
+        fputs("frame\tdisplayNs\tproj\thashL\thashR\trelAgeL\trelAgeR\timgIdxL\timgIdxR"
+              "\tlumaL\tlumaR\tlayers\tstate\n",
+              g_hashFile);
+    }
+    if (g_hashFile) {
+        fprintf(g_hashFile,
+                "%llu\t%lld\t%d\t%016llx\t%016llx\t%u\t%u\t%u\t%u\t%.2f\t%.2f\t%u\t%s\n",
+                static_cast<unsigned long long>(sub.frameIndex),
+                static_cast<long long>(sub.displayTime), proj ? 1 : 0,
+                static_cast<unsigned long long>(hsh[0]), static_cast<unsigned long long>(hsh[1]),
+                relAge[0], relAge[1], idx[0], idx[1], luma[0], luma[1], sub.layerCount,
+                session_state_name(sub.snap.state));
+        // Flushed per line so a live tail (and a post-crash read) always sees
+        // the latest frame; at 80 presents/s the cost is noise next to the
+        // staging Map above.
+        fflush(g_hashFile);
+    }
 }
 
 } // namespace xrsim

--- a/src/tools/xrsim/xrsim_control.cpp
+++ b/src/tools/xrsim/xrsim_control.cpp
@@ -533,7 +533,13 @@ void apply_line(const char* line) {
     // --- capture ------------------------------------------------------------
     if (a.is(0, "capture")) {
         if (a.is(1, "next")) g.captureCountdown.store(a.u(2, 1));
-        else if (a.is(1, "every")) g.captureEvery.store(a.u(2, 0));
+        else if (a.is(1, "every")) {
+            // A `shot <name>` leaves its tag behind; a sequence run with the
+            // tag still set would overwrite ONE file forever, so arming the
+            // sequence clears it and restores frame-index naming.
+            g.captureTag[0] = '\0';
+            g.captureEvery.store(a.u(2, 0));
+        }
         else if (a.is(1, "off")) { g.captureCountdown.store(0); g.captureEvery.store(0); }
         else if (a.is(1, "layers")) g.captureLayers.store(!a.is(2, "off"));
         else if (a.is(1, "size")) { g.captureWidth.store(a.u(2, 1032)); g.captureHeight.store(a.u(3, 1104)); }
@@ -544,6 +550,15 @@ void apply_line(const char* line) {
     if (a.is(0, "shot")) {
         if (a.n > 1) strncpy_s(g.captureTag, a.s(1), _TRUNCATE);
         g.captureCountdown.store(1);
+        return;
+    }
+    // Per-eye source-hash log (issue #31): `hash every <n>` appends one TSV
+    // line per Nth submitted frame to capture\eyehash.tsv; `hash off` stops.
+    if (a.is(0, "hash")) {
+        if (a.is(1, "every")) g.hashEvery.store(a.u(2, 1));
+        else if (a.is(1, "on")) g.hashEvery.store(1);
+        else if (a.is(1, "off")) g.hashEvery.store(0);
+        else set_error("unknown hash subcommand '%s' (every <n>|on|off)", a.s(1));
         return;
     }
     if (a.is(0, "compose")) {
@@ -576,6 +591,7 @@ void apply_line(const char* line) {
         g.captureCountdown.store(0);
         g.captureEvery.store(0);
         g.captureLayers.store(true);
+        g.hashEvery.store(0);
         pacing_wake();
         return;
     }
@@ -676,6 +692,12 @@ void write_state_json() {
 
     fprintf(f, "  \"layersLastFrame\": %u,\n", compositor_last_layer_count());
     fprintf(f, "  \"projectionViews\": %u,\n", compositor_last_projection_views());
+    fprintf(f, "  \"eyeHash\": {\"frame\": %llu, \"every\": %u, "
+               "\"L\": \"%016llx\", \"R\": \"%016llx\", \"relAgeL\": %u, \"relAgeR\": %u},\n",
+            static_cast<unsigned long long>(g.lastEyeHashFrame.load()), g.hashEvery.load(),
+            static_cast<unsigned long long>(g.lastEyeHash[0].load()),
+            static_cast<unsigned long long>(g.lastEyeHash[1].load()),
+            g.lastEyeRelAge[0].load(), g.lastEyeRelAge[1].load());
     char esc[1024];
     fprintf(f, "  \"captureSeq\": %u,\n", g.captureSeq.load());
     fprintf(f, "  \"lastCapture\": \"%s\",\n", json_escape(g.lastCapturePath, esc, sizeof(esc)));

--- a/src/tools/xrsim/xrsim_frame.cpp
+++ b/src/tools/xrsim/xrsim_frame.cpp
@@ -380,6 +380,8 @@ static XrResult impl_EndFrame(XrSession session, const XrFrameEndInfo* info) noe
     // state.json reports whatever the last capture happened to see and an agent
     // polling "is the laser armed yet" reads a stale answer.
     compositor_note_layers(sub);
+    const uint32_t hashEvery = g.hashEvery.load();
+    if (hashEvery > 0 && (sub.frameIndex % hashEvery) == 0) compositor_hash_frame(sub);
     if (capture || g.composeAlways.load()) compositor_on_end_frame(sub, capture);
     swapchains_begin_frame_census();
     return XR_SUCCESS;

--- a/src/tools/xrsim/xrsim_internal.h
+++ b/src/tools/xrsim/xrsim_internal.h
@@ -127,6 +127,17 @@ struct Globals {
     std::atomic<uint32_t> captureHeight{1104};
     char captureTag[64] = {};
 
+    // Per-eye source fingerprinting (the BS2 left-eye flicker hunt). Every N
+    // submitted frames the projection layer's two SOURCE textures - the images
+    // the game actually released per eye, before any quad is composited over
+    // them - are hashed and appended to capture\eyehash.tsv. This is the
+    // temporal per-eye oracle the PNG capture path cannot be (quad layers move
+    // with the head and would mask a frozen eye image).
+    std::atomic<uint32_t> hashEvery{0};
+    std::atomic<uint64_t> lastEyeHash[2]{};
+    std::atomic<uint32_t> lastEyeRelAge[2]{};
+    std::atomic<uint64_t> lastEyeHashFrame{0};
+
     // Command bookkeeping, surfaced in state.json as the ack channel.
     std::atomic<uint32_t> cmdSeq{0};
     char lastCmd[256] = {};
@@ -161,6 +172,7 @@ uint64_t session_layered_frames();  // layer-carrying submissions (VdxrLayers po
 void swapchains_begin_frame_census();
 void swapchains_for_each(void (*fn)(uint32_t, const SimSwapchain&, void*), void* user);
 ID3D11Texture2D* swapchain_last_image(XrSwapchain handle, uint32_t* outW, uint32_t* outH);
+bool swapchain_release_info(XrSwapchain handle, uint32_t* outIdx, uint32_t* outFrame);
 
 // Resolve a space to a world pose at a given time, using the published snapshot.
 bool space_pose(const SimSpace& space, const FrameSnapshot& snap, Pose& out, bool& tracked);
@@ -231,6 +243,8 @@ void compositor_init(ID3D11Device* device, ID3D11DeviceContext* context);
 void compositor_shutdown();
 void compositor_on_end_frame(const SimSubmission& sub, bool capture);
 void compositor_note_layers(const SimSubmission& sub);
+// Per-eye source-hash log (issue #31 hunt); called from xrEndFrame when armed.
+void compositor_hash_frame(const SimSubmission& sub);
 uint32_t compositor_last_layer_count();
 uint32_t compositor_last_projection_views();
 

--- a/src/tools/xrsim/xrsim_session.cpp
+++ b/src/tools/xrsim/xrsim_session.cpp
@@ -668,6 +668,15 @@ ID3D11Texture2D* swapchain_last_image(XrSwapchain handle, uint32_t* outW, uint32
     return sc->images[sc->lastReleased];
 }
 
+bool swapchain_release_info(XrSwapchain handle, uint32_t* outIdx, uint32_t* outFrame) {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    SimSwapchain* sc = swapchain_get(handle);
+    if (!sc || !sc->everReleased) return false;
+    if (outIdx) *outIdx = sc->lastReleased;
+    if (outFrame) *outFrame = sc->releasedOnFrame;
+    return true;
+}
+
 // ---------------------------------------------------------------------------
 // Shims
 // ---------------------------------------------------------------------------

--- a/tools/eye-seq-diff.ps1
+++ b/tools/eye-seq-diff.ps1
@@ -1,0 +1,147 @@
+# eye-seq-diff.ps1 - temporal per-eye oracle for the BS2 left-eye flicker hunt.
+#
+# Reads the simulator's capture\eyehash.tsv (written by the xrsim `hash every N`
+# command: one row per Nth submitted XR frame, with an FNV hash of each eye's
+# SOURCE projection texture, that eye's swapchain release age, and a subsampled
+# mean luma) and flags the signatures the [flick]/[pair] counters are blind to:
+#
+#   left-stale   hashL repeated while hashR advanced  (left eye re-showed a frame)
+#   right-stale  hashR repeated while hashL advanced  (the lone-left break parks
+#                the RIGHT eye - the backwards-probe case)
+#   eye-swap     hashL equals the previous or current hashR (tag phase offset)
+#   age-spike    a projection frame submitted with a source older than MaxAge
+#   luma-pop     one eye's mean luma jumped by LumaPop while the other held
+#                (the HUD-burn signature: a flat menu/HUD layer landing in one
+#                eye brightens that eye only)
+#
+# Exit code: 0 = clean, 2 = anomalies found, 1 = could not read input.
+# Usage:
+#   .\tools\eye-seq-diff.ps1                       # default sim capture dir
+#   .\tools\eye-seq-diff.ps1 -Tsv path\eyehash.tsv -Out report.tsv
+param(
+    [string]$Tsv = "$env:LOCALAPPDATA\BioshockVR\xrsim\capture\eyehash.tsv",
+    [string]$Out = "",
+    [double]$LumaPop = 8.0,     # one-eye mean-luma jump that counts as a pop (0-255 scale)
+    [double]$LumaHold = 3.0,    # the OTHER eye must move less than this to count
+    [uint32]$MaxAge = 0,        # a projection frame's source older than this is a spike
+    [switch]$Quiet
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $Tsv)) {
+    Write-Host "eye-seq-diff: input not found: $Tsv" -ForegroundColor Red
+    exit 1
+}
+
+# Share-friendly read: the sim keeps the file open (flushes per line).
+$fs = [System.IO.File]::Open($Tsv, 'Open', 'Read', 'ReadWrite')
+try {
+    $reader = New-Object System.IO.StreamReader($fs)
+    $lines = @()
+    while ($null -ne ($l = $reader.ReadLine())) { $lines += $l }
+} finally { $fs.Close() }
+
+if ($lines.Count -lt 2) {
+    Write-Host "eye-seq-diff: no data rows in $Tsv" -ForegroundColor Yellow
+    exit 1
+}
+
+$header = $lines[0] -split "`t"
+$col = @{}
+for ($i = 0; $i -lt $header.Count; $i++) { $col[$header[$i]] = $i }
+foreach ($need in @('frame','proj','hashL','hashR','relAgeL','relAgeR','lumaL','lumaR')) {
+    if (-not $col.ContainsKey($need)) {
+        Write-Host "eye-seq-diff: column '$need' missing - wrong or old TSV format" -ForegroundColor Red
+        exit 1
+    }
+}
+
+$anomalies = New-Object System.Collections.Generic.List[string]
+$counts = @{ 'left-stale'=0; 'right-stale'=0; 'eye-swap'=0; 'age-spike'=0; 'luma-pop'=0 }
+$prev = $null
+$rows = 0
+$projRows = 0
+
+foreach ($line in ($lines | Select-Object -Skip 1)) {
+    $f = $line -split "`t"
+    if ($f.Count -lt $header.Count) { continue }
+    $rows++
+    $cur = [pscustomobject]@{
+        Frame = [uint64]$f[$col['frame']]
+        Proj  = [int]$f[$col['proj']]
+        HashL = $f[$col['hashL']]
+        HashR = $f[$col['hashR']]
+        AgeL  = [uint32]$f[$col['relAgeL']]
+        AgeR  = [uint32]$f[$col['relAgeR']]
+        LumaL = [double]$f[$col['lumaL']]
+        LumaR = [double]$f[$col['lumaR']]
+    }
+
+    # Only projection (stereo world) frames carry per-eye meaning; quad-mode
+    # frames (menus, loading) legitimately hold one swapchain for ages.
+    if ($cur.Proj -eq 1) {
+        $projRows++
+
+        if ($cur.AgeL -gt $MaxAge -or $cur.AgeR -gt $MaxAge) {
+            $counts['age-spike']++
+            $anomalies.Add("$($cur.Frame)`tage-spike`tageL=$($cur.AgeL) ageR=$($cur.AgeR)")
+        }
+        if ($cur.HashL -eq $cur.HashR -and $cur.HashL -ne '0000000000000000') {
+            $counts['eye-swap']++
+            $anomalies.Add("$($cur.Frame)`teye-swap`thashL==hashR (mono or copied eye) $($cur.HashL)")
+        }
+
+        if ($null -ne $prev -and $prev.Proj -eq 1) {
+            $lHeld = ($cur.HashL -eq $prev.HashL)
+            $rHeld = ($cur.HashR -eq $prev.HashR)
+            if ($lHeld -and -not $rHeld) {
+                $counts['left-stale']++
+                $anomalies.Add("$($cur.Frame)`tleft-stale`thashL repeated ($($cur.HashL)) while hashR advanced")
+            }
+            if ($rHeld -and -not $lHeld) {
+                $counts['right-stale']++
+                $anomalies.Add("$($cur.Frame)`tright-stale`thashR repeated ($($cur.HashR)) while hashL advanced")
+            }
+            if ($cur.HashL -eq $prev.HashR -and $cur.HashL -ne '0000000000000000') {
+                $counts['eye-swap']++
+                $anomalies.Add("$($cur.Frame)`teye-swap`thashL equals PREVIOUS hashR ($($cur.HashL))")
+            }
+
+            $dL = [math]::Abs($cur.LumaL - $prev.LumaL)
+            $dR = [math]::Abs($cur.LumaR - $prev.LumaR)
+            if ($dL -ge $LumaPop -and $dR -le $LumaHold) {
+                $counts['luma-pop']++
+                $anomalies.Add("$($cur.Frame)`tluma-pop`tLEFT jumped $([math]::Round($dL,2)) (right held $([math]::Round($dR,2))) lumaL $([math]::Round($prev.LumaL,2))->$([math]::Round($cur.LumaL,2))")
+            } elseif ($dR -ge $LumaPop -and $dL -le $LumaHold) {
+                $counts['luma-pop']++
+                $anomalies.Add("$($cur.Frame)`tluma-pop`tRIGHT jumped $([math]::Round($dR,2)) (left held $([math]::Round($dL,2))) lumaR $([math]::Round($prev.LumaR,2))->$([math]::Round($cur.LumaR,2))")
+            }
+        }
+    }
+    $prev = $cur
+}
+
+$total = 0
+foreach ($k in $counts.Keys) { $total += $counts[$k] }
+
+if ($Out) {
+    $report = @("frame`tkind`tdetail") + $anomalies
+    Set-Content -Path $Out -Value $report -Encoding utf8
+}
+
+if (-not $Quiet) {
+    Write-Host ("eye-seq-diff: {0} rows ({1} projection), anomalies: {2}" -f $rows, $projRows, $total)
+    foreach ($k in @('left-stale','right-stale','eye-swap','age-spike','luma-pop')) {
+        $c = $counts[$k]
+        if ($c -gt 0) { Write-Host ("  {0,-11} {1}" -f $k, $c) -ForegroundColor Yellow }
+        else          { Write-Host ("  {0,-11} 0" -f $k) }
+    }
+    if ($total -gt 0) {
+        Write-Host "--- first 20 anomalies ---"
+        $anomalies | Select-Object -First 20 | ForEach-Object { Write-Host "  $_" }
+        if ($Out) { Write-Host "full report: $Out" }
+    }
+}
+
+if ($total -gt 0) { exit 2 } else { exit 0 }


### PR DESCRIPTION
BS2 left-eye flicker (issue #31): diagnosed end to end and the main artifact FIXED. Core changes are log-only/opt-in; the fix itself is BS2-adapter-only.

## The fix
The engine's dirty-flagged SkeletonInstance update (vtable slot 0xA4) re-evaluates the hands **inside pass 1 only**, after every existing repaint site and before the hands mesh is drawn, so the LEFT eye rendered the raw engine pose while pass 2 (flag already clear) rendered the driven one. A hardware write-watch named that writer; `vrbones wfix` hooks the virtual with a naked, convention-agnostic ret-hook (filtered to the hands/weapon skeleton instances, game thread only) and repaints the driven pose the moment it returns. Auto-installed at rig resolve, ships ON; `vrbones wfix off` is the A/B.

**Sim verification (three-state A-B-A, same boot):** per-eye frame-to-frame diffs track within ~2 with the fix; without it the left eye spikes alone (raw recoil pose in the left eye, driven pose in the right, captured on camera). One repaint per pass-1 writer return in the counters; rest pose unchanged (0.14 mean diff); game stable across four hooked boots; user on the flat window: "now there's no snapping". **Headset confirmation still pending.**

## Also landed
- **xrsim per-eye source hashing** (`hash every <n>`, `capture\eyehash.tsv`, state.json `eyeHash`) + `tools/eye-seq-diff.ps1`; sticky capture-tag fix.
- **`vrbones diag31`**: [pairEdge] and [hudgate] event-edge witnesses, [pair] `deep=`; **`vrbones race|watch|fullmask|p1fix|p2fix`** diagnosis levers.
- Docs: `docs/bioshock2/ENGINE_NOTES.md` s74 (mechanism, writer RVAs, evidence), STATUS/TESTING/VERIFICATION.

## Still open (documented, not in this PR)
- Menu-transition HUD burn (5/5 reproducible, witnessed by [hudgate]).
- Weapon scale flicker (not yet reproduced on a fresh boot).
- Crash-persistence of the written game FOV in Shared.ini.